### PR TITLE
(CODEX) Cleanup brain.py warnings and fix lint/type issues

### DIFF
--- a/bt_servant.py
+++ b/bt_servant.py
@@ -354,7 +354,7 @@ async def handle_meta_webhook(
                             return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content={"error": "Unauthorized sender"})
 
                         asyncio.create_task(process_message(user_message=user_message))
-                    except Exception as e:
+                    except Exception:
                         logger.error("Error while processing user message...", exc_info=True)
                         continue
         return Response(status_code=200)
@@ -362,7 +362,7 @@ async def handle_meta_webhook(
     except json.JSONDecodeError:
         logger.error("Invalid JSON received", exc_info=True)
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content={"error": "Invalid JSON"})
-    except Exception as e:
+    except Exception:
         logger.error("Error handling Meta webhook payload", exc_info=True)
         return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"error": "Internal server error"})
 
@@ -408,7 +408,7 @@ async def process_message(user_message: UserMessage):
 
             update_user_chat_history(user_id=user_message.user_id, query=user_message.text, response=full_response_text)
             logger.info("Overall process_message processing time: %.2f seconds", time.time() - start_time)
-        except Exception as e:
+        except Exception:
             logger.error("Error handling Meta webhook payload", exc_info=True)
             # TODO: THIS MESSAGE NEEDS TO BE TRANSLATED AT SOME POINT!!! - IJL
             error_message = ("I'm sorry. I'm having a bad day and I'm having trouble responding. "

--- a/config.py
+++ b/config.py
@@ -1,32 +1,33 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 from pathlib import Path
 
 
 class Config(BaseSettings):
-    OPENAI_API_KEY: str = Field(..., env="OPENAI_API_KEY")
-    META_VERIFY_TOKEN: str = Field(..., env="META_VERIFY_TOKEN")
-    META_WHATSAPP_TOKEN: str = Field(..., env="META_WHATSAPP_TOKEN")
-    META_PHONE_NUMBER_ID: str = Field(..., env="META_PHONE_NUMBER_ID")
-    META_APP_SECRET: str = Field(..., env="META_APP_SECRET")
-    FACEBOOK_USER_AGENT: str = Field(..., env="FACEBOOK_USER_AGENT")
-    IN_META_SANDBOX_MODE: bool = Field(default=False, env="IN_META_SANDBOX_MODE")
-    META_SANDBOX_PHONE_NUMBER: str = Field(default="11111111", env="META_SANDBOX_PHONE_NUMBER")
-    MESSAGE_AGE_CUTOFF_IN_SECONDS: int = Field(default=3600, env="MESSAGE_AGE_CUTOFF_IN_SECONDS")
-    BASE_URL: str = Field(..., env="BASE_URL")
-    BT_SERVANT_LOG_LEVEL: str = Field(default="info", env="BT_SERVANT_LOG_LEVEL")
-    MAX_META_TEXT_LENGTH: int = Field(default=4096, env="MAX_META_TEXT_LENGTH")
+    # Model settings
+    model_config = SettingsConfigDict(env_file=".env")
+
+    OPENAI_API_KEY: str = Field(...)
+    META_VERIFY_TOKEN: str = Field(...)
+    META_WHATSAPP_TOKEN: str = Field(...)
+    META_PHONE_NUMBER_ID: str = Field(...)
+    META_APP_SECRET: str = Field(...)
+    FACEBOOK_USER_AGENT: str = Field(...)
+    IN_META_SANDBOX_MODE: bool = Field(default=False)
+    META_SANDBOX_PHONE_NUMBER: str = Field(default="11111111")
+    MESSAGE_AGE_CUTOFF_IN_SECONDS: int = Field(default=3600)
+    BASE_URL: str = Field(...)
+    BT_SERVANT_LOG_LEVEL: str = Field(default="info")
+    MAX_META_TEXT_LENGTH: int = Field(default=4096)
     # Admin API token for protecting CRUD endpoints
-    ADMIN_API_TOKEN: str | None = Field(default=None, env="ADMIN_API_TOKEN")
+    ADMIN_API_TOKEN: str | None = Field(default=None)
     # Enable admin auth for protected endpoints (default False for local/dev tests)
-    ENABLE_ADMIN_AUTH: bool = Field(default=False, env="ENABLE_ADMIN_AUTH")
+    ENABLE_ADMIN_AUTH: bool = Field(default=False)
 
     # Optional with default value
-    DATA_DIR: Path = Field(default=Path("/data"), env="DATA_DIR")
-
-    class Config:
-        env_file = ".env"
+    DATA_DIR: Path = Field(default=Path("/data"))
 
 
 # Create a single instance to import elsewhere
-config = Config()
+# mypy cannot infer environment-based initialization for BaseSettings
+config = Config()  # type: ignore[call-arg]

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,6 +1,5 @@
 """DB package public interface: user and Chroma helpers."""
 
-from .user_db import get_user_db
 from .chroma_db import (
     get_or_create_chroma_collection,
     get_chroma_collection,


### PR DESCRIPTION
Refactor and cleanup across brain.py with supporting fixes:

- Import order corrected; added module/class/function docstrings.
- Rename features_summary_response -> FEATURES_SUMMARY_RESPONSE.
- Remove extraneous f-string; drop unused vars; simplify returns.
- Fix missing arg to chop_text fallback; set-comprehension for resource list.
- Add targeted pylint disables for long lines/too many locals.
- Remove unused exception aliases in bt_servant.py.
- Remove unused import from db/__init__.py to satisfy ruff.
- Update config.py to Pydantic v2 style SettingsConfigDict; remove env= usage
  to fix mypy Field overload issues; add mypy ignore for env-based init.

Why:
- Resolve PyCharm/ruff/pylint warnings in brain.py (and nearby files).
- Address ruff unused import and mypy Field overload issues requested.

Tests and lint:
- ruff check . passes.
- pylint brain.py passes (no findings).
- mypy config.py passes; repo has pre-existing mypy issues elsewhere.
- pytest -q: 6 passed.

Notes:
- Remaining mypy errors exist in user_message.py, messaging.py, and db/* and
  appear pre-existing; can tackle in a follow-up PR.
