### PR TITLE
Add get-passage-keywords intent and keyword datasets

### DIFF
--- a/sources/keyword_data/keywords_1CH.json
+++ b/sources/keyword_data/keywords_1CH.json
@@ -1,0 +1,13006 @@
+{
+  "1:1": [
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "Seth",
+      "tw_match": "Seth"
+    }
+  ],
+  "1:2": [],
+  "1:3": [
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    },
+    {
+      "surface": "Lamech",
+      "tw_match": "Lamech"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    },
+    {
+      "surface": "Japheth",
+      "tw_match": "Japheth"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Japheth",
+      "tw_match": "Japheth"
+    },
+    {
+      "surface": "Tubal",
+      "tw_match": "Tubal"
+    }
+  ],
+  "1:6": [],
+  "1:7": [
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Girgashites",
+      "tw_match": "Girgashites"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Hamathites",
+      "tw_match": "Hamathites"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "Ashur",
+      "tw_match": "Ashur"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "1:18": [],
+  "1:19": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:20": [],
+  "1:21": [],
+  "1:22": [
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    }
+  ],
+  "1:23": [],
+  "1:24": [
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    }
+  ],
+  "1:25": [],
+  "1:26": [
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "Kedar",
+      "tw_match": "Kedar"
+    }
+  ],
+  "1:30": [],
+  "1:31": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    }
+  ],
+  "1:32": [
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    }
+  ],
+  "1:33": [
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "1:34": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:35": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Reuel",
+      "tw_match": "Reuel"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    }
+  ],
+  "1:36": [
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    }
+  ],
+  "1:37": [
+    {
+      "surface": "Reuel",
+      "tw_match": "Reuel"
+    }
+  ],
+  "1:38": [
+    {
+      "surface": "sons of Seir",
+      "tw_match": "sons of Seir"
+    }
+  ],
+  "1:39": [],
+  "1:40": [],
+  "1:41": [],
+  "1:42": [],
+  "1:43": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:44": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "1:45": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "1:46": [
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "1:47": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "1:48": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "1:49": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "1:50": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "1:51": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    }
+  ],
+  "1:52": [
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    }
+  ],
+  "1:53": [
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    }
+  ],
+  "1:54": [
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "2:5": [],
+  "2:6": [],
+  "2:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "2:14": [],
+  "2:15": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Ishmaelite",
+      "tw_match": "Ishmaelite"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "Ephrath",
+      "tw_match": "Ephrath"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "2:20": [],
+  "2:21": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "Geshur",
+      "tw_match": "Geshur"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "Ephrathah",
+      "tw_match": "Ephrathah"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    }
+  ],
+  "2:26": [],
+  "2:27": [
+    {
+      "surface": "Ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "2:28": [],
+  "2:29": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "2:30": [],
+  "2:31": [],
+  "2:32": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "2:33": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "2:34": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "2:35": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "2:36": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    }
+  ],
+  "2:37": [],
+  "2:38": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "2:39": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "2:40": [],
+  "2:41": [],
+  "2:42": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "2:43": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    }
+  ],
+  "2:44": [],
+  "2:45": [],
+  "2:46": [
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    }
+  ],
+  "2:47": [
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    }
+  ],
+  "2:48": [
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "2:49": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "2:50": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Ephrathah",
+      "tw_match": "Ephrathah"
+    }
+  ],
+  "2:51": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "2:52": [],
+  "2:53": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "2:54": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "2:55": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "Jezreelite",
+      "tw_match": "Jezreelite"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Geshur",
+      "tw_match": "Geshur"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    }
+  ],
+  "3:3": [],
+  "3:4": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "3:6": [],
+  "3:7": [],
+  "3:8": [],
+  "3:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    }
+  ],
+  "3:17": [],
+  "3:18": [],
+  "3:19": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    }
+  ],
+  "3:20": [],
+  "3:21": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    }
+  ],
+  "3:22": [],
+  "3:23": [],
+  "3:24": [],
+  "4:1": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Ephrathah",
+      "tw_match": "Ephrathah"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "4:5": [],
+  "4:6": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "4:7": [],
+  "4:8": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:11": [],
+  "4:12": [
+    {
+      "surface": "Rapha",
+      "tw_match": "Rapha"
+    }
+  ],
+  "4:13": [],
+  "4:14": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "4:16": [],
+  "4:17": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "4:19": [],
+  "4:20": [
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "ruled",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    }
+  ],
+  "4:25": [],
+  "4:26": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "Bilhah",
+      "tw_match": "Bilhah"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "Bethuel",
+      "tw_match": "Bethuel"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "4:33": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "4:34": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    }
+  ],
+  "4:35": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    }
+  ],
+  "4:36": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    }
+  ],
+  "4:37": [],
+  "4:38": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:39": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "4:40": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "peaceful",
+      "tw_match": "peaceful"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    }
+  ],
+  "4:41": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "4:42": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    }
+  ],
+  "4:43": [
+    {
+      "surface": "Amalekites",
+      "tw_match": "Amalekite"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "birthright",
+      "tw_match": "birthright"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "birthright",
+      "tw_match": "birthright"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Euphrates River",
+      "tw_match": "Euphrates River"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Sharon",
+      "tw_match": "Sharon"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "5:19": [],
+  "5:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Mount Hermon",
+      "tw_match": "Mount Hermon"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    }
+  ],
+  "6:5": [],
+  "6:6": [],
+  "6:7": [],
+  "6:8": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "6:20": [],
+  "6:21": [],
+  "6:22": [
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    }
+  ],
+  "6:23": [],
+  "6:24": [
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    }
+  ],
+  "6:25": [],
+  "6:26": [],
+  "6:27": [],
+  "6:28": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "6:30": [],
+  "6:31": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    }
+  ],
+  "6:32": [
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "6:33": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "6:34": [],
+  "6:35": [],
+  "6:36": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Zephaniah",
+      "tw_match": "Zephaniah"
+    }
+  ],
+  "6:37": [
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    }
+  ],
+  "6:38": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:39": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "6:40": [
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    }
+  ],
+  "6:41": [],
+  "6:42": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "6:43": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "6:44": [],
+  "6:45": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    }
+  ],
+  "6:46": [],
+  "6:47": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "6:48": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:49": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "altar of incense",
+      "tw_match": "altar of incense"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Holies",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:50": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    }
+  ],
+  "6:51": [],
+  "6:52": [],
+  "6:53": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    }
+  ],
+  "6:54": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "6:55": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "6:56": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "6:57": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "6:58": [],
+  "6:59": [
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    }
+  ],
+  "6:60": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "6:61": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "6:62": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "6:63": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "6:64": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "6:65": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "6:66": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "6:67": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "6:68": [],
+  "6:69": [
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "6:70": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "6:71": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "6:72": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    }
+  ],
+  "6:73": [
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    }
+  ],
+  "6:74": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "6:75": [],
+  "6:76": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "6:77": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "6:78": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "6:79": [],
+  "6:80": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "6:81": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "7:12": [],
+  "7:13": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Bilhah",
+      "tw_match": "Bilhah"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Aramean",
+      "tw_match": "Aramean"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "7:15": [],
+  "7:16": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "7:24": [],
+  "7:25": [],
+  "7:26": [],
+  "7:27": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:30": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "7:31": [],
+  "7:32": [],
+  "7:33": [],
+  "7:34": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "7:35": [],
+  "7:36": [],
+  "7:37": [],
+  "7:38": [],
+  "7:39": [],
+  "7:40": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Rapha",
+      "tw_match": "Rapha"
+    }
+  ],
+  "8:3": [],
+  "8:4": [
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    }
+  ],
+  "8:5": [],
+  "8:6": [
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "8:9": [],
+  "8:10": [],
+  "8:11": [],
+  "8:12": [],
+  "8:13": [
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "8:14": [],
+  "8:15": [],
+  "8:16": [
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    }
+  ],
+  "8:17": [],
+  "8:18": [],
+  "8:19": [],
+  "8:20": [],
+  "8:21": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "8:22": [],
+  "8:23": [],
+  "8:24": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    }
+  ],
+  "8:25": [],
+  "8:26": [
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "8:31": [],
+  "8:32": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    }
+  ],
+  "8:36": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    }
+  ],
+  "8:37": [],
+  "8:38": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    }
+  ],
+  "8:39": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "8:40": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "9:6": [],
+  "9:7": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Reuel",
+      "tw_match": "Reuel"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:12": [],
+  "9:13": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Korahites",
+      "tw_match": "Korahite"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "thresholds",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "gatekeeper",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "thresholds",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "official",
+      "tw_match": "official"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "9:28": [],
+  "9:29": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Korahite",
+      "tw_match": "Korahite"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "9:32": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "9:33": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "9:34": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:35": [
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "9:36": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "9:37": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "9:38": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:39": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "9:40": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    }
+  ],
+  "9:41": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    }
+  ],
+  "9:42": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    }
+  ],
+  "9:43": [],
+  "9:44": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "mistreat",
+      "tw_match": "mistreat"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jebus",
+      "tw_match": "Jebus"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Jebus",
+      "tw_match": "Jebus"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "11:27": [],
+  "11:28": [],
+  "11:29": [],
+  "11:30": [],
+  "11:31": [
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    }
+  ],
+  "11:32": [],
+  "11:33": [],
+  "11:34": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "11:35": [
+    {
+      "surface": "Ur",
+      "tw_match": "Ur"
+    }
+  ],
+  "11:36": [
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    }
+  ],
+  "11:37": [],
+  "11:38": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    }
+  ],
+  "11:39": [
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "11:40": [],
+  "11:41": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "11:42": [],
+  "11:43": [
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    }
+  ],
+  "11:44": [],
+  "11:45": [],
+  "11:46": [
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    }
+  ],
+  "11:47": [],
+  "12:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "a bow",
+      "tw_match": "a bow"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "Gibeonite",
+      "tw_match": "Gibeonite"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "12:5": [],
+  "12:6": [
+    {
+      "surface": "Korahites",
+      "tw_match": "Korahite"
+    }
+  ],
+  "12:7": [],
+  "12:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "12:11": [],
+  "12:12": [],
+  "12:13": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "betray",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "12:27": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "12:30": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "12:31": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:32": [
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:33": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "12:34": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "12:35": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "12:36": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "12:37": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "12:38": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:39": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "12:40": [
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "mules",
+      "tw_match": "mule"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Lebo Hamath",
+      "tw_match": "Lebo Hamath"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "celebrating",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "stumbled",
+      "tw_match": "stumble"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Gittite",
+      "tw_match": "Gittite"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "14:5": [],
+  "14:6": [],
+  "14:7": [],
+  "14:8": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "assign",
+      "tw_match": "assign"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "instructor",
+      "tw_match": "instructors"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "celebrating",
+      "tw_match": "celebrate"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "distributed",
+      "tw_match": "distributed"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "Glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "16:19": [],
+  "16:20": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "Splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "16:29": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "16:30": [
+    {
+      "surface": "Tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "16:31": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    }
+  ],
+  "16:32": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    }
+  ],
+  "16:33": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "16:34": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "16:35": [
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "16:36": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    }
+  ],
+  "16:37": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:38": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    }
+  ],
+  "16:39": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "16:40": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:41": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "16:42": [
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "16:43": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "honoring",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "ransomed",
+      "tw_match": "ransomed"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "17:24": [
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "17:25": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "17:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "17:27": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Moabites",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "Euphrates River",
+      "tw_match": "Euphrates River"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "Aram of Damascus",
+      "tw_match": "Aram of Damascus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Arameans",
+      "tw_match": "Aramean"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "Aram of Damascus",
+      "tw_match": "Aram of Damascus"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "honoring",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Aram Naharaim",
+      "tw_match": "Aram Naharaim"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "besieged",
+      "tw_match": "besieged"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Goliath",
+      "tw_match": "Goliath"
+    },
+    {
+      "surface": "Gittite",
+      "tw_match": "Gittite"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Rapha",
+      "tw_match": "Rapha"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "Rapha",
+      "tw_match": "Rapha"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "21:29": [
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "21:30": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "Tyrians",
+      "tw_match": "Tyrians"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "a house for my name",
+      "tw_match": "a house for my name"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "a house for my name",
+      "tw_match": "a house for my name"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "a house of Yahweh",
+      "tw_match": "a house of Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "23:16": [],
+  "23:17": [],
+  "23:18": [],
+  "23:19": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "23:23": [],
+  "23:24": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "23:26": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    }
+  ],
+  "23:27": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "23:30": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:31": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "23:32": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "24:8": [],
+  "24:9": [],
+  "24:10": [
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    }
+  ],
+  "24:12": [],
+  "24:13": [],
+  "24:14": [],
+  "24:15": [],
+  "24:16": [],
+  "24:17": [],
+  "24:18": [],
+  "24:19": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "24:21": [],
+  "24:22": [],
+  "24:23": [],
+  "24:24": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    }
+  ],
+  "24:25": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "24:26": [],
+  "24:27": [],
+  "24:28": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "24:29": [],
+  "24:30": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "24:31": [
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "alike",
+      "tw_match": "alike"
+    },
+    {
+      "surface": "understands",
+      "tw_match": "understand"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "25:10": [],
+  "25:11": [],
+  "25:12": [],
+  "25:13": [],
+  "25:14": [],
+  "25:15": [],
+  "25:16": [],
+  "25:17": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "25:18": [],
+  "25:19": [],
+  "25:20": [],
+  "25:21": [],
+  "25:22": [],
+  "25:23": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    }
+  ],
+  "25:24": [],
+  "25:25": [],
+  "25:26": [],
+  "25:27": [],
+  "25:28": [],
+  "25:29": [],
+  "25:30": [],
+  "25:31": [],
+  "26:1": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "Korahites",
+      "tw_match": "Korahite"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "26:7": [],
+  "26:8": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "26:9": [],
+  "26:10": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "advisor",
+      "tw_match": "advisor"
+    },
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "26:18": [],
+  "26:19": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "Korahites",
+      "tw_match": "Korahite"
+    }
+  ],
+  "26:20": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    }
+  ],
+  "26:21": [],
+  "26:22": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:23": [],
+  "26:24": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "26:25": [
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    }
+  ],
+  "26:26": [
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    }
+  ],
+  "26:27": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:28": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    }
+  ],
+  "26:29": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "26:30": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "26:31": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "26:32": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Benjaminites",
+      "tw_match": "Benjaminite"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    }
+  ],
+  "27:18": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    }
+  ],
+  "27:19": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "27:20": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    }
+  ],
+  "27:21": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "27:22": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "27:23": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "27:24": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "27:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    }
+  ],
+  "27:26": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "27:27": [
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "27:28": [
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    }
+  ],
+  "27:29": [
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "Sharon",
+      "tw_match": "Sharon"
+    }
+  ],
+  "27:30": [
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "Ishmaelite",
+      "tw_match": "Ishmaelite"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "27:31": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "27:32": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "advisor",
+      "tw_match": "advisor"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "27:33": [
+    {
+      "surface": "advisor",
+      "tw_match": "advisor"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "27:34": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "a house for my name",
+      "tw_match": "a house for my name"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "understands",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "28:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "lampstands",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "altar of incense",
+      "tw_match": "altar of incense"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "28:20": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:21": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "delighting",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "29:7": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "29:12": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "29:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    }
+  ],
+  "29:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "29:15": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "29:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "29:17": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "29:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "29:19": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "29:20": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "29:21": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "29:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "29:23": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "29:24": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "29:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "29:26": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "29:27": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "29:28": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "29:29": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "29:30": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_1CO.json
+++ b/sources/keyword_data/keywords_1CO.json
@@ -1,0 +1,5958 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Corinth",
+      "tw_match": "Corinth"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "confirm",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "1:11": [],
+  "1:12": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Apollos",
+      "tw_match": "Apollos"
+    },
+    {
+      "surface": "Cephas",
+      "tw_match": "Cephas"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "baptize",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:30": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "sanctification",
+      "tw_match": "sanctification"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "1:31": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "proclamation",
+      "tw_match": "proclamation"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "predestined",
+      "tw_match": "predestined"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "searches",
+      "tw_match": "search"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "discerned",
+      "tw_match": "discern"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "discerns",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "discerned",
+      "tw_match": "discern"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "instruct",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "3:2": [],
+  "3:3": [
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Apollos",
+      "tw_match": "Apollos"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Apollos",
+      "tw_match": "Apollos"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "Apollos",
+      "tw_match": "Apollos"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "planting",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "planting",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "catches",
+      "tw_match": "catch"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Apollos",
+      "tw_match": "Apollos"
+    },
+    {
+      "surface": "Cephas",
+      "tw_match": "Cephas"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "stewards",
+      "tw_match": "steward"
+    },
+    {
+      "surface": "mysteries",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "stewards",
+      "tw_match": "steward"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "court",
+      "tw_match": "court"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "aware",
+      "tw_match": "aware"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "Apollos",
+      "tw_match": "Apollos"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "dishonored",
+      "tw_match": "dishonored"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "reviled",
+      "tw_match": "revile"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "slandered",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "shaming",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "4:16": [],
+  "4:17": [
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "remind",
+      "tw_match": "remind"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "4:18": [],
+  "4:19": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "immorality",
+      "tw_match": "immorality"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "day of the Lord",
+      "tw_match": "day of the Lord"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "leavens",
+      "tw_match": "leaven"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "Clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "idolaters",
+      "tw_match": "idolater"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    },
+    {
+      "surface": "idolater",
+      "tw_match": "idolater"
+    },
+    {
+      "surface": "drunkard",
+      "tw_match": "drunkard"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "legal",
+      "tw_match": "legal"
+    },
+    {
+      "surface": "disputes",
+      "tw_match": "disputes"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "discern",
+      "tw_match": "discern"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "unbelievers",
+      "tw_match": "unbeliever"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "wronged",
+      "tw_match": "wronged"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    },
+    {
+      "surface": "idolaters",
+      "tw_match": "idolater"
+    },
+    {
+      "surface": "adulterers",
+      "tw_match": "adulterer"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "drunkards",
+      "tw_match": "drunkard"
+    },
+    {
+      "surface": "slanderers",
+      "tw_match": "slanderers"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "mastered",
+      "tw_match": "master"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "immorality",
+      "tw_match": "immorality"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "tempt",
+      "tw_match": "tempt"
+    },
+    {
+      "surface": "self-control",
+      "tw_match": "self-control"
+    }
+  ],
+  "7:6": [],
+  "7:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "self-control",
+      "tw_match": "self-control"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "reconciled",
+      "tw_match": "reconciled"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "7:13": [],
+  "7:14": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "unbeliever",
+      "tw_match": "unbeliever"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "Circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "freeman",
+      "tw_match": "freeman"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "7:30": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "possessing",
+      "tw_match": "possess"
+    }
+  ],
+  "7:31": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "7:32": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "7:33": [
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    }
+  ],
+  "7:34": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "7:35": [
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "7:36": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "marriage",
+      "tw_match": "marriage"
+    },
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    }
+  ],
+  "7:37": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "7:38": [
+    {
+      "surface": "marrying",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "7:39": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "7:40": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "Knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    },
+    {
+      "surface": "consciences",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "proof",
+      "tw_match": "proof"
+    },
+    {
+      "surface": "apostleship",
+      "tw_match": "apostleship"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "9:3": [],
+  "9:4": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Cephas",
+      "tw_match": "Cephas"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "serves",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "soldier",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "plowing",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "plow",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "stewardship",
+      "tw_match": "stewardship"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "law of God",
+      "tw_match": "law of God"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "prize",
+      "tw_match": "prize"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "self-control",
+      "tw_match": "self-control"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "boxing",
+      "tw_match": "box"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "enslave",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "preached",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "disqualified",
+      "tw_match": "disqualified"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "10:3": [],
+  "10:4": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "idolaters",
+      "tw_match": "idolater"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "snakes",
+      "tw_match": "snake"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "temptation",
+      "tw_match": "temptation"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "tempted",
+      "tw_match": "tempt"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "idolatry",
+      "tw_match": "idolatry"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Judge",
+      "tw_match": "judge"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "unbelievers",
+      "tw_match": "unbeliever"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "10:30": [
+    {
+      "surface": "insulted",
+      "tw_match": "insult"
+    }
+  ],
+  "10:31": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "traditions",
+      "tw_match": "tradition"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "dishonors",
+      "tw_match": "dishonor"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "dishonors",
+      "tw_match": "dishonor"
+    }
+  ],
+  "11:6": [],
+  "11:7": [
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:8": [],
+  "11:9": [
+    {
+      "surface": "created",
+      "tw_match": "created"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "Judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "11:19": [],
+  "11:20": [
+    {
+      "surface": "Lord’s Supper",
+      "tw_match": "Lord’s Supper"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "humiliate",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "betrayed",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "11:24": [],
+  "11:25": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "11:30": [],
+  "11:31": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "11:33": [],
+  "11:34": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "12:1": [],
+  "12:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "pagans",
+      "tw_match": "pagan"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "ministries",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "discernments",
+      "tw_match": "discernment"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "member",
+      "tw_match": "member"
+    }
+  ],
+  "12:15": [],
+  "12:16": [],
+  "12:17": [],
+  "12:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "member",
+      "tw_match": "member"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "members",
+      "tw_match": "member"
+    }
+  ],
+  "12:21": [],
+  "12:22": [
+    {
+      "surface": "members",
+      "tw_match": "member"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "members",
+      "tw_match": "member"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "member",
+      "tw_match": "member"
+    },
+    {
+      "surface": "suffers",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "12:27": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    }
+  ],
+  "12:30": [
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "interpret",
+      "tw_match": "interpret"
+    }
+  ],
+  "12:31": [],
+  "13:1": [
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "mysteries",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "Love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "patient",
+      "tw_match": "patient"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "wrongs",
+      "tw_match": "wrong"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "believes",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "hopes",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "Love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "prophecies",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "partial",
+      "tw_match": "partial"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "understands",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "mysteries",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "encouragement",
+      "tw_match": "encouragement"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "interpret",
+      "tw_match": "interpret"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "interpret",
+      "tw_match": "interpret"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "prays",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "unfruitful",
+      "tw_match": "unfruitful"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "instruct",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "unbelievers",
+      "tw_match": "unbeliever"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "unbelievers",
+      "tw_match": "unbeliever"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "unbeliever",
+      "tw_match": "unbeliever"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "interpret",
+      "tw_match": "interpret"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "interpreter",
+      "tw_match": "interpreter"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "14:30": [],
+  "14:31": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    }
+  ],
+  "14:32": [
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "subject",
+      "tw_match": "subject"
+    }
+  ],
+  "14:33": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "14:34": [
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "in submission",
+      "tw_match": "in submission"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "14:35": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "14:36": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "14:37": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "14:38": [],
+  "14:39": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    }
+  ],
+  "14:40": [],
+  "15:1": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "Cephas",
+      "tw_match": "Cephas"
+    }
+  ],
+  "15:6": [],
+  "15:7": [
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "labored",
+      "tw_match": "labored"
+    },
+    {
+      "surface": "harder",
+      "tw_match": "harder"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "subjection",
+      "tw_match": "subjection"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "corrupts",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "15:34": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "15:35": [],
+  "15:36": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    }
+  ],
+  "15:37": [
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "15:38": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "seeds",
+      "tw_match": "seed"
+    }
+  ],
+  "15:39": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "15:40": [
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "15:41": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "15:42": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "15:43": [
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "15:44": [],
+  "15:45": [
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "15:46": [],
+  "15:47": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "15:48": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "15:49": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    }
+  ],
+  "15:50": [
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "15:51": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    }
+  ],
+  "15:52": [
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    }
+  ],
+  "15:53": [
+    {
+      "surface": "incorruptibility",
+      "tw_match": "incorruptibility"
+    }
+  ],
+  "15:54": [
+    {
+      "surface": "incorruptibility",
+      "tw_match": "incorruptibility"
+    }
+  ],
+  "15:55": [],
+  "15:56": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "15:57": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "15:58": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Galatia",
+      "tw_match": "Galatia"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "week",
+      "tw_match": "week"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "prospered",
+      "tw_match": "prosper"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "16:4": [],
+  "16:5": [
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    },
+    {
+      "surface": "Pentecost",
+      "tw_match": "Pentecost"
+    }
+  ],
+  "16:9": [],
+  "16:10": [
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "Apollos",
+      "tw_match": "Apollos"
+    },
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "be subject to",
+      "tw_match": "be subject to"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "laboring",
+      "tw_match": "laboring"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "Aquila",
+      "tw_match": "Aquila"
+    },
+    {
+      "surface": "Priscilla",
+      "tw_match": "Priscilla"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_1JN.json
+++ b/sources/keyword_data/keywords_1JN.json
@@ -1,0 +1,1651 @@
+{
+  "1:1": [],
+  "1:2": [
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "announcing",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "announcing",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "propitiation",
+      "tw_match": "propitiation"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "perfected",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "2:9": [],
+  "2:10": [
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "lust",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "antichrist",
+      "tw_match": "antichrist"
+    },
+    {
+      "surface": "antichrists",
+      "tw_match": "antichrist"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:19": [],
+  "2:20": [
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "antichrist",
+      "tw_match": "antichrist"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "confessing",
+      "tw_match": "confess"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "2:26": [],
+  "2:27": [
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "begotten",
+      "tw_match": "begotten"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "children of God",
+      "tw_match": "children of God"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "children of God",
+      "tw_match": "children of God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "purifies",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "committing",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "lawlessness",
+      "tw_match": "lawlessness"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "committing",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "begotten",
+      "tw_match": "begotten"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "children of God",
+      "tw_match": "children of God"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "condemns",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "confesses",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "antichrist",
+      "tw_match": "antichrist"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "begotten",
+      "tw_match": "begotten"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "propitiation",
+      "tw_match": "propitiation"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "perfected",
+      "tw_match": "perfect"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "confesses",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "perfected",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "day of judgment",
+      "tw_match": "day of judgment"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "Fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "perfected",
+      "tw_match": "perfect"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "begotten",
+      "tw_match": "begotten"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "begetting",
+      "tw_match": "beget"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "children of God",
+      "tw_match": "children of God"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "begotten",
+      "tw_match": "begotten"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "5:14": [],
+  "5:15": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "begotten",
+      "tw_match": "begotten"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_1KI.json
+++ b/sources/keyword_data/keywords_1KI.json
@@ -1,0 +1,16559 @@
+{
+  "1:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "Bathsheba",
+      "tw_match": "Bathsheba"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "advise",
+      "tw_match": "advise"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "Bathsheba",
+      "tw_match": "Bathsheba"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Bathsheba",
+      "tw_match": "Bathsheba"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Bathsheba",
+      "tw_match": "Bathsheba"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ransomed",
+      "tw_match": "ransomed"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "1:30": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:31": [
+    {
+      "surface": "Bathsheba",
+      "tw_match": "Bathsheba"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "1:32": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    }
+  ],
+  "1:33": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "mule",
+      "tw_match": "mule"
+    }
+  ],
+  "1:34": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "1:35": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:36": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "1:37": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "1:38": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "mule",
+      "tw_match": "mule"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "1:39": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:40": [
+    {
+      "surface": "flutes",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:41": [
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "1:42": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    }
+  ],
+  "1:43": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "1:44": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "mule",
+      "tw_match": "mule"
+    }
+  ],
+  "1:45": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "1:46": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "1:47": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "1:48": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "1:49": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    }
+  ],
+  "1:50": [
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "1:51": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "1:52": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "1:53": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "sandal",
+      "tw_match": "sandal"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Gileadite",
+      "tw_match": "Gileadite"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "Benjaminite",
+      "tw_match": "Benjaminite"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "Bathsheba",
+      "tw_match": "Bathsheba"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "2:14": [],
+  "2:15": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:16": [],
+  "2:17": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Bathsheba",
+      "tw_match": "Bathsheba"
+    },
+    {
+      "surface": "Good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Bathsheba",
+      "tw_match": "Bathsheba"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    }
+  ],
+  "2:30": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "2:31": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "2:32": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "2:33": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:34": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "2:35": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    }
+  ],
+  "2:36": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:37": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:38": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:39": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "2:40": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "2:41": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "2:42": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:43": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:44": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:45": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "2:46": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "completing",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "discern",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:19": [],
+  "3:20": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "compassionate",
+      "tw_match": "compassionate"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "4:14": [],
+  "4:15": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "deer",
+      "tw_match": "deer"
+    },
+    {
+      "surface": "roebuck",
+      "tw_match": "roebuck"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "steed",
+      "tw_match": "steed"
+    },
+    {
+      "surface": "regulation",
+      "tw_match": "regulations"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "proverbs",
+      "tw_match": "proverb"
+    }
+  ],
+  "4:33": [
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "4:34": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "the house for my name",
+      "tw_match": "the house for my name"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "reigning",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "ax",
+      "tw_match": "ax"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "cherubs",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "cherubs",
+      "tw_match": "cherub"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "cherubs",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:28": [
+    {
+      "surface": "cherubs",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "cherubs",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "6:31": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    }
+  ],
+  "6:32": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "cherubs",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "6:33": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "6:34": [
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "6:35": [
+    {
+      "surface": "cherubs",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "6:36": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "6:37": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "6:38": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "requirements",
+      "tw_match": "requirements"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "7:4": [],
+  "7:5": [
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "cherubs",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "7:30": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "7:31": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "7:32": [],
+  "7:33": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "7:34": [],
+  "7:35": [],
+  "7:36": [
+    {
+      "surface": "cherubs",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "7:37": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    }
+  ],
+  "7:38": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "7:39": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "7:40": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:41": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "7:42": [
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "7:43": [],
+  "7:44": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "7:45": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "7:46": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    }
+  ],
+  "7:47": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "7:48": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "7:49": [
+    {
+      "surface": "lampstands",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    }
+  ],
+  "7:50": [
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "7:51": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "cherubs",
+      "tw_match": "cherub"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "cherubs",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "a house for my name",
+      "tw_match": "a house for my name"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "the house for my name",
+      "tw_match": "the house for my name"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "8:36": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "8:37": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "8:38": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "8:39": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "8:40": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "8:41": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:42": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "8:43": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "8:44": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "8:45": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "8:46": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:47": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "8:48": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "8:49": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "8:50": [
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    }
+  ],
+  "8:51": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "8:52": [
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    }
+  ],
+  "8:53": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "8:54": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bowing",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "8:55": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:56": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "8:57": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "8:58": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "8:59": [
+    {
+      "surface": "pleaded",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:60": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:61": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "8:62": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:63": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "dedicated",
+      "tw_match": "dedicate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "8:64": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "8:65": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Lebo Hamath",
+      "tw_match": "Lebo Hamath"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "8:66": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "delighted",
+      "tw_match": "delight"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "storehouses",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "reeds",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "cupbearers",
+      "tw_match": "cupbearer"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "delighted",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "mules",
+      "tw_match": "mule"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "Edomite",
+      "tw_match": "Edomite"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "princesses",
+      "tw_match": "princess"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Ashtoreth",
+      "tw_match": "Ashtoreth"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Ammonites",
+      "tw_match": "Ammonite"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Edomite",
+      "tw_match": "Edomite"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Edomite",
+      "tw_match": "Edomite"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Paran",
+      "tw_match": "Paran"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:33": [
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Ashtoreth",
+      "tw_match": "Ashtoreth"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "11:34": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "11:35": [
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "11:36": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "11:37": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:38": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:39": [
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:40": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    }
+  ],
+  "11:41": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "11:42": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:43": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "hard work",
+      "tw_match": "hard work"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "advising",
+      "tw_match": "advise"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "advised",
+      "tw_match": "advise"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "advising",
+      "tw_match": "advise"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "advised",
+      "tw_match": "advise"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "12:27": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "slay",
+      "tw_match": "slay"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "12:30": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "12:31": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "12:32": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "12:33": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Seize",
+      "tw_match": "seize"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "lied",
+      "tw_match": "lie"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "13:26": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "13:27": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "13:29": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "13:30": [
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "13:31": [
+    {
+      "surface": "burying",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "13:32": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "13:33": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "13:34": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "annihilate",
+      "tw_match": "annihilate"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Asherahs",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "14:30": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "14:31": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "breathing",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "annihilated",
+      "tw_match": "annihilate"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "15:34": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "provoking",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "provoking",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "annihilated",
+      "tw_match": "annihilate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "provoking",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "provoking",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "16:29": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "16:30": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:31": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "16:32": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "16:33": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "16:34": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "17:19": [],
+  "17:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "17:23": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "17:24": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "wadis",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "mule",
+      "tw_match": "mule"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "slay",
+      "tw_match": "slay"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "slay",
+      "tw_match": "slay"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "forsaking",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "Cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:31": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:32": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trench",
+      "tw_match": "trenches"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "18:33": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    }
+  ],
+  "18:34": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "18:35": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "trench",
+      "tw_match": "trenches"
+    }
+  ],
+  "18:36": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "18:37": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:38": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "trench",
+      "tw_match": "trenches"
+    }
+  ],
+  "18:39": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:40": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    }
+  ],
+  "18:41": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    }
+  ],
+  "18:42": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "18:43": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "18:44": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    }
+  ],
+  "18:45": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "18:46": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "plowing",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "assign",
+      "tw_match": "assign"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "20:29": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "20:30": [],
+  "20:31": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "20:32": [
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "waists",
+      "tw_match": "waist"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "20:33": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "20:34": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "20:35": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "20:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "20:37": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "20:38": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "20:39": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "20:40": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "20:41": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "20:42": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "20:43": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "Jezreelite",
+      "tw_match": "Jezreelite"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Jezreelite",
+      "tw_match": "Jezreelite"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "Jezreelite",
+      "tw_match": "Jezreelite"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "Jezreelite",
+      "tw_match": "Jezreelite"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "witnessed",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "Jezreelite",
+      "tw_match": "Jezreelite"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "Jezreelite",
+      "tw_match": "Jezreelite"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "murdered",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "21:29": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "host of the heavens",
+      "tw_match": "host of the heavens"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    }
+  ],
+  "22:31": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:32": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:33": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:34": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "charioteer",
+      "tw_match": "charioteers"
+    }
+  ],
+  "22:35": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "22:36": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "22:37": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "22:38": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "22:39": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:40": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "22:41": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:42": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "22:43": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "22:44": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:45": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "22:46": [
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "22:47": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "22:48": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "22:49": [
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "22:50": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "22:51": [
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "22:52": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "22:53": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_1PE.json
+++ b/sources/keyword_data/keywords_1PE.json
@@ -1,0 +1,2090 @@
+{
+  "1:1": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "dispersion",
+      "tw_match": "dispersion"
+    },
+    {
+      "surface": "Pontus",
+      "tw_match": "Pontus"
+    },
+    {
+      "surface": "Galatia",
+      "tw_match": "Galatia"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "foreknowledge",
+      "tw_match": "foreknowledge"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "sanctification",
+      "tw_match": "sanctification"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "born again",
+      "tw_match": "born again"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "trials",
+      "tw_match": "trial"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "inquiring",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "glories",
+      "tw_match": "glory"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sojourn",
+      "tw_match": "sojourn"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "born again",
+      "tw_match": "born again"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "hypocrisies",
+      "tw_match": "hypocrisy"
+    },
+    {
+      "surface": "envies",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "slanders",
+      "tw_match": "slander"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cornerstone",
+      "tw_match": "cornerstone"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "praiseworthy",
+      "tw_match": "praiseworthy"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "people of God",
+      "tw_match": "people of God"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "exhort",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "slander",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "House",
+      "tw_match": "house"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "reviled",
+      "tw_match": "revile"
+    },
+    {
+      "surface": "revile",
+      "tw_match": "revile"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "hoping",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "assigning",
+      "tw_match": "assign"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "heirs",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "likeminded",
+      "tw_match": "likeminded"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "insult",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "sanctify",
+      "tw_match": "sanctify"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "meekness",
+      "tw_match": "meekness"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "slandered",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "reviling",
+      "tw_match": "revile"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "saves",
+      "tw_match": "save"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "authorities",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "lusts",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    },
+    {
+      "surface": "idolatry",
+      "tw_match": "idolatry"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "reviling",
+      "tw_match": "revile"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "preached",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "4:9": [],
+  "4:10": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "stewards",
+      "tw_match": "steward"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serves",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "eternities",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "trial",
+      "tw_match": "trial"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "reviled",
+      "tw_match": "revile"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "Christian",
+      "tw_match": "Christian"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "ungodly",
+      "tw_match": "ungodly"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "Creator",
+      "tw_match": "creator"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "elder",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "exhort",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "lording",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "5:7": [],
+  "5:8": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "confirm",
+      "tw_match": "confirm"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Silvanus",
+      "tw_match": "Silvanus"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "exhorting",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_1SA.json
+++ b/sources/keyword_data/keywords_1SA.json
@@ -1,0 +1,15591 @@
+{
+  "1:1": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Ephraimite",
+      "tw_match": "Ephraimite"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Hannah",
+      "tw_match": "Hannah"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Hannah",
+      "tw_match": "Hannah"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "provocation",
+      "tw_match": "provocation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Hannah",
+      "tw_match": "Hannah"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Hannah",
+      "tw_match": "Hannah"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "doorpost",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Hannah",
+      "tw_match": "Hannah"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "Hannah",
+      "tw_match": "Hannah"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "provocation",
+      "tw_match": "provocation"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Hannah",
+      "tw_match": "Hannah"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Hannah",
+      "tw_match": "Hannah"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "Hannah",
+      "tw_match": "Hannah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Hannah",
+      "tw_match": "Hannah"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "haughty",
+      "tw_match": "haughty"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Hannah",
+      "tw_match": "Hannah"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "intercede",
+      "tw_match": "intercede"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "honoring",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "2:31": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "2:32": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:33": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "2:34": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:35": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:36": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "assign",
+      "tw_match": "assign"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "Box of the Covenant of Yahweh",
+      "tw_match": "Box of the Covenant of Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "Box of the Covenant of Yahweh",
+      "tw_match": "Box of the Covenant of Yahweh"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Box of the Covenant of Yahweh",
+      "tw_match": "Box of the Covenant of Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "outcry",
+      "tw_match": "outcry"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "4:16": [],
+  "4:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    },
+    {
+      "surface": "Ekronites",
+      "tw_match": "Ekronites"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "diviners",
+      "tw_match": "diviner"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    },
+    {
+      "surface": "harvesting",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "Ashkelon",
+      "tw_match": "Ashkelon"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "lamented",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Ashtoreths",
+      "tw_match": "Ashtoreth"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Ashtoreths",
+      "tw_match": "Ashtoreth"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "dishonest",
+      "tw_match": "dishonest"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "reigning",
+      "tw_match": "reign"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "plow",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "plowing",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "8:13": [],
+  "8:14": [
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "seeds",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "maidservants",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Benjaminite",
+      "tw_match": "Benjaminite"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Benjaminite",
+      "tw_match": "Benjaminite"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    },
+    {
+      "surface": "calamities",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "distresses",
+      "tw_match": "distresses"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:23": [],
+  "10:24": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "deliverance",
+      "tw_match": "deliverance"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "deliverance",
+      "tw_match": "deliverance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "Testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "veiled",
+      "tw_match": "veiled"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    }
+  ],
+  "12:4": [],
+  "12:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Witness",
+      "tw_match": "witness"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Ashtoreths",
+      "tw_match": "Ashtoreth"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "instruct",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "pits",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "cisterns",
+      "tw_match": "cistern"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "scattering",
+      "tw_match": "scatter"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "plow",
+      "tw_match": "plow"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "plowshares",
+      "tw_match": "plowshares"
+    },
+    {
+      "surface": "axes",
+      "tw_match": "ax"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "pomegranate",
+      "tw_match": "pomegranate"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "14:7": [],
+  "14:8": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    }
+  ],
+  "14:9": [],
+  "14:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "14:30": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:31": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:32": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    }
+  ],
+  "14:33": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "14:34": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Disperse",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    }
+  ],
+  "14:35": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:36": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:37": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "14:38": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "cornerstones",
+      "tw_match": "cornerstone"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "14:39": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "14:40": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "14:41": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "14:42": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "14:43": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "14:44": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "14:45": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "14:46": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:47": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "14:48": [
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:49": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "14:50": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "14:51": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "14:52": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Amalekite",
+      "tw_match": "Amalekite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Amalekite",
+      "tw_match": "Amalekite"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kingdom of Israel",
+      "tw_match": "kingdom of Israel"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "Glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "bonds",
+      "tw_match": "bonds"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    }
+  ],
+  "15:34": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    }
+  ],
+  "15:35": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "look for",
+      "tw_match": "look for"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "breathed",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Goliath",
+      "tw_match": "Goliath"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Choose",
+      "tw_match": "choose"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "17:23": [
+    {
+      "surface": "Goliath",
+      "tw_match": "Goliath"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "17:24": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "17:25": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "17:26": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:27": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "17:28": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "17:29": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "17:30": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "17:31": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "17:32": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "17:33": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "17:34": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "17:35": [
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "17:36": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:37": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "17:38": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "17:39": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "17:40": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    }
+  ],
+  "17:41": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "17:42": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "17:43": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "17:44": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "17:45": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:46": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:47": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "17:48": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "17:49": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "17:50": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "17:51": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    }
+  ],
+  "17:52": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "17:53": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    }
+  ],
+  "17:54": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "17:55": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "17:56": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "17:57": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "17:58": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "celebrating",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "dreaded",
+      "tw_match": "dread"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "avenged",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "delighted",
+      "tw_match": "delight"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "Profane",
+      "tw_match": "profane"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "Good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "20:20": [],
+  "20:21": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "20:29": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "20:30": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "perverting",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "choosing",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "20:31": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "20:32": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "20:33": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "20:34": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "dishonored",
+      "tw_match": "dishonored"
+    }
+  ],
+  "20:35": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "20:36": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "20:37": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "20:38": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "20:39": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "20:40": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "20:41": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    }
+  ],
+  "20:42": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Edomite",
+      "tw_match": "Edomite"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "herders",
+      "tw_match": "herder"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Goliath",
+      "tw_match": "Goliath"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Benjaminite",
+      "tw_match": "Benjaminite"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "Edomite",
+      "tw_match": "Edomite"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Goliath",
+      "tw_match": "Goliath"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "inquiring",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Edomite",
+      "tw_match": "Edomite"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Edomite",
+      "tw_match": "Edomite"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "plundering",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "besiege",
+      "tw_match": "besiege"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "confirm",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "23:26": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "23:27": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "En Gedi",
+      "tw_match": "En Gedi"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "En Gedi",
+      "tw_match": "En Gedi"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "Profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "dispersed",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "slay",
+      "tw_match": "slay"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "reigning",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "kingdom of Israel",
+      "tw_match": "kingdom of Israel"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Paran",
+      "tw_match": "Paran"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "25:20": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "25:21": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "25:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "25:23": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "25:24": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    }
+  ],
+  "25:25": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    }
+  ],
+  "25:26": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "25:27": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "25:28": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "25:29": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "25:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "25:31": [
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    }
+  ],
+  "25:32": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "25:33": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "discernment",
+      "tw_match": "discernment"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    }
+  ],
+  "25:34": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "25:35": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "25:36": [
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "25:37": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "25:38": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:39": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "25:40": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    }
+  ],
+  "25:41": [
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "washing",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "25:42": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "25:43": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "25:44": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "26:18": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "26:20": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "26:21": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "26:22": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "26:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "26:24": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "26:25": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Amalekite",
+      "tw_match": "Amalekite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "appointing",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "pits",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "divine",
+      "tw_match": "divine"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "pits",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    }
+  ],
+  "28:10": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "disturbed",
+      "tw_match": "disturb"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "28:20": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "28:21": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "28:22": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "28:23": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "28:24": [
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "28:25": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    }
+  ],
+  "29:7": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "30:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Amalekite",
+      "tw_match": "Amalekite"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "30:2": [
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    }
+  ],
+  "30:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "30:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "30:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "overtaking",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "delivering",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "30:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "30:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "30:11": [
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "30:12": [
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "30:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Amalekite",
+      "tw_match": "Amalekite"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "30:14": [
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "30:15": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "30:16": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "celebrating",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "30:17": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "30:18": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    }
+  ],
+  "30:19": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "30:20": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "30:21": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "30:22": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "30:23": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:24": [],
+  "30:25": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "30:26": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:27": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    }
+  ],
+  "30:28": [],
+  "30:29": [],
+  "30:30": [],
+  "30:31": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "31:4": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "31:5": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "31:6": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "31:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "31:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "31:10": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ashtoreths",
+      "tw_match": "Ashtoreth"
+    }
+  ],
+  "31:11": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "31:12": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "31:13": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_1TH.json
+++ b/sources/keyword_data/keywords_1TH.json
@@ -1,0 +1,1467 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Silvanus",
+      "tw_match": "Silvanus"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Thessalonians",
+      "tw_match": "Thessalonian"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "mistreated",
+      "tw_match": "mistreat"
+    },
+    {
+      "surface": "Philippi",
+      "tw_match": "Philippi"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "exhortation",
+      "tw_match": "exhortation"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "preached",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "exhorting",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "encouraging",
+      "tw_match": "encouraging"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "disturbed",
+      "tw_match": "disturb"
+    },
+    {
+      "surface": "afflictions",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "tempted",
+      "tw_match": "tempt"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "pleading",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "sanctification",
+      "tw_match": "sanctification"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "sanctification",
+      "tw_match": "sanctification"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "passion",
+      "tw_match": "passions"
+    },
+    {
+      "surface": "lust",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "transgress",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "sanctification",
+      "tw_match": "sanctification"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "rejecting",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "rejects",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "4:12": [],
+  "4:13": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "archangel",
+      "tw_match": "archangel"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "day of the Lord",
+      "tw_match": "day of the Lord"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "breastplate",
+      "tw_match": "breastplate"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "laboring",
+      "tw_match": "laboring"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "admonishing",
+      "tw_match": "admonish"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    },
+    {
+      "surface": "Admonish",
+      "tw_match": "admonish"
+    },
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    },
+    {
+      "surface": "patient",
+      "tw_match": "patient"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "quench",
+      "tw_match": "quench"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "prophecies",
+      "tw_match": "prophecy"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "Test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "sanctify",
+      "tw_match": "sanctify"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "Faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_1TI.json
+++ b/sources/keyword_data/keywords_1TI.json
@@ -1,0 +1,1775 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "stewardship",
+      "tw_match": "stewardship"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "ungodly",
+      "tw_match": "ungodly"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "unholy",
+      "tw_match": "unholy"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    },
+    {
+      "surface": "acceptance",
+      "tw_match": "acceptance"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "prophecies",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "blaspheme",
+      "tw_match": "blaspheme"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "intercessions",
+      "tw_match": "intercession"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "peaceful",
+      "tw_match": "peaceful"
+    },
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mediator",
+      "tw_match": "mediator"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "self-control",
+      "tw_match": "self-control"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "submission",
+      "tw_match": "submission"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "Eve",
+      "tw_match": "Eve"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "self-control",
+      "tw_match": "self-control"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "self-controlled",
+      "tw_match": "self-controlled"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "in submission",
+      "tw_match": "in submission"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "deacons",
+      "tw_match": "deacon"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "slanderers",
+      "tw_match": "slanderers"
+    },
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "deacons",
+      "tw_match": "deacon"
+    },
+    {
+      "surface": "households",
+      "tw_match": "household"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "hoping",
+      "tw_match": "hope"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "deceiving",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "teachings",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "hypocrisy",
+      "tw_match": "hypocrisy"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    },
+    {
+      "surface": "acceptance",
+      "tw_match": "acceptance"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "believers",
+      "tw_match": "believer"
+    }
+  ],
+  "4:11": [],
+  "4:12": [
+    {
+      "surface": "believers",
+      "tw_match": "believer"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "exhortation",
+      "tw_match": "exhortation"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "council",
+      "tw_match": "council"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "4:15": [],
+  "4:16": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "exhort",
+      "tw_match": "exhort"
+    }
+  ],
+  "5:2": [],
+  "5:3": [
+    {
+      "surface": "Honor",
+      "tw_match": "honor"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "self",
+      "tw_match": "self"
+    }
+  ],
+  "5:7": [],
+  "5:8": [
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "unbeliever",
+      "tw_match": "unbeliever"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "reviling",
+      "tw_match": "revile"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "Scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "elder",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "partiality",
+      "tw_match": "partiality"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "Likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "believers",
+      "tw_match": "believer"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "blasphemies",
+      "tw_match": "blasphemy"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "6:8": [],
+  "6:9": [
+    {
+      "surface": "temptation",
+      "tw_match": "temptation"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "evils",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "confessed",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "confession",
+      "tw_match": "confession"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "confession",
+      "tw_match": "confession"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigning",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_2CH.json
+++ b/sources/keyword_data/keywords_2CH.json
@@ -1,0 +1,19534 @@
+{
+  "1:1": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "source",
+      "tw_match": "source"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "bearers",
+      "tw_match": "bearers"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "census",
+      "tw_match": "census"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "bearers",
+      "tw_match": "bearers"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "thresholds",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holies",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holies",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "4:2": [],
+  "4:3": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "lampstands",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "4:14": [],
+  "4:15": [],
+  "4:16": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "lampstands",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Holies",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holies",
+      "tw_match": "holy"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "trumpeters",
+      "tw_match": "trumpeters"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "lofty",
+      "tw_match": "lofty"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "a house for my name",
+      "tw_match": "a house for my name"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "the house for my name",
+      "tw_match": "the house for my name"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prays",
+      "tw_match": "pray"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "6:28": [
+    {
+      "surface": "Famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "6:31": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "6:32": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "6:33": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "6:34": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:35": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "6:36": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:37": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:38": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:39": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "6:40": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "6:41": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "6:42": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "faithfulnesses",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "dedicated",
+      "tw_match": "dedicate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "trumpeting",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Lebo Hamath",
+      "tw_match": "Lebo Hamath"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "dedication",
+      "tw_match": "dedication"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worshipped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    }
+  ],
+  "8:5": [],
+  "8:6": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Perizzites",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "laborers",
+      "tw_match": "laborer"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "laborers",
+      "tw_match": "laborer"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Weeks",
+      "tw_match": "week"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Complete",
+      "tw_match": "complete"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "cupbearers",
+      "tw_match": "cupbearer"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "delighted",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Arabia",
+      "tw_match": "Arabia"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "House",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "House",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "mules",
+      "tw_match": "mule"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "Prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "lied",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "advise",
+      "tw_match": "advise"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "favorable",
+      "tw_match": "favorable"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "advised",
+      "tw_match": "advise"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "advise",
+      "tw_match": "advise"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "11:7": [],
+  "11:8": [
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "11:9": [],
+  "11:10": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "fortifications",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "storehouses",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "kingdom of Judah",
+      "tw_match": "kingdom of Judah"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "Righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reigning",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "lied",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "lied",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "Gerar",
+      "tw_match": "Gerar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "Gerar",
+      "tw_match": "Gerar"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "spoils",
+      "tw_match": "spoils"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "abominable",
+      "tw_match": "abominable"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "lied",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Arabians",
+      "tw_match": "Arabian"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "17:18": [],
+  "17:19": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "host of heaven",
+      "tw_match": "host of heaven"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "deception",
+      "tw_match": "deception"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "deception",
+      "tw_match": "deception"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:31": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:32": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:33": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "charioteer",
+      "tw_match": "charioteers"
+    }
+  ],
+  "18:34": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "deliverance",
+      "tw_match": "deliverance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Korahites",
+      "tw_match": "Korahite"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "watchtower",
+      "tw_match": "watchtower"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "spoils",
+      "tw_match": "spoils"
+    },
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "plundering",
+      "tw_match": "plunder"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:29": [
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:30": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:31": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "20:32": [
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:33": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:34": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:35": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "20:36": [
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    }
+  ],
+  "20:37": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Arabians",
+      "tw_match": "Arabian"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Arabians",
+      "tw_match": "Arabian"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "advisor",
+      "tw_match": "advisor"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "advisors",
+      "tw_match": "advisor"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Arameans",
+      "tw_match": "Aramean"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "reigning",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "Horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "restoration",
+      "tw_match": "restoration"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    }
+  ],
+  "24:24": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    }
+  ],
+  "24:25": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "24:26": [],
+  "24:27": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Fathers",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "sons of Seir",
+      "tw_match": "sons of Seir"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Edomites",
+      "tw_match": "Edomite"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "sons of Seir",
+      "tw_match": "sons of Seir"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "counselor",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "counselled",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "25:20": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "25:21": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    }
+  ],
+  "25:22": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "25:23": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "25:24": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "25:25": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "25:26": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "25:27": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "25:28": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "instructing",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Arabians",
+      "tw_match": "Arabian"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "Ammonites",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "cisterns",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "lover",
+      "tw_match": "lover"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "altar of incense",
+      "tw_match": "altar of incense"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:18": [
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "raged",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "leprosy",
+      "tw_match": "leprosy"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar of incense",
+      "tw_match": "altar of incense"
+    }
+  ],
+  "26:20": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "26:21": [
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "26:22": [
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "26:23": [
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "28:10": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "spoils",
+      "tw_match": "spoils"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "persons",
+      "tw_match": "person"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "Edomites",
+      "tw_match": "Edomite"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "28:20": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "28:21": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "28:22": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    }
+  ],
+  "28:23": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "28:24": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "28:25": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:26": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "28:27": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reigning",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    }
+  ],
+  "29:7": [
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "29:12": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    }
+  ],
+  "29:13": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "29:14": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "29:15": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "29:16": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "29:17": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "29:18": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "29:19": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:20": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:21": [
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:22": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "29:23": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "29:24": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "atone",
+      "tw_match": "atone"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "29:25": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "29:26": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    }
+  ],
+  "29:27": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "29:28": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "worshipping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "29:29": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    }
+  ],
+  "29:30": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    }
+  ],
+  "29:31": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "29:32": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:33": [
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "29:34": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    }
+  ],
+  "29:35": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "29:36": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "30:1": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "30:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "30:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "30:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "30:8": [
+    {
+      "surface": "harden",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "30:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "compassionate",
+      "tw_match": "compassionate"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "30:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "ridiculing",
+      "tw_match": "ridicule"
+    }
+  ],
+  "30:11": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "30:12": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "30:13": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "30:14": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "30:15": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:16": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scattering",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "30:17": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "slaughtering",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:18": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "atone",
+      "tw_match": "atone"
+    }
+  ],
+  "30:19": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "purifying",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "30:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "30:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "30:22": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "confessing",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "30:23": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "30:24": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    }
+  ],
+  "30:25": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "30:26": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "30:27": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    }
+  ],
+  "31:4": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    }
+  ],
+  "31:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    }
+  ],
+  "31:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:7": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "31:8": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "31:10": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "31:11": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "31:12": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "31:13": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "overseers",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:14": [
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gatekeeper",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "31:15": [
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "31:16": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "31:17": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "31:18": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "consecrating",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "31:19": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "31:20": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:21": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "32:1": [
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "32:2": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "32:3": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "32:4": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "32:5": [
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    }
+  ],
+  "32:6": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "32:7": [
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "32:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "32:9": [
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "32:10": [
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "32:11": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "32:12": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "32:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "32:14": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:15": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:16": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "32:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "32:18": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "frighten",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "32:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "32:20": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "32:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "32:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "32:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "32:24": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "32:25": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "32:26": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "32:27": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    }
+  ],
+  "32:28": [
+    {
+      "surface": "storehouses",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "32:29": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:30": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "32:31": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "32:32": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "faithfulnesses",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "32:33": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "33:1": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "33:2": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "33:3": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "host of the heavens",
+      "tw_match": "host of the heavens"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    }
+  ],
+  "33:4": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "33:5": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "host of the heavens",
+      "tw_match": "host of the heavens"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "33:6": [
+    {
+      "surface": "soothsaying",
+      "tw_match": "soothsaying"
+    },
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "magic",
+      "tw_match": "magic"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    }
+  ],
+  "33:7": [
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "33:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "33:9": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "33:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "33:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "33:12": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    }
+  ],
+  "33:13": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "33:14": [
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "33:15": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "33:16": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "33:17": [
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "33:18": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seers",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "33:19": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    }
+  ],
+  "33:20": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "33:21": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "33:22": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    }
+  ],
+  "33:23": [
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    }
+  ],
+  "33:24": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "33:25": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "34:1": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "34:2": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "34:3": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reigning",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    }
+  ],
+  "34:4": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "34:5": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "34:6": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "34:7": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "34:8": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reigning",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "34:9": [
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "34:10": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "34:11": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "34:12": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "34:13": [
+    {
+      "surface": "bearers",
+      "tw_match": "bearers"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    }
+  ],
+  "34:14": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "34:15": [
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "34:16": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "34:17": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "34:18": [
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "34:19": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "34:20": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "34:21": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "34:22": [
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "prophetess",
+      "tw_match": "prophetess"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "34:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "34:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "34:25": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "quenched",
+      "tw_match": "quenched"
+    }
+  ],
+  "34:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "34:27": [
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "34:28": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "34:29": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "34:30": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "34:31": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "34:32": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "34:33": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "35:1": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "35:2": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "35:3": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "35:4": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "35:5": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "35:6": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "35:7": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "Passovers",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "35:8": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Passovers",
+      "tw_match": "Passover"
+    }
+  ],
+  "35:9": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Passovers",
+      "tw_match": "Passover"
+    }
+  ],
+  "35:10": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "35:11": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "35:12": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "35:13": [
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    }
+  ],
+  "35:14": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "35:15": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "35:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    }
+  ],
+  "35:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "35:18": [
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "35:19": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "35:20": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    }
+  ],
+  "35:21": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "35:22": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "35:23": [
+    {
+      "surface": "archers",
+      "tw_match": "archer"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "35:24": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    }
+  ],
+  "35:25": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Laments",
+      "tw_match": "lament"
+    }
+  ],
+  "35:26": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "faithfulnesses",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    }
+  ],
+  "35:27": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "36:1": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "36:2": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "36:3": [
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "36:4": [
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "36:5": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "36:6": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "36:7": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "36:8": [
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "36:9": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "36:10": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "36:11": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "36:12": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "36:13": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "36:14": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "36:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "36:16": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "36:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    }
+  ],
+  "36:18": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "36:19": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "36:20": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    }
+  ],
+  "36:21": [
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "36:22": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "36:23": [
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_2CO.json
+++ b/sources/keyword_data/keywords_2CO.json
@@ -1,0 +1,3599 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Corinth",
+      "tw_match": "Corinth"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    }
+  ],
+  "1:17": [],
+  "1:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Silvanus",
+      "tw_match": "Silvanus"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Corinth",
+      "tw_match": "Corinth"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "2:1": [],
+  "2:2": [],
+  "2:3": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "proof",
+      "tw_match": "proof"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Troas",
+      "tw_match": "Troas"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    }
+  ],
+  "2:16": [],
+  "2:17": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:2": [],
+  "3:3": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "condemnation",
+      "tw_match": "condemnation"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Spirit of the Lord",
+      "tw_match": "Spirit of the Lord"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "unveiled",
+      "tw_match": "unveiled"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "veiled",
+      "tw_match": "veiled"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "unbelievers",
+      "tw_match": "unbeliever"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "image of God",
+      "tw_match": "image of God"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:8": [],
+  "4:9": [
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "5:3": [],
+  "5:4": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "consciences",
+      "tw_match": "conscience"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "5:15": [],
+  "5:16": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reconciled",
+      "tw_match": "reconciled"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "reconciliation",
+      "tw_match": "reconciliation"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "reconciling",
+      "tw_match": "reconcile"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "reconciliation",
+      "tw_match": "reconciliation"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "implore",
+      "tw_match": "implore"
+    },
+    {
+      "surface": "reconciled",
+      "tw_match": "reconciled"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "favorable",
+      "tw_match": "favorable"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "tribulations",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "hardships",
+      "tw_match": "hardship"
+    },
+    {
+      "surface": "distresses",
+      "tw_match": "distresses"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "labors",
+      "tw_match": "labors"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "word of truth",
+      "tw_match": "word of truth"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "unknown",
+      "tw_match": "unknown"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "possessing",
+      "tw_match": "possess"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Corinthians",
+      "tw_match": "Corinthians"
+    }
+  ],
+  "6:12": [],
+  "6:13": [],
+  "6:14": [
+    {
+      "surface": "yoked",
+      "tw_match": "yoked"
+    },
+    {
+      "surface": "unbelievers",
+      "tw_match": "unbeliever"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "lawlessness",
+      "tw_match": "lawlessness"
+    },
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "believer",
+      "tw_match": "believer"
+    },
+    {
+      "surface": "unbeliever",
+      "tw_match": "unbeliever"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "welcome",
+      "tw_match": "welcome"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "perfecting",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "wronged",
+      "tw_match": "wronged"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "condemnation",
+      "tw_match": "condemnation"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "encouragement",
+      "tw_match": "encouragement"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "afflictions",
+      "tw_match": "affliction"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "conflicts",
+      "tw_match": "conflict"
+    },
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "reporting",
+      "tw_match": "report"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    },
+    {
+      "surface": "encouragement",
+      "tw_match": "encouragement"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "boasted",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "trial",
+      "tw_match": "trial"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "pleaded",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "proving",
+      "tw_match": "proving"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "profitable",
+      "tw_match": "profitable"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    }
+  ],
+  "8:17": [],
+  "8:18": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "8:22": [],
+  "8:23": [
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    },
+    {
+      "surface": "fellow worker",
+      "tw_match": "fellow worker"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "proof",
+      "tw_match": "proof"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "sowing",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "distributed",
+      "tw_match": "distributed"
+    },
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "sower",
+      "tw_match": "sower"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "proof",
+      "tw_match": "proof"
+    },
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "confession",
+      "tw_match": "confession"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "meek",
+      "tw_match": "meek"
+    },
+    {
+      "surface": "meekness",
+      "tw_match": "meekness"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "pleading",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    }
+  ],
+  "10:3": [],
+  "10:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    }
+  ],
+  "10:10": [],
+  "10:11": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "labors",
+      "tw_match": "labors"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "Eve",
+      "tw_match": "Eve"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "proclaims",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "humbling",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "preached",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "wonder",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "enslaves",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "exalts",
+      "tw_match": "exalt"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "Israelites",
+      "tw_match": "Israelites"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "hard work",
+      "tw_match": "hard work"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "rods",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "hard work",
+      "tw_match": "hard work"
+    },
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    }
+  ],
+  "11:33": [],
+  "12:1": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "profitable",
+      "tw_match": "profitable"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "12:4": [],
+  "12:5": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "thorn",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "hardships",
+      "tw_match": "hardship"
+    },
+    {
+      "surface": "distresses",
+      "tw_match": "distresses"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "12:16": [],
+  "12:17": [],
+  "12:18": [
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "quarreling",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "slanders",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "gossips",
+      "tw_match": "gossips"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "proof",
+      "tw_match": "proof"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "Test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "13:8": [],
+  "13:9": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "restoration",
+      "tw_match": "restoration"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_2JN.json
+++ b/sources/keyword_data/keywords_2JN.json
@@ -1,0 +1,192 @@
+{
+  "1:1": [
+    {
+      "surface": "elder",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "confessing",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "antichrist",
+      "tw_match": "antichrist"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_2KI.json
+++ b/sources/keyword_data/keywords_2KI.json
@@ -1,0 +1,15917 @@
+{
+  "1:1": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "tied",
+      "tw_match": "tied"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "kneeled",
+      "tw_match": "kneel"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "pleaded",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "2:10": [],
+  "2:11": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "shaming",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    }
+  ],
+  "2:20": [],
+  "2:21": [
+    {
+      "surface": "source",
+      "tw_match": "source"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "Mount Carmel",
+      "tw_match": "Mount Carmel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cisterns",
+      "tw_match": "cistern"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "tied",
+      "tw_match": "tied"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    }
+  ],
+  "4:4": [],
+  "4:5": [],
+  "4:6": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "4:20": [],
+  "4:21": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Mount Carmel",
+      "tw_match": "Mount Carmel"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "Gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blesses",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "4:33": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:34": [
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    }
+  ],
+  "4:35": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "4:36": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    }
+  ],
+  "4:37": [
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "4:38": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "4:39": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "4:40": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "4:41": [],
+  "4:42": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "4:43": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    }
+  ],
+  "4:44": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "deliverance",
+      "tw_match": "deliverance"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "mules",
+      "tw_match": "mule"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    },
+    {
+      "surface": "prostrate",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    },
+    {
+      "surface": "Aramean",
+      "tw_match": "Aramean"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "olives",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "6:7": [],
+  "6:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Beware",
+      "tw_match": "beware"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "guarded",
+      "tw_match": "guard"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    }
+  ],
+  "6:28": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "6:31": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    }
+  ],
+  "6:32": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "6:33": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "gatekeeper",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "tied",
+      "tw_match": "tied"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "grains",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "sojourn",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "sojourned",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "reporting",
+      "tw_match": "report"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "shaming",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Arameans",
+      "tw_match": "Aramean"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "Arameans",
+      "tw_match": "Aramean"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "Ahijah",
+      "tw_match": "Ahijah"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "burying",
+      "tw_match": "bury"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "Arameans",
+      "tw_match": "Aramean"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "watchtower",
+      "tw_match": "watchtower"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Jezreelite",
+      "tw_match": "Jezreelite"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "sorceries",
+      "tw_match": "sorceries"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "Jezreelite",
+      "tw_match": "Jezreelite"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "9:32": [
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    }
+  ],
+  "9:33": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "9:34": [
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "9:35": [
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    }
+  ],
+  "9:36": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    }
+  ],
+  "9:37": [
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "Seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "cunning",
+      "tw_match": "cunning"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "10:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:31": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "10:34": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:35": [
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "10:36": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "column",
+      "tw_match": "column"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "trumpeters",
+      "tw_match": "trumpeters"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Jehoram",
+      "tw_match": "Jehoram"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "savior",
+      "tw_match": "savior"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "a bow",
+      "tw_match": "a bow"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "burying",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Fathers",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "thorn",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "stir up",
+      "tw_match": "stir up"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ahaziah",
+      "tw_match": "Ahaziah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "pledges",
+      "tw_match": "pledges"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "Desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wipe out",
+      "tw_match": "wipe out"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Gileadites",
+      "tw_match": "Gileadite"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    }
+  ],
+  "15:34": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "15:35": [
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:36": [
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "15:37": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "15:38": [
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Arameans",
+      "tw_match": "Aramean"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "besieged",
+      "tw_match": "besieged"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    },
+    {
+      "surface": "Media",
+      "tw_match": "Media"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "Asherah pole",
+      "tw_match": "Asherah pole"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "host of the heavens",
+      "tw_match": "host of the heavens"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "divined",
+      "tw_match": "divine"
+    },
+    {
+      "surface": "divinations",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    }
+  ],
+  "17:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "17:24": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    }
+  ],
+  "17:25": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    }
+  ],
+  "17:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "17:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "17:28": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:29": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Samaritans",
+      "tw_match": "Samaritan"
+    }
+  ],
+  "17:30": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    }
+  ],
+  "17:31": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "17:32": [
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "17:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    }
+  ],
+  "17:34": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:35": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "prostrate",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "17:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "prostrate",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "17:37": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "17:38": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "17:39": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "17:40": [
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    }
+  ],
+  "17:41": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "Asherah pole",
+      "tw_match": "Asherah pole"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Medes",
+      "tw_match": "Medes"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "columns",
+      "tw_match": "column"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "prostrate",
+      "tw_match": "prostrate"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Aramaic",
+      "tw_match": "Aramaic"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "18:31": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "18:32": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "18:33": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "18:34": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "18:35": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "18:36": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "18:37": [
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "insulted",
+      "tw_match": "insult"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    },
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "shakes",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "19:25": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "19:26": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "19:27": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "raging",
+      "tw_match": "rage"
+    }
+  ],
+  "19:28": [
+    {
+      "surface": "raging",
+      "tw_match": "rage"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "seeded",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "19:30": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "19:31": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:32": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "19:33": [
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:34": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "19:35": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "19:36": [
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    }
+  ],
+  "19:37": [
+    {
+      "surface": "prostrating",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ararat",
+      "tw_match": "Ararat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Asherah pole",
+      "tw_match": "Asherah pole"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "host of the heavens",
+      "tw_match": "host of the heavens"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "host of the heavens",
+      "tw_match": "host of the heavens"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "soothsayers",
+      "tw_match": "soothsayer"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophetess",
+      "tw_match": "prophetess"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "host of the heavens",
+      "tw_match": "host of the heavens"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "pagan",
+      "tw_match": "pagan"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "host of the heavens",
+      "tw_match": "host of the heavens"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "Asherah pole",
+      "tw_match": "Asherah pole"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "courtyards",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Asherah pole",
+      "tw_match": "Asherah pole"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "provoking",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "pits",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "soothsayers",
+      "tw_match": "soothsayer"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "23:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "23:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Euphrates River",
+      "tw_match": "Euphrates River"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "23:30": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "23:31": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "23:32": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "23:33": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "23:34": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "23:35": [
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:36": [
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "23:37": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Euphrates River",
+      "tw_match": "Euphrates River"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "besieging",
+      "tw_match": "besiege"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "exiling",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "citizens",
+      "tw_match": "citizen"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "siegework",
+      "tw_match": "siegeworks"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "Zephaniah",
+      "tw_match": "Zephaniah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "25:20": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "25:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    }
+  ],
+  "25:22": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "25:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    }
+  ],
+  "25:24": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "25:25": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "25:26": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "25:27": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "25:28": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "25:29": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "25:30": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_2PE.json
+++ b/sources/keyword_data/keywords_2PE.json
@@ -1,0 +1,1148 @@
+{
+  "1:1": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "divine",
+      "tw_match": "divine"
+    },
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "divine",
+      "tw_match": "divine"
+    },
+    {
+      "surface": "corruption",
+      "tw_match": "corruption"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "lust",
+      "tw_match": "lust"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "self-control",
+      "tw_match": "self-control"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "unfruitful",
+      "tw_match": "unfruitful"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "remind",
+      "tw_match": "remind"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "Likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "eyewitnesses",
+      "tw_match": "eyewitness"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "Glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "slandered",
+      "tw_match": "slander"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "condemnation",
+      "tw_match": "condemnation"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "preacher",
+      "tw_match": "preacher"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "ungodly",
+      "tw_match": "ungodly"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "ungodly",
+      "tw_match": "ungodly"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tormenting",
+      "tw_match": "torment"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    },
+    {
+      "surface": "trial",
+      "tw_match": "trial"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    },
+    {
+      "surface": "day of judgment",
+      "tw_match": "day of judgment"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "lusts",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "Self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "insulting",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "insulting",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "slandering",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "blemishes",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "deceptions",
+      "tw_match": "deception"
+    },
+    {
+      "surface": "feasting",
+      "tw_match": "feasting"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "adulteress",
+      "tw_match": "adulteress"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "vanity",
+      "tw_match": "vanity"
+    },
+    {
+      "surface": "lusts",
+      "tw_match": "lust"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "promising",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "pig",
+      "tw_match": "pig"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "mockers",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "mockery",
+      "tw_match": "mockery"
+    },
+    {
+      "surface": "last days",
+      "tw_match": "last days"
+    },
+    {
+      "surface": "lusts",
+      "tw_match": "lust"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "flooded",
+      "tw_match": "flood"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "day of judgment",
+      "tw_match": "day of judgment"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "ungodly",
+      "tw_match": "ungodly"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "patient",
+      "tw_match": "patient"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "day of the Lord",
+      "tw_match": "day of the Lord"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "scriptures",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_2SA.json
+++ b/sources/keyword_data/keywords_2SA.json
@@ -1,0 +1,13342 @@
+{
+  "1:1": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Amalekite",
+      "tw_match": "Amalekite"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Amalekite",
+      "tw_match": "Amalekite"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "lamented",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Bow",
+      "tw_match": "bow"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Ashkelon",
+      "tw_match": "Ashkelon"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "eagles",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "2:30": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "2:31": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "2:32": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Geshur",
+      "tw_match": "Geshur"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "3:15": [],
+  "3:16": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "3:29": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "leprosy",
+      "tw_match": "leprosy"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "3:30": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "murdered",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "3:31": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    }
+  ],
+  "3:32": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "3:33": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "lamented",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "3:34": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "3:35": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:36": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:37": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "3:38": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:39": [
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "murdered",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "hung",
+      "tw_match": "hung"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "Abner",
+      "tw_match": "Abner"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "5:15": [],
+  "5:16": [],
+  "5:17": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "the Valley of the Raphaites",
+      "tw_match": "the Valley of the Raphaites"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "the Valley of the Raphaites",
+      "tw_match": "the Valley of the Raphaites"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "celebrating",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stumbled",
+      "tw_match": "stumble"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Gittite",
+      "tw_match": "Gittite"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Gittite",
+      "tw_match": "Gittite"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "distributed",
+      "tw_match": "distributed"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "celebrated",
+      "tw_match": "celebrate"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "scepters",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "a house for my name",
+      "tw_match": "a house for my name"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "Aram of Damascus",
+      "tw_match": "Aram of Damascus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Aram of Damascus",
+      "tw_match": "Aram of Damascus"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "Cherethites",
+      "tw_match": "Cherethites"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "honoring",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "charioteers",
+      "tw_match": "charioteers"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "besieged",
+      "tw_match": "besieged"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Bathsheba",
+      "tw_match": "Bathsheba"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "sanctifying",
+      "tw_match": "sanctify"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "lamented",
+      "tw_match": "lament"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "ewe",
+      "tw_match": "ewe"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "ewe",
+      "tw_match": "ewe"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "ewe",
+      "tw_match": "ewe"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "murdered",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Bathsheba",
+      "tw_match": "Bathsheba"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "12:27": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "12:30": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "12:31": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "axes",
+      "tw_match": "ax"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "cunning",
+      "tw_match": "cunning"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "Lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "13:26": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "13:27": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    }
+  ],
+  "13:29": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "mule",
+      "tw_match": "mule"
+    }
+  ],
+  "13:30": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "13:31": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "13:32": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "humbling",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    }
+  ],
+  "13:33": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    }
+  ],
+  "13:34": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "13:35": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "13:36": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "13:37": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Geshur",
+      "tw_match": "Geshur"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:38": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Geshur",
+      "tw_match": "Geshur"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "13:39": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Amnon",
+      "tw_match": "Amnon"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "deliverer",
+      "tw_match": "deliverer"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "heir",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "quench",
+      "tw_match": "quench"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "people of God",
+      "tw_match": "people of God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Geshur",
+      "tw_match": "Geshur"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "14:30": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "14:31": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "14:32": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Geshur",
+      "tw_match": "Geshur"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "14:33": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "prostrate",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Geshur",
+      "tw_match": "Geshur"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "counselor",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "chooses",
+      "tw_match": "choose"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Cherethites",
+      "tw_match": "Cherethites"
+    },
+    {
+      "surface": "Gittites",
+      "tw_match": "Gittite"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Gittite",
+      "tw_match": "Gittite"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gittite",
+      "tw_match": "Gittite"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Mount of Olives",
+      "tw_match": "Mount of Olives"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prostrate",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "15:34": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "15:35": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "15:36": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    }
+  ],
+  "15:37": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "prostrate",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Benjaminite",
+      "tw_match": "Benjaminite"
+    },
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "counseled",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "counseled",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "pits",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "counseled",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "counseled",
+      "tw_match": "counsel"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "17:23": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "17:24": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:25": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "17:26": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "17:27": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Gileadite",
+      "tw_match": "Gileadite"
+    }
+  ],
+  "17:28": [
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "17:29": [
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Gittite",
+      "tw_match": "Gittite"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "mule",
+      "tw_match": "mule"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "hung",
+      "tw_match": "hung"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "18:23": [],
+  "18:24": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "gatekeeper",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "18:31": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "18:32": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "18:33": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "shamed",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "Benjaminite",
+      "tw_match": "Benjaminite"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "19:25": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:26": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "19:27": [
+    {
+      "surface": "slandered",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "19:28": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:30": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "19:31": [
+    {
+      "surface": "Gileadite",
+      "tw_match": "Gileadite"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:32": [
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:33": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "19:34": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "19:35": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:36": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "19:37": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "19:38": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "19:39": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "19:40": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "19:41": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "19:42": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:43": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "Absalom",
+      "tw_match": "Absalom"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Cherethites",
+      "tw_match": "Cherethites"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "waist",
+      "tw_match": "waist"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "20:12": [],
+  "20:13": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "besieged",
+      "tw_match": "besieged"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Inquiring",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "dispersed",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "Cherethites",
+      "tw_match": "Cherethites"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Gibeonites",
+      "tw_match": "Gibeonite"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Gibeonites",
+      "tw_match": "Gibeonite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gibeonites",
+      "tw_match": "Gibeonite"
+    },
+    {
+      "surface": "atone",
+      "tw_match": "atone"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "Gibeonites",
+      "tw_match": "Gibeonite"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "Gibeonites",
+      "tw_match": "Gibeonite"
+    },
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "Rapha",
+      "tw_match": "Rapha"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Rapha",
+      "tw_match": "Rapha"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Goliath",
+      "tw_match": "Goliath"
+    },
+    {
+      "surface": "Gittite",
+      "tw_match": "Gittite"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Rapha",
+      "tw_match": "Rapha"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "Rapha",
+      "tw_match": "Rapha"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "deliverer",
+      "tw_match": "deliverer"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "savior",
+      "tw_match": "savior"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "22:5": [],
+  "22:6": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "snares",
+      "tw_match": "snare"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "22:13": [],
+  "22:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "22:17": [],
+  "22:18": [
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "delighted",
+      "tw_match": "delight"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rewarded",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "cunning",
+      "tw_match": "cunning"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:31": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "22:32": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:33": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "22:34": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "deer",
+      "tw_match": "deer"
+    }
+  ],
+  "22:35": [
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "a bow",
+      "tw_match": "a bow"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "22:36": [
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "22:37": [],
+  "22:38": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "22:39": [
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "22:40": [
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "22:41": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "22:42": [
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:43": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    }
+  ],
+  "22:44": [
+    {
+      "surface": "disputes",
+      "tw_match": "disputes"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "22:45": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "22:46": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "22:47": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "22:48": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    }
+  ],
+  "22:49": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "22:50": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "22:51": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "thorn",
+      "tw_match": "thorn"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "the Valley of the Raphaites",
+      "tw_match": "the Valley of the Raphaites"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "Profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "23:25": [],
+  "23:26": [],
+  "23:27": [],
+  "23:28": [],
+  "23:29": [
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "23:30": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "wadis",
+      "tw_match": "wadi"
+    }
+  ],
+  "23:31": [],
+  "23:32": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "23:33": [],
+  "23:34": [],
+  "23:35": [],
+  "23:36": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    }
+  ],
+  "23:37": [
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "23:38": [],
+  "23:39": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "seer",
+      "tw_match": "seer"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Choose",
+      "tw_match": "choose"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "24:24": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "24:25": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_2TH.json
+++ b/sources/keyword_data/keywords_2TH.json
@@ -1,0 +1,840 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Silvanus",
+      "tw_match": "Silvanus"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Thessalonians",
+      "tw_match": "Thessalonian"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "afflictions",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "evidence",
+      "tw_match": "evidence"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "afflicting",
+      "tw_match": "afflict"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "day of the Lord",
+      "tw_match": "day of the Lord"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "lawlessness",
+      "tw_match": "lawlessness"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "exalting",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "lawlessness",
+      "tw_match": "lawlessness"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "sanctification",
+      "tw_match": "sanctification"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "belief",
+      "tw_match": "belief"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "traditions",
+      "tw_match": "tradition"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "traditions",
+      "tw_match": "tradition"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "exhorting",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_2TI.json
+++ b/sources/keyword_data/keywords_2TI.json
@@ -1,0 +1,1323 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "reminding",
+      "tw_match": "remind"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "self-control",
+      "tw_match": "self-control"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Rome",
+      "tw_match": "Rome"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "soldier",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "soldier",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "crowned",
+      "tw_match": "crowned"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Remind",
+      "tw_match": "remind"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "word of truth",
+      "tw_match": "word of truth"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "ungodliness",
+      "tw_match": "ungodliness"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "lusts",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "patient",
+      "tw_match": "patient"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "meekness",
+      "tw_match": "meekness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "last days",
+      "tw_match": "last days"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "boastful",
+      "tw_match": "boastful"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "blasphemous",
+      "tw_match": "blasphemous"
+    },
+    {
+      "surface": "unholy",
+      "tw_match": "unholy"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "households",
+      "tw_match": "household"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:9": [],
+  "3:10": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "Iconium",
+      "tw_match": "Iconium"
+    },
+    {
+      "surface": "Lystra",
+      "tw_match": "Lystra"
+    },
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "Scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "breathed",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "profitable",
+      "tw_match": "profitable"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Preach",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "reprove",
+      "tw_match": "reprove"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "exhort",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "4:4": [],
+  "4:5": [
+    {
+      "surface": "Suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "evangelist",
+      "tw_match": "evangelist"
+    },
+    {
+      "surface": "Fulfill",
+      "tw_match": "fulfill"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "4:9": [],
+  "4:10": [
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "Thessalonica",
+      "tw_match": "Thessalonica"
+    },
+    {
+      "surface": "Galatia",
+      "tw_match": "Galatia"
+    },
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "Luke",
+      "tw_match": "Luke"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "Tychicus",
+      "tw_match": "Tychicus"
+    },
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "Troas",
+      "tw_match": "Troas"
+    },
+    {
+      "surface": "scrolls",
+      "tw_match": "scroll"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "evils",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "4:16": [],
+  "4:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "proclamation",
+      "tw_match": "proclamation"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "Prisca",
+      "tw_match": "Prisca"
+    },
+    {
+      "surface": "Aquila",
+      "tw_match": "Aquila"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "Corinth",
+      "tw_match": "Corinth"
+    }
+  ],
+  "4:21": [],
+  "4:22": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_3JN.json
+++ b/sources/keyword_data/keywords_3JN.json
@@ -1,0 +1,181 @@
+{
+  "1:1": [
+    {
+      "surface": "elder",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "prospers",
+      "tw_match": "prosper"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "1:8": [],
+  "1:9": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "1:13": [],
+  "1:14": [],
+  "1:15": [
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_ACT.json
+++ b/sources/keyword_data/keywords_ACT.json
@@ -1,0 +1,15745 @@
+{
+  "1:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "proofs",
+      "tw_match": "proof"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "restoring",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:9": [],
+  "1:10": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Galileans",
+      "tw_match": "Galilean"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Thomas",
+      "tw_match": "Thomas"
+    },
+    {
+      "surface": "Bartholomew",
+      "tw_match": "Bartholomew"
+    },
+    {
+      "surface": "Matthew",
+      "tw_match": "Matthew"
+    },
+    {
+      "surface": "Simon the Zealot",
+      "tw_match": "Simon the Zealot"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "prostrate",
+      "tw_match": "prostrate"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "Psalms",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "apostleship",
+      "tw_match": "apostleship"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Pentecost",
+      "tw_match": "Pentecost"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "language",
+      "tw_match": "language"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Galileans",
+      "tw_match": "Galilean"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "language",
+      "tw_match": "language"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Medes",
+      "tw_match": "Medes"
+    },
+    {
+      "surface": "Elamites",
+      "tw_match": "Elamites"
+    },
+    {
+      "surface": "Mesopotamia",
+      "tw_match": "Mesopotamia"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Pontus",
+      "tw_match": "Pontus"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Cyrene",
+      "tw_match": "Cyrene"
+    },
+    {
+      "surface": "Romans",
+      "tw_match": "Roman"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Cretans",
+      "tw_match": "Cretan"
+    },
+    {
+      "surface": "Arabians",
+      "tw_match": "Arabian"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:12": [],
+  "2:13": [
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "the eleven",
+      "tw_match": "the eleven"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "last days",
+      "tw_match": "last days"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "day of the Lord",
+      "tw_match": "day of the Lord"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "Israelites",
+      "tw_match": "Israelites"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mighty works",
+      "tw_match": "mighty works"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "foreknowledge",
+      "tw_match": "foreknowledge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "exulted",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Hades",
+      "tw_match": "Hades"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    }
+  ],
+  "2:28": [],
+  "2:29": [
+    {
+      "surface": "patriarch",
+      "tw_match": "patriarch"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:30": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "2:31": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Hades",
+      "tw_match": "Hades"
+    }
+  ],
+  "2:32": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "2:33": [
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "2:34": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "2:35": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "2:36": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "2:37": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "2:38": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "2:39": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "2:40": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "2:41": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:42": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    }
+  ],
+  "2:43": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "2:44": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "2:45": [
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:46": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "2:47": [
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "seizing",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "wonder",
+      "tw_match": "wonder"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Israelites",
+      "tw_match": "Israelites"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "Repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "restoration",
+      "tw_match": "restoration"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "in Jesus",
+      "tw_match": "in Jesus"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "Annas",
+      "tw_match": "Annas"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "Caiaphas",
+      "tw_match": "Caiaphas"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    }
+  ],
+  "4:7": [],
+  "4:8": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:14": [],
+  "4:15": [],
+  "4:16": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "4:17": [],
+  "4:18": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "4:20": [],
+  "4:21": [
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "4:33": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "4:34": [
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "4:35": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "distributed",
+      "tw_match": "distributed"
+    }
+  ],
+  "4:36": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Encouragement",
+      "tw_match": "encouragement"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Cyprus",
+      "tw_match": "Cyprus"
+    }
+  ],
+  "4:37": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "lied",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "hours",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "Spirit of the Lord",
+      "tw_match": "Spirit of the Lord"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "5:13": [],
+  "5:14": [
+    {
+      "surface": "believers",
+      "tw_match": "believer"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "hung",
+      "tw_match": "hung"
+    }
+  ],
+  "5:31": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:32": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:33": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "5:34": [
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "5:35": [
+    {
+      "surface": "Israelites",
+      "tw_match": "Israelites"
+    }
+  ],
+  "5:36": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "dispersed",
+      "tw_match": "disperse"
+    }
+  ],
+  "5:37": [
+    {
+      "surface": "Galilean",
+      "tw_match": "Galilean"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "census",
+      "tw_match": "census"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "5:38": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "5:39": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "5:40": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    }
+  ],
+  "5:41": [
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    }
+  ],
+  "5:42": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "multiplying",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "Hellenists",
+      "tw_match": "Hellenist"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "reputation",
+      "tw_match": "reputation"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Stephen",
+      "tw_match": "Stephen"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "Stephen",
+      "tw_match": "Stephen"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Cilicia",
+      "tw_match": "Cilicia"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "Stephen",
+      "tw_match": "Stephen"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "bribed",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "blasphemous",
+      "tw_match": "blasphemous"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Mesopotamia",
+      "tw_match": "Mesopotamia"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "enslave",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "enslave",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "patriarchs",
+      "tw_match": "patriarch"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "patriarchs",
+      "tw_match": "patriarch"
+    },
+    {
+      "surface": "envying",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "afflictions",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "mistreated",
+      "tw_match": "mistreat"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "mistreated",
+      "tw_match": "mistreat"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "quarreling",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "hurting",
+      "tw_match": "hurt"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "7:30": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "7:31": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "7:32": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "7:33": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "sandal",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "7:34": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "7:35": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "7:36": [
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Red Sea",
+      "tw_match": "Red Sea"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "7:37": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "7:38": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "7:39": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "7:40": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "7:41": [
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "7:42": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "host of heaven",
+      "tw_match": "host of heaven"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    }
+  ],
+  "7:43": [
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "7:44": [
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "7:45": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "possessing",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "7:46": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "7:47": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "7:48": [
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "7:49": [
+    {
+      "surface": "Heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "7:50": [],
+  "7:51": [
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "7:52": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "persecute",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "betrayers",
+      "tw_match": "betrayer"
+    }
+  ],
+  "7:53": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "7:54": [],
+  "7:55": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "7:56": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:57": [],
+  "7:58": [
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "7:59": [
+    {
+      "surface": "stoning",
+      "tw_match": "stoning"
+    },
+    {
+      "surface": "Stephen",
+      "tw_match": "Stephen"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "7:60": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Stephen",
+      "tw_match": "Stephen"
+    },
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "delivering",
+      "tw_match": "deliver"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "sorcery",
+      "tw_match": "sorcery"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sorceries",
+      "tw_match": "sorceries"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "bond",
+      "tw_match": "bond"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Samaritans",
+      "tw_match": "Samaritan"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "Ethiopian",
+      "tw_match": "Ethiopian"
+    },
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Ethiopians",
+      "tw_match": "Ethiopian"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "Scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "8:36": [
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "8:37": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:38": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "8:39": [
+    {
+      "surface": "Spirit of the Lord",
+      "tw_match": "Spirit of the Lord"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "8:40": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Azotus",
+      "tw_match": "Azotus"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "breathing",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    }
+  ],
+  "9:6": [],
+  "9:7": [],
+  "9:8": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Tarsus",
+      "tw_match": "Tarsus"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "evils",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "choosing",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "proving",
+      "tw_match": "proving"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "Hellenists",
+      "tw_match": "Hellenist"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    },
+    {
+      "surface": "Tarsus",
+      "tw_match": "Tarsus"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "encouragement",
+      "tw_match": "encouragement"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "multiplying",
+      "tw_match": "multiply"
+    }
+  ],
+  "9:32": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "9:33": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "9:34": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "9:35": [
+    {
+      "surface": "Sharon",
+      "tw_match": "Sharon"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "9:36": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "9:37": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "9:38": [
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "9:39": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "9:40": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    }
+  ],
+  "9:41": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "9:42": [
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "9:43": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    },
+    {
+      "surface": "Cornelius",
+      "tw_match": "Cornelius"
+    },
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Cornelius",
+      "tw_match": "Cornelius"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    },
+    {
+      "surface": "memorial offering",
+      "tw_match": "memorial offering"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "soldier",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "descending",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Cornelius",
+      "tw_match": "Cornelius"
+    },
+    {
+      "surface": "inquiry",
+      "tw_match": "inquiries"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "10:20": [],
+  "10:21": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Cornelius",
+      "tw_match": "Cornelius"
+    },
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    },
+    {
+      "surface": "Cornelius",
+      "tw_match": "Cornelius"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Cornelius",
+      "tw_match": "Cornelius"
+    },
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "unlawful",
+      "tw_match": "unlawful"
+    },
+    {
+      "surface": "Jewish",
+      "tw_match": "Jewish"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "10:29": [],
+  "10:30": [
+    {
+      "surface": "Cornelius",
+      "tw_match": "Cornelius"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "10:31": [
+    {
+      "surface": "Cornelius",
+      "tw_match": "Cornelius"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "10:34": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "favoritism",
+      "tw_match": "favoritism"
+    }
+  ],
+  "10:35": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "10:36": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "10:37": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    }
+  ],
+  "10:38": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    }
+  ],
+  "10:39": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "hanging",
+      "tw_match": "hang"
+    }
+  ],
+  "10:40": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:41": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:42": [
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Judge",
+      "tw_match": "judge"
+    }
+  ],
+  "10:43": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "bear witness",
+      "tw_match": "bear witness"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "10:44": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "10:45": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "10:46": [
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "10:47": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "10:48": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    }
+  ],
+  "11:3": [],
+  "11:4": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Stephen",
+      "tw_match": "Stephen"
+    },
+    {
+      "surface": "Phoenicia",
+      "tw_match": "Phoenicia"
+    },
+    {
+      "surface": "Cyprus",
+      "tw_match": "Cyprus"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "encouraging",
+      "tw_match": "encouraging"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "Tarsus",
+      "tw_match": "Tarsus"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Christians",
+      "tw_match": "Christian"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "prospering",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "Jewish",
+      "tw_match": "Jewish"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "quarreling",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "Tyrians",
+      "tw_match": "Tyrians"
+    },
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "tetrarch",
+      "tw_match": "tetrarch"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Cyprus",
+      "tw_match": "Cyprus"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "magician",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "Jewish",
+      "tw_match": "Jewish"
+    },
+    {
+      "surface": "false prophet",
+      "tw_match": "false prophet"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "proconsul",
+      "tw_match": "proconsul"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "Magician",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "proconsul",
+      "tw_match": "proconsul"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "proconsul",
+      "tw_match": "proconsul"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "exhortation",
+      "tw_match": "exhortation"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Israelites",
+      "tw_match": "Israelites"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "sojourned",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "completing",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "13:26": [
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "13:27": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "condemning",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "13:29": [
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "13:30": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:31": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "13:32": [
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "13:33": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Psalm",
+      "tw_match": "psalm"
+    }
+  ],
+  "13:34": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "13:35": [
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    }
+  ],
+  "13:36": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "13:37": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:38": [
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    }
+  ],
+  "13:39": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "13:40": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "13:41": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    }
+  ],
+  "13:42": [
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "13:43": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:44": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    }
+  ],
+  "13:45": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "blaspheming",
+      "tw_match": "blaspheme"
+    }
+  ],
+  "13:46": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "13:47": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "13:48": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "13:49": [
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    }
+  ],
+  "13:50": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    }
+  ],
+  "13:51": [
+    {
+      "surface": "Iconium",
+      "tw_match": "Iconium"
+    }
+  ],
+  "13:52": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "Iconium",
+      "tw_match": "Iconium"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "mistreat",
+      "tw_match": "mistreat"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "aware",
+      "tw_match": "aware"
+    },
+    {
+      "surface": "Lystra",
+      "tw_match": "Lystra"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "Lystra",
+      "tw_match": "Lystra"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "Iconium",
+      "tw_match": "Iconium"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Lystra",
+      "tw_match": "Lystra"
+    },
+    {
+      "surface": "Iconium",
+      "tw_match": "Iconium"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "encouraging",
+      "tw_match": "encouraging"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "afflictions",
+      "tw_match": "affliction"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "14:24": [],
+  "14:25": [],
+  "14:26": [
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "reporting",
+      "tw_match": "report"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Phoenicia",
+      "tw_match": "Phoenicia"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "circumcise",
+      "tw_match": "circumcise"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "distinguish",
+      "tw_match": "distinguish"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "James",
+      "tw_match": "James"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "Syria",
+      "tw_match": "Syria"
+    },
+    {
+      "surface": "Cilicia",
+      "tw_match": "Cilicia"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "disturbed",
+      "tw_match": "disturb"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    },
+    {
+      "surface": "reporting",
+      "tw_match": "report"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "encouragement",
+      "tw_match": "encouragement"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "15:34": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    }
+  ],
+  "15:35": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    }
+  ],
+  "15:36": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    }
+  ],
+  "15:37": [
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "15:38": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "15:39": [
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Cyprus",
+      "tw_match": "Cyprus"
+    }
+  ],
+  "15:40": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "15:41": [
+    {
+      "surface": "Syria",
+      "tw_match": "Syria"
+    },
+    {
+      "surface": "Cilicia",
+      "tw_match": "Cilicia"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "Lystra",
+      "tw_match": "Lystra"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Jewish",
+      "tw_match": "Jewish"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Lystra",
+      "tw_match": "Lystra"
+    },
+    {
+      "surface": "Iconium",
+      "tw_match": "Iconium"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "delivering",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Troas",
+      "tw_match": "Troas"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "Troas",
+      "tw_match": "Troas"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "Philippi",
+      "tw_match": "Philippi"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "divining",
+      "tw_match": "divine"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "seizing",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "magistrates",
+      "tw_match": "magistrate"
+    },
+    {
+      "surface": "troubling",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "Romans",
+      "tw_match": "Roman"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "magistrates",
+      "tw_match": "magistrate"
+    },
+    {
+      "surface": "rods",
+      "tw_match": "rod"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "16:29": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    }
+  ],
+  "16:30": [
+    {
+      "surface": "Sirs",
+      "tw_match": "sir"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "16:31": [
+    {
+      "surface": "Believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    }
+  ],
+  "16:32": [
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "16:33": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "16:34": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:35": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "magistrates",
+      "tw_match": "magistrate"
+    },
+    {
+      "surface": "Release",
+      "tw_match": "release"
+    }
+  ],
+  "16:36": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "magistrates",
+      "tw_match": "magistrate"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "16:37": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "trial",
+      "tw_match": "trial"
+    },
+    {
+      "surface": "Romans",
+      "tw_match": "Roman"
+    }
+  ],
+  "16:38": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "magistrates",
+      "tw_match": "magistrate"
+    },
+    {
+      "surface": "Romans",
+      "tw_match": "Roman"
+    }
+  ],
+  "16:39": [],
+  "16:40": [
+    {
+      "surface": "exhorted",
+      "tw_match": "exhort"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Thessalonica",
+      "tw_match": "Thessalonica"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "bond",
+      "tw_match": "bond"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    },
+    {
+      "surface": "Berea",
+      "tw_match": "Berea"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "Thessalonica",
+      "tw_match": "Thessalonica"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Thessalonica",
+      "tw_match": "Thessalonica"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Berea",
+      "tw_match": "Berea"
+    },
+    {
+      "surface": "troubling",
+      "tw_match": "trouble"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "17:23": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Unknown",
+      "tw_match": "unknown"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    }
+  ],
+  "17:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "temples",
+      "tw_match": "temple"
+    }
+  ],
+  "17:25": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "17:26": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "17:27": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "17:28": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "17:29": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Divine",
+      "tw_match": "divine"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    }
+  ],
+  "17:30": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    }
+  ],
+  "17:31": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "17:32": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    }
+  ],
+  "17:33": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "17:34": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "Corinth",
+      "tw_match": "Corinth"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Aquila",
+      "tw_match": "Aquila"
+    },
+    {
+      "surface": "Priscilla",
+      "tw_match": "Priscilla"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Rome",
+      "tw_match": "Rome"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "tentmakers",
+      "tw_match": "tentmakers"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "Silas",
+      "tw_match": "Silas"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "insulting",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Corinthians",
+      "tw_match": "Corinthians"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "18:10": [],
+  "18:11": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "Syria",
+      "tw_match": "Syria"
+    },
+    {
+      "surface": "Priscilla",
+      "tw_match": "Priscilla"
+    },
+    {
+      "surface": "Aquila",
+      "tw_match": "Aquila"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Galatia",
+      "tw_match": "Galatia"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "Jewish",
+      "tw_match": "Jewish"
+    },
+    {
+      "surface": "Apollos",
+      "tw_match": "Apollos"
+    },
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Priscilla",
+      "tw_match": "Priscilla"
+    },
+    {
+      "surface": "Aquila",
+      "tw_match": "Aquila"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "encouraging",
+      "tw_match": "encouraging"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "welcome",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Apollos",
+      "tw_match": "Apollos"
+    },
+    {
+      "surface": "Corinth",
+      "tw_match": "Corinth"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in Jesus",
+      "tw_match": "in Jesus"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    }
+  ],
+  "19:7": [],
+  "19:8": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "Jewish",
+      "tw_match": "Jewish"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "proclaims",
+      "tw_match": "proclaim"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "Jewish",
+      "tw_match": "Jewish"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "evil spirit",
+      "tw_match": "evil spirit"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "evil spirit",
+      "tw_match": "evil spirit"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "confessing",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "magical",
+      "tw_match": "magical"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "Rome",
+      "tw_match": "Rome"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "19:25": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    }
+  ],
+  "19:26": [
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "19:27": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "goddess",
+      "tw_match": "goddess"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "worships",
+      "tw_match": "worship"
+    }
+  ],
+  "19:28": [
+    {
+      "surface": "Ephesians",
+      "tw_match": "Ephesian"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "19:30": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "19:31": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "19:32": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "19:33": [
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "19:34": [
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "hours",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Ephesians",
+      "tw_match": "Ephesian"
+    }
+  ],
+  "19:35": [
+    {
+      "surface": "Ephesians",
+      "tw_match": "Ephesian"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Ephesian",
+      "tw_match": "Ephesian"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    }
+  ],
+  "19:36": [],
+  "19:37": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "goddess",
+      "tw_match": "goddess"
+    }
+  ],
+  "19:38": [
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "proconsuls",
+      "tw_match": "proconsul"
+    }
+  ],
+  "19:39": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "19:40": [],
+  "19:41": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "exhorted",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "Greece",
+      "tw_match": "Greece"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Syria",
+      "tw_match": "Syria"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "Thessalonians",
+      "tw_match": "Thessalonian"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "Tychicus",
+      "tw_match": "Tychicus"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "Troas",
+      "tw_match": "Troas"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "Philippi",
+      "tw_match": "Philippi"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Troas",
+      "tw_match": "Troas"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "week",
+      "tw_match": "week"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "20:12": [],
+  "20:13": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "20:14": [],
+  "20:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Pentecost",
+      "tw_match": "Pentecost"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    },
+    {
+      "surface": "trials",
+      "tw_match": "trial"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "testifies",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "afflictions",
+      "tw_match": "affliction"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "overseers",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:29": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "20:30": [
+    {
+      "surface": "perverted",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "20:31": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "admonishing",
+      "tw_match": "admonish"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:32": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "20:33": [
+    {
+      "surface": "coveted",
+      "tw_match": "covet"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "20:34": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "20:35": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "20:36": [
+    {
+      "surface": "bowing",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    }
+  ],
+  "20:37": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "kissing",
+      "tw_match": "kiss"
+    }
+  ],
+  "20:38": [],
+  "21:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Phoenicia",
+      "tw_match": "Phoenicia"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "Cyprus",
+      "tw_match": "Cyprus"
+    },
+    {
+      "surface": "Syria",
+      "tw_match": "Syria"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    }
+  ],
+  "21:6": [],
+  "21:7": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Evangelist",
+      "tw_match": "evangelist"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "circumcise",
+      "tw_match": "circumcise"
+    },
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    }
+  ],
+  "21:22": [],
+  "21:23": [
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "Israelites",
+      "tw_match": "Israelites"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "21:29": [
+    {
+      "surface": "Ephesian",
+      "tw_match": "Ephesian"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "21:30": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "21:31": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "21:32": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "centurions",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "21:33": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "21:34": [
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    }
+  ],
+  "21:35": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    }
+  ],
+  "21:36": [],
+  "21:37": [
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    }
+  ],
+  "21:38": [
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "21:39": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Jewish",
+      "tw_match": "Jewish"
+    },
+    {
+      "surface": "Cilicia",
+      "tw_match": "Cilicia"
+    },
+    {
+      "surface": "citizen",
+      "tw_match": "citizen"
+    }
+  ],
+  "21:40": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    }
+  ],
+  "22:1": [],
+  "22:2": [
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "Jewish",
+      "tw_match": "Jewish"
+    },
+    {
+      "surface": "Tarsus",
+      "tw_match": "Tarsus"
+    },
+    {
+      "surface": "Cilicia",
+      "tw_match": "Cilicia"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "delivering",
+      "tw_match": "deliver"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "testifies",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    },
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    }
+  ],
+  "22:9": [],
+  "22:10": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "Stephen",
+      "tw_match": "Stephen"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "22:23": [],
+  "22:24": [
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "Roman",
+      "tw_match": "Roman"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Roman",
+      "tw_match": "Roman"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Roman",
+      "tw_match": "Roman"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "citizenship",
+      "tw_match": "citizenship"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Roman",
+      "tw_match": "Roman"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "insulting",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Rome",
+      "tw_match": "Rome"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "23:13": [],
+  "23:14": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "centurions",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "centurions",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "spearmen",
+      "tw_match": "spearmen"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    }
+  ],
+  "23:25": [],
+  "23:26": [
+    {
+      "surface": "Governor",
+      "tw_match": "governor"
+    }
+  ],
+  "23:27": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "Roman",
+      "tw_match": "Roman"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "23:30": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "23:31": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "23:32": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    }
+  ],
+  "23:33": [
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    },
+    {
+      "surface": "delivering",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "23:34": [
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Cilicia",
+      "tw_match": "Cilicia"
+    }
+  ],
+  "23:35": [
+    {
+      "surface": "guarded",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "24:4": [],
+  "24:5": [
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Nazarenes",
+      "tw_match": "Nazarene"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "desecrate",
+      "tw_match": "desecrate"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "24:7": [],
+  "24:8": [
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "arguing",
+      "tw_match": "arguing"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    }
+  ],
+  "24:13": [],
+  "24:14": [
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    }
+  ],
+  "24:24": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "24:25": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "self-control",
+      "tw_match": "self-control"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "24:26": [
+    {
+      "surface": "hoping",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "24:27": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "council",
+      "tw_match": "council"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Caesarea",
+      "tw_match": "Caesarea"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "Romans",
+      "tw_match": "Roman"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "evils",
+      "tw_match": "evil"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "disputes",
+      "tw_match": "disputes"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "25:20": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "25:21": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    }
+  ],
+  "25:22": [],
+  "25:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "25:24": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "25:25": [],
+  "25:26": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "25:27": [],
+  "26:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "punishing",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "blaspheme",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    },
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "26:18": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "26:20": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    }
+  ],
+  "26:21": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "26:22": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "26:23": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "26:24": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "26:25": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "26:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "26:27": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "26:28": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Christian",
+      "tw_match": "Christian"
+    }
+  ],
+  "26:29": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "26:30": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    }
+  ],
+  "26:31": [],
+  "26:32": [
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "delivering",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "Thessalonian",
+      "tw_match": "Thessalonian"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "Cyprus",
+      "tw_match": "Cyprus"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Cilicia",
+      "tw_match": "Cilicia"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "Crete",
+      "tw_match": "Crete"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "27:10": [],
+  "27:11": [
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Crete",
+      "tw_match": "Crete"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "Crete",
+      "tw_match": "Crete"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "27:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "27:19": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "27:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "27:21": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Crete",
+      "tw_match": "Crete"
+    }
+  ],
+  "27:22": [
+    {
+      "surface": "courage",
+      "tw_match": "courage"
+    }
+  ],
+  "27:23": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "27:24": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "27:25": [
+    {
+      "surface": "courage",
+      "tw_match": "courage"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "27:26": [],
+  "27:27": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "27:28": [],
+  "27:29": [
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "27:30": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "27:31": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "27:32": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    }
+  ],
+  "27:33": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    }
+  ],
+  "27:34": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "27:35": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "27:36": [
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    }
+  ],
+  "27:37": [
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "27:38": [
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "27:39": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "27:40": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "27:41": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "27:42": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "27:43": [
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "27:44": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "viper",
+      "tw_match": "viper"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "hanging",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Justice",
+      "tw_match": "justice"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "watched",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "welcoming",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    }
+  ],
+  "28:9": [],
+  "28:10": [
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "honors",
+      "tw_match": "honor"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Rome",
+      "tw_match": "Rome"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "courage",
+      "tw_match": "courage"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "Rome",
+      "tw_match": "Rome"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "soldier",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Romans",
+      "tw_match": "Roman"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "release",
+      "tw_match": "release"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "28:20": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "28:21": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "28:22": [],
+  "28:23": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "28:24": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "28:25": [
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "28:26": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "28:27": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "28:28": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "28:29": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "28:30": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "welcoming",
+      "tw_match": "welcome"
+    }
+  ],
+  "28:31": [
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_AMO.json
+++ b/sources/keyword_data/keywords_AMO.json
@@ -1,0 +1,2953 @@
+{
+  "1:1": [
+    {
+      "surface": "Amos",
+      "tw_match": "Amos"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "threshed",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "gate bars",
+      "tw_match": "gate bars"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "Ashkelon",
+      "tw_match": "Ashkelon"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "raged",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "pledges",
+      "tw_match": "pledges"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "oaks",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Nazirites",
+      "tw_match": "Nazirite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Nazirites",
+      "tw_match": "Nazirite"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "3:3": [],
+  "3:4": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "overtakes",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "tithes",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "freewill",
+      "tw_match": "freewill"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "pleases",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "staggered",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "creates",
+      "tw_match": "create"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "quench",
+      "tw_match": "quench"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "bribes",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "prudent",
+      "tw_match": "prudent"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "mourners",
+      "tw_match": "mourner"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "festivals",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "assemblies",
+      "tw_match": "assembly"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "oils",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "feasts",
+      "tw_match": "feast"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "detest",
+      "tw_match": "detest"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "plow",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "Lebo Hamath",
+      "tw_match": "Lebo Hamath"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Amos",
+      "tw_match": "Amos"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "sanctuaries",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Amos",
+      "tw_match": "Amos"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "Amos",
+      "tw_match": "Amos"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "Amos",
+      "tw_match": "Amos"
+    },
+    {
+      "surface": "Seer",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "Amos",
+      "tw_match": "Amos"
+    },
+    {
+      "surface": "Amaziah",
+      "tw_match": "Amaziah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Amos",
+      "tw_match": "Amos"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the Nile",
+      "tw_match": "the Nile"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "festivals",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "stagger",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Crete",
+      "tw_match": "Crete"
+    },
+    {
+      "surface": "Arameans",
+      "tw_match": "Aramean"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "shakes",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plowman",
+      "tw_match": "plowman"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_COL.json
+++ b/sources/keyword_data/keywords_COL.json
@@ -1,0 +1,1581 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Colossae",
+      "tw_match": "Colossae"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "word of truth",
+      "tw_match": "word of truth"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "dominions",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "authorities",
+      "tw_match": "authority"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "reconcile",
+      "tw_match": "reconcile"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "reconciled",
+      "tw_match": "reconciled"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "afflictions",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "stewardship",
+      "tw_match": "stewardship"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "admonishing",
+      "tw_match": "admonish"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Beware",
+      "tw_match": "beware"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "tradition",
+      "tw_match": "tradition"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "authorities",
+      "tw_match": "authority"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "delighting",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "prize",
+      "tw_match": "prize"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "principles",
+      "tw_match": "principle"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    }
+  ],
+  "2:21": [],
+  "2:22": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "teachings",
+      "tw_match": "teaching"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "passion",
+      "tw_match": "passions"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "idolatry",
+      "tw_match": "idolatry"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:7": [],
+  "3:8": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "slander",
+      "tw_match": "slander"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "freeman",
+      "tw_match": "freeman"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "bond",
+      "tw_match": "bond"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "admonishing",
+      "tw_match": "admonish"
+    },
+    {
+      "surface": "psalms",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "Fathers",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "Slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "favoritism",
+      "tw_match": "favoritism"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "4:4": [],
+  "4:5": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "redeeming",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Tychicus",
+      "tw_match": "Tychicus"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "Luke",
+      "tw_match": "Luke"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_DAN.json
+++ b/sources/keyword_data/keywords_DAN.json
@@ -1,0 +1,7864 @@
+{
+  "1:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "besieged",
+      "tw_match": "besieged"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Shinar",
+      "tw_match": "Shinar"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "nobility",
+      "tw_match": "nobility"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "Mishael",
+      "tw_match": "Mishael"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "Mishael",
+      "tw_match": "Mishael"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "steward",
+      "tw_match": "steward"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "Mishael",
+      "tw_match": "Mishael"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "steward",
+      "tw_match": "steward"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "Mishael",
+      "tw_match": "Mishael"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "sorcerers",
+      "tw_match": "sorcerer"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aramaic",
+      "tw_match": "Aramaic"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "corrupt",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "magician",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "Chaldean",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "prudence",
+      "tw_match": "prudence"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "Mishael",
+      "tw_match": "Mishael"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "astrologers",
+      "tw_match": "astrologers"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "mysteries",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "latter days",
+      "tw_match": "latter days"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "mysteries",
+      "tw_match": "mystery"
+    }
+  ],
+  "2:30": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "2:31": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "statue",
+      "tw_match": "statue"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    }
+  ],
+  "2:32": [
+    {
+      "surface": "statue",
+      "tw_match": "statue"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "2:33": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "2:34": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "statue",
+      "tw_match": "statue"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "2:35": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "statue",
+      "tw_match": "statue"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:36": [
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:37": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "2:38": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "2:39": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:40": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "2:41": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "2:42": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "2:43": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "2:44": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "2:45": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    }
+  ],
+  "2:46": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "2:47": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "mysteries",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    }
+  ],
+  "2:48": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "honors",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "prefect",
+      "tw_match": "prefect"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    }
+  ],
+  "2:49": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "magistrates",
+      "tw_match": "magistrate"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "dedication",
+      "tw_match": "dedication"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "magistrates",
+      "tw_match": "magistrate"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "dedication",
+      "tw_match": "dedication"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "worshipped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "malicious",
+      "tw_match": "malicious"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "tied up",
+      "tw_match": "tied up"
+    },
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "3:29": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:30": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "prospering",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "alarmed",
+      "tw_match": "alarmed"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "astrologers",
+      "tw_match": "astrologers"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "for a while",
+      "tw_match": "for a while"
+    },
+    {
+      "surface": "alarmed",
+      "tw_match": "alarmed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "alarm",
+      "tw_match": "alarm"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "4:33": [
+    {
+      "surface": "Immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "eagles",
+      "tw_match": "eagle"
+    }
+  ],
+  "4:34": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "4:35": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "4:36": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "noblemen",
+      "tw_match": "noblemen"
+    }
+  ],
+  "4:37": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "noblemen",
+      "tw_match": "noblemen"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "noblemen",
+      "tw_match": "noblemen"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "noblemen",
+      "tw_match": "noblemen"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "astrologers",
+      "tw_match": "astrologers"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "alarmed",
+      "tw_match": "alarmed"
+    },
+    {
+      "surface": "noblemen",
+      "tw_match": "noblemen"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "noblemen",
+      "tw_match": "noblemen"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "alarm",
+      "tw_match": "alarm"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "astrologers",
+      "tw_match": "astrologers"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "interpreting",
+      "tw_match": "interpret"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "interpretations",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "rewards",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "5:25": [],
+  "5:26": [
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "5:27": [],
+  "5:28": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Medes",
+      "tw_match": "Medes"
+    },
+    {
+      "surface": "Persians",
+      "tw_match": "Persians"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "proclamation",
+      "tw_match": "proclamation"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "Chaldean",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "5:31": [
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "Mede",
+      "tw_match": "Mede"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "distinguished",
+      "tw_match": "distinguish"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "corruption",
+      "tw_match": "corruption"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Medes",
+      "tw_match": "Medes"
+    },
+    {
+      "surface": "Persians",
+      "tw_match": "Persians"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "signed",
+      "tw_match": "sign"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "signed",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "kneeling",
+      "tw_match": "kneel"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "imploring",
+      "tw_match": "implore"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Medes",
+      "tw_match": "Medes"
+    },
+    {
+      "surface": "Persians",
+      "tw_match": "Persians"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "signed",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Medes",
+      "tw_match": "Medes"
+    },
+    {
+      "surface": "Persians",
+      "tw_match": "Persians"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "delivers",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "6:28": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "prospered",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "leopard",
+      "tw_match": "leopard"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "Days",
+      "tw_match": "day"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "alarming",
+      "tw_match": "alarm"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "Days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "dominions",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "alarming",
+      "tw_match": "alarm"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "Land",
+      "tw_match": "land"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "host of heaven",
+      "tw_match": "host of heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "Gabriel",
+      "tw_match": "Gabriel"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "Understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "8:18": [],
+  "8:19": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Media",
+      "tw_match": "Media"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Greece",
+      "tw_match": "Greece"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "understands",
+      "tw_match": "understand"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "cunning",
+      "tw_match": "cunning"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "descendant",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "Medes",
+      "tw_match": "Medes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "desolations",
+      "tw_match": "desolations"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "confession",
+      "tw_match": "confession"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "awesome",
+      "tw_match": "awesome"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "ruled",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "desolations",
+      "tw_match": "desolations"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "confessing",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "Gabriel",
+      "tw_match": "Gabriel"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    },
+    {
+      "surface": "holy city",
+      "tw_match": "holy city"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "atone",
+      "tw_match": "atone"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "Desolations",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    },
+    {
+      "surface": "desolator",
+      "tw_match": "desolator"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "conflict",
+      "tw_match": "conflict"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "weeks",
+      "tw_match": "week"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "weeks",
+      "tw_match": "week"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "waist",
+      "tw_match": "waist"
+    },
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "10:9": [],
+  "10:10": [
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "latter days",
+      "tw_match": "latter days"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "10:15": [],
+  "10:16": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "10:18": [],
+  "10:19": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "Greece",
+      "tw_match": "Greece"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "Mede",
+      "tw_match": "Mede"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "stir up",
+      "tw_match": "stir up"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Greece",
+      "tw_match": "Greece"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "ruled",
+      "tw_match": "rule"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "cast metal images",
+      "tw_match": "cast metal images"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:12": [],
+  "11:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "fortifications",
+      "tw_match": "fortifications"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "Land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "tax collector",
+      "tw_match": "tax collector"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "11:23": [],
+  "11:24": [
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "stir up",
+      "tw_match": "stir up"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "corrupt",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:33": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:34": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "hypocrisy",
+      "tw_match": "hypocrisy"
+    }
+  ],
+  "11:35": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "11:36": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    }
+  ],
+  "11:37": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "11:38": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "11:39": [
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:40": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "11:41": [
+    {
+      "surface": "Land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:42": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "11:43": [
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "11:44": [
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "11:45": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "patient",
+      "tw_match": "patient"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_DEU.json
+++ b/sources/keyword_data/keywords_DEU.json
@@ -1,0 +1,17723 @@
+{
+  "1:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "Paran",
+      "tw_match": "Paran"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    },
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "disputes",
+      "tw_match": "disputes"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "alike",
+      "tw_match": "alike"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "1:24": [],
+  "1:25": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Anakites",
+      "tw_match": "Anakites"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "1:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "1:31": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "carries",
+      "tw_match": "carry"
+    }
+  ],
+  "1:32": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:33": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:34": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:35": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:36": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:37": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:38": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    }
+  ],
+  "1:39": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "1:40": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    }
+  ],
+  "1:41": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    }
+  ],
+  "1:42": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "1:43": [
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    }
+  ],
+  "1:44": [
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    }
+  ],
+  "1:45": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:46": [
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:3": [],
+  "2:4": [
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Anakites",
+      "tw_match": "Anakites"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Raphaites",
+      "tw_match": "Raphaites"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Anakites",
+      "tw_match": "Anakites"
+    },
+    {
+      "surface": "Moabites",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "2:16": [],
+  "2:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Raphaites",
+      "tw_match": "Raphaites"
+    },
+    {
+      "surface": "Ammonites",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "Anakites",
+      "tw_match": "Anakites"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "Moabites",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:30": [
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:31": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "2:32": [
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    }
+  ],
+  "2:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:34": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    }
+  ],
+  "2:35": [
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "2:36": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:37": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Mount Hermon",
+      "tw_match": "Mount Hermon"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Raphaites",
+      "tw_match": "Raphaites"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Raphaites",
+      "tw_match": "Raphaites"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Geshurites",
+      "tw_match": "Geshurites"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Salt Sea",
+      "tw_match": "Salt Sea"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "instruct",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "3:29": [
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Baal Peor",
+      "tw_match": "Baal Peor"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    },
+    {
+      "surface": "Assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "beget",
+      "tw_match": "beget"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "4:33": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:34": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "trials",
+      "tw_match": "trial"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "4:35": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:36": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "instruct",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:37": [
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "4:38": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:39": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:40": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:41": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "4:42": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "4:43": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "4:44": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:45": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "4:46": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "4:47": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "4:48": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "4:49": [
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "carved figure",
+      "tw_match": "carved figure"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "unpunished",
+      "tw_match": "unpunished"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sanctify",
+      "tw_match": "sanctify"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "Honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "5:19": [],
+  "5:20": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "false testimony",
+      "tw_match": "false testimony"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "covet",
+      "tw_match": "covet"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "5:31": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "5:32": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "5:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "6:6": [],
+  "6:7": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "cisterns",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "Keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Girgashites",
+      "tw_match": "Girgashites"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Perizzites",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "marriages",
+      "tw_match": "marriage"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenants",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "regulations",
+      "tw_match": "regulations"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "trials",
+      "tw_match": "trial"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "covet",
+      "tw_match": "covet"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "trapped",
+      "tw_match": "trapped"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Detesting",
+      "tw_match": "detest"
+    },
+    {
+      "surface": "detest",
+      "tw_match": "detest"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "instructs",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "fountains",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "multiplies",
+      "tw_match": "multiply"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Anakites",
+      "tw_match": "Anakites"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Anak",
+      "tw_match": "Anak"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    },
+    {
+      "surface": "figure",
+      "tw_match": "figure"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "blot out",
+      "tw_match": "blot out"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "interceded",
+      "tw_match": "intercede"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "provoking",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "acacia",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "circumcise",
+      "tw_match": "circumcise"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "Euphrates River",
+      "tw_match": "Euphrates River"
+    },
+    {
+      "surface": "the western sea",
+      "tw_match": "the western sea"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "oaks",
+      "tw_match": "oak"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "tithes",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "freewill",
+      "tw_match": "freewill"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "households",
+      "tw_match": "household"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "tithes",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "deer",
+      "tw_match": "deer"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "freewill",
+      "tw_match": "freewill"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "chooses",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "deer",
+      "tw_match": "deer"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "alike",
+      "tw_match": "alike"
+    }
+  ],
+  "12:23": [],
+  "12:24": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "12:27": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "12:30": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "trapped",
+      "tw_match": "trapped"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "12:31": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "12:32": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonder",
+      "tw_match": "wonder"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonder",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "13:8": [],
+  "13:9": [
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "abominable",
+      "tw_match": "abominable"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "deer",
+      "tw_match": "deer"
+    },
+    {
+      "surface": "roebuck",
+      "tw_match": "roebuck"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "pig",
+      "tw_match": "pig"
+    }
+  ],
+  "14:9": [],
+  "14:10": [],
+  "14:11": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    }
+  ],
+  "14:13": [],
+  "14:14": [],
+  "14:15": [],
+  "14:16": [],
+  "14:17": [],
+  "14:18": [],
+  "14:19": [],
+  "14:20": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "Tithing",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "blesses",
+      "tw_match": "bless"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "strong drink",
+      "tw_match": "strong drink"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "harden",
+      "tw_match": "harden"
+    }
+  ],
+  "15:8": [],
+  "15:9": [
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "serves",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "sanctify",
+      "tw_match": "sanctify"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "alike",
+      "tw_match": "alike"
+    },
+    {
+      "surface": "deer",
+      "tw_match": "deer"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "Keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "leavened",
+      "tw_match": "leaven"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "weeks",
+      "tw_match": "week"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "Festival of Weeks",
+      "tw_match": "Festival of Weeks"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Shelters",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Festival of Weeks",
+      "tw_match": "Festival of Weeks"
+    },
+    {
+      "surface": "Shelters",
+      "tw_match": "shelter"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "perverts",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "Righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "transgressing",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "alike",
+      "tw_match": "alike"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "soothsayer",
+      "tw_match": "soothsayer"
+    },
+    {
+      "surface": "diviner",
+      "tw_match": "diviner"
+    },
+    {
+      "surface": "sorcerer",
+      "tw_match": "sorcerer"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "soothsayers",
+      "tw_match": "soothsayer"
+    },
+    {
+      "surface": "diviners",
+      "tw_match": "diviner"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "18:19": [],
+  "18:20": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "murders",
+      "tw_match": "murder"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "ax",
+      "tw_match": "ax"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "19:7": [],
+  "19:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "bounds",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "false witness",
+      "tw_match": "false witness"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "false witness",
+      "tw_match": "false witness"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "19:21": [],
+  "20:1": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "panic",
+      "tw_match": "panic"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "dedicated",
+      "tw_match": "dedicate"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "dedicate",
+      "tw_match": "dedicate"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "breathing",
+      "tw_match": "breath"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "ax",
+      "tw_match": "ax"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "descend",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    }
+  ],
+  "21:7": [],
+  "21:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "mistreat",
+      "tw_match": "mistreat"
+    },
+    {
+      "surface": "humiliating",
+      "tw_match": "humiliate"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "regulation",
+      "tw_match": "regulations"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "drunkard",
+      "tw_match": "drunkard"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:6": [],
+  "22:7": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "plow",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "22:11": [],
+  "22:12": [],
+  "22:13": [],
+  "22:14": [
+    {
+      "surface": "virginity",
+      "tw_match": "virginity"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "virginity",
+      "tw_match": "virginity"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "virginity",
+      "tw_match": "virginity"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "silvers",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "virginity",
+      "tw_match": "virginity"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "fornication",
+      "tw_match": "fornication"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "murders",
+      "tw_match": "murder"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "silvers",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "22:30": [],
+  "23:1": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "Aram Naharaim",
+      "tw_match": "Aram Naharaim"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "detest",
+      "tw_match": "detest"
+    },
+    {
+      "surface": "Edomite",
+      "tw_match": "Edomite"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "23:11": [],
+  "23:12": [],
+  "23:13": [],
+  "23:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "chooses",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "23:19": [],
+  "23:20": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "vowing",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "marries",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "Restoring",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "Fathers",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "unjust",
+      "tw_match": "unjust"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "sandal",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "sandal",
+      "tw_match": "sandal"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    }
+  ],
+  "25:12": [],
+  "25:13": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "wipe out",
+      "tw_match": "wipe out"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Aramean",
+      "tw_match": "Aramean"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "hard work",
+      "tw_match": "hard work"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "tithing",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    }
+  ],
+  "26:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "carved image",
+      "tw_match": "carved image"
+    },
+    {
+      "surface": "figure",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "dishonors",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "27:18": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "27:19": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "27:20": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "27:21": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "27:22": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "27:23": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "27:24": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "27:25": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "27:26": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:10": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "28:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "rebukes",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    }
+  ],
+  "28:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "28:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "28:23": [
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "28:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "28:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "28:26": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "28:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "28:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:29": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "deliverer",
+      "tw_match": "deliverer"
+    }
+  ],
+  "28:30": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "28:31": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "deliverer",
+      "tw_match": "deliverer"
+    }
+  ],
+  "28:32": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "28:33": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "28:34": [],
+  "28:35": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "28:37": [
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:38": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "28:39": [
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "28:40": [
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "olives",
+      "tw_match": "olive"
+    }
+  ],
+  "28:41": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "28:42": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "28:43": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "descend",
+      "tw_match": "descend"
+    }
+  ],
+  "28:44": [],
+  "28:45": [
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "28:46": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "28:47": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:48": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    }
+  ],
+  "28:49": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "28:50": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "elder",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "28:51": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "28:52": [
+    {
+      "surface": "besiege",
+      "tw_match": "besiege"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:53": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "28:54": [
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "28:55": [
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "28:56": [
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "28:57": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "28:58": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "dreaded",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:59": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "afflictions",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    }
+  ],
+  "28:60": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "28:61": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "28:62": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:63": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "multiplying",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "28:64": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "28:65": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "28:66": [
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "28:67": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "28:68": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "29:7": [
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "29:12": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    }
+  ],
+  "29:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "29:14": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    }
+  ],
+  "29:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "29:16": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "29:17": [
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "29:18": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    }
+  ],
+  "29:19": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "29:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "blot out",
+      "tw_match": "blot out"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "29:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "29:22": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:23": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sulfur",
+      "tw_match": "sulfur"
+    },
+    {
+      "surface": "sows",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "29:24": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "29:25": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "29:26": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "29:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    }
+  ],
+  "29:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "29:29": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "30:1": [
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "30:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    }
+  ],
+  "30:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "circumcise",
+      "tw_match": "circumcise"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "30:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "30:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    }
+  ],
+  "30:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "30:11": [],
+  "30:12": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "30:13": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "30:14": [],
+  "30:15": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "30:16": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "30:17": [
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "30:18": [
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "30:19": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "30:20": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "31:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "31:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:6": [
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "31:7": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    }
+  ],
+  "31:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:10": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Shelters",
+      "tw_match": "shelter"
+    }
+  ],
+  "31:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "31:12": [
+    {
+      "surface": "Assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "31:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "31:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "31:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "31:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "31:17": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "31:19": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "31:20": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "31:21": [
+    {
+      "surface": "evils",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    }
+  ],
+  "31:22": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:23": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "31:24": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "31:25": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:26": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "31:27": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:28": [
+    {
+      "surface": "Assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "31:29": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "corrupt",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "provoking",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "31:30": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "32:1": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "32:2": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "32:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:4": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "32:5": [
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "32:6": [
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "32:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "32:8": [
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "32:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "32:10": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "watched",
+      "tw_match": "watch"
+    }
+  ],
+  "32:11": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    }
+  ],
+  "32:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "32:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "32:14": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "32:15": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "32:16": [
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "32:17": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "32:18": [
+    {
+      "surface": "bearer",
+      "tw_match": "bearer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "provocation",
+      "tw_match": "provocation"
+    }
+  ],
+  "32:20": [
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "32:21": [
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "32:22": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    }
+  ],
+  "32:23": [],
+  "32:24": [
+    {
+      "surface": "wasted",
+      "tw_match": "wasted"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "32:25": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    }
+  ],
+  "32:26": [],
+  "32:27": [
+    {
+      "surface": "provocation",
+      "tw_match": "provocation"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "32:28": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "32:29": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "latter days",
+      "tw_match": "latter days"
+    }
+  ],
+  "32:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "32:31": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "32:32": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "32:33": [
+    {
+      "surface": "serpents",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "vipers",
+      "tw_match": "viper"
+    }
+  ],
+  "32:34": [
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    }
+  ],
+  "32:35": [
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "32:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "32:37": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "32:38": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "32:39": [
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "32:40": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "32:41": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "32:42": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "32:43": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "32:44": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "32:45": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "32:46": [
+    {
+      "surface": "bore witness",
+      "tw_match": "bore witness"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "32:47": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "32:48": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "32:49": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "32:50": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "32:51": [
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "32:52": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "33:1": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "33:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "Paran",
+      "tw_match": "Paran"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "33:3": [
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "tied",
+      "tw_match": "tied"
+    }
+  ],
+  "33:4": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "33:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "33:6": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "33:7": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "33:8": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    }
+  ],
+  "33:9": [
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "guarded",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "33:10": [
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "33:11": [
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "33:12": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "33:13": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "33:14": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "33:15": [
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "33:16": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    }
+  ],
+  "33:17": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "33:18": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "33:19": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "33:20": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lioness",
+      "tw_match": "lioness"
+    }
+  ],
+  "33:21": [
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "carried out",
+      "tw_match": "carried out"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "33:22": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "33:23": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "33:24": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "favored",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "33:25": [
+    {
+      "surface": "Iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "33:26": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "33:27": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "33:28": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "33:29": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "fawn",
+      "tw_match": "fawn"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    }
+  ],
+  "34:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "34:2": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "the western sea",
+      "tw_match": "the western sea"
+    }
+  ],
+  "34:3": [
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Zoar",
+      "tw_match": "Zoar"
+    }
+  ],
+  "34:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "34:5": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "34:6": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "34:7": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    }
+  ],
+  "34:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "34:9": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "34:10": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "34:11": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "34:12": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_ECC.json
+++ b/sources/keyword_data/keywords_ECC.json
@@ -1,0 +1,3069 @@
+{
+  "1:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:2": [],
+  "1:3": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:5": [],
+  "1:6": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "1:9": [],
+  "1:10": [
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "1:11": [],
+  "1:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "unpleasant",
+      "tw_match": "unpleasant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "1:15": [],
+  "1:16": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "2:6": [],
+  "2:7": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "2:20": [],
+  "2:21": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:25": [],
+  "2:26": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "3:20": [],
+  "3:21": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "4:1": [],
+  "4:2": [
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "4:7": [],
+  "4:8": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "unpleasant",
+      "tw_match": "unpleasant"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "4:15": [],
+  "4:16": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "robbery",
+      "tw_match": "robbery"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "joys",
+      "tw_match": "joy"
+    }
+  ],
+  "6:1": [],
+  "6:2": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "burial place",
+      "tw_match": "burial place"
+    },
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    }
+  ],
+  "6:4": [],
+  "6:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "6:11": [],
+  "6:12": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "Wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "Wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "7:24": [],
+  "7:25": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "snares",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "7:27": [],
+  "7:28": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "pleases",
+      "tw_match": "please"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "snared",
+      "tw_match": "snare"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "besieged",
+      "tw_match": "besieged"
+    },
+    {
+      "surface": "siegeworks",
+      "tw_match": "siegeworks"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "11:10": [],
+  "12:1": [
+    {
+      "surface": "Creator",
+      "tw_match": "creator"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "12:2": [],
+  "12:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "mourners",
+      "tw_match": "mourner"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:8": [],
+  "12:9": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "proverbs",
+      "tw_match": "proverb"
+    }
+  ],
+  "12:10": [],
+  "12:11": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "scrolls",
+      "tw_match": "scroll"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "Fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_EPH.json
+++ b/sources/keyword_data/keywords_EPH.json
@@ -1,0 +1,2434 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "predestined",
+      "tw_match": "predestined"
+    },
+    {
+      "surface": "adoption",
+      "tw_match": "adoption"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "predestined",
+      "tw_match": "predestined"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "word of truth",
+      "tw_match": "word of truth"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "1:23": [],
+  "2:1": [
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "authorities",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "fulfilling",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "community",
+      "tw_match": "community"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "covenants",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "regulations",
+      "tw_match": "regulations"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "reconcile",
+      "tw_match": "reconcile"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "citizens",
+      "tw_match": "citizen"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "cornerstone",
+      "tw_match": "cornerstone"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "stewardship",
+      "tw_match": "stewardship"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "heirs",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "authorities",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "bond",
+      "tw_match": "bond"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "evangelists",
+      "tw_match": "evangelist"
+    },
+    {
+      "surface": "pastors",
+      "tw_match": "pastor"
+    },
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "hardness",
+      "tw_match": "hardness"
+    }
+  ],
+  "4:19": [],
+  "4:20": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "in Jesus",
+      "tw_match": "in Jesus"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "corrupt",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "quarreling",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "forgiving",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "idolater",
+      "tw_match": "idolater"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:7": [],
+  "5:8": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "unfruitful",
+      "tw_match": "unfruitful"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "5:12": [],
+  "5:13": [],
+  "5:14": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "redeeming",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "psalms",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "submitting",
+      "tw_match": "submitting"
+    },
+    {
+      "surface": "reverence",
+      "tw_match": "reverence"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "savior",
+      "tw_match": "savior"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "subject",
+      "tw_match": "subject"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "sanctify",
+      "tw_match": "sanctify"
+    },
+    {
+      "surface": "washing",
+      "tw_match": "wash"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "members",
+      "tw_match": "member"
+    }
+  ],
+  "5:31": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "5:32": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "5:33": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "Slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "favoritism",
+      "tw_match": "favoritism"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "authorities",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "breastplate",
+      "tw_match": "breastplate"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "perseverance",
+      "tw_match": "perseverance"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "6:20": [],
+  "6:21": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Tychicus",
+      "tw_match": "Tychicus"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "incorruptibility",
+      "tw_match": "incorruptibility"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_EST.json
+++ b/sources/keyword_data/keywords_EST.json
@@ -1,0 +1,4045 @@
+{
+  "1:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "ruled",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Ethiopia",
+      "tw_match": "Ethiopia"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "royalty",
+      "tw_match": "royalty"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "Media",
+      "tw_match": "Media"
+    },
+    {
+      "surface": "noblemen",
+      "tw_match": "noblemen"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "hanging",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "royalty",
+      "tw_match": "royalty"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Vashti",
+      "tw_match": "Vashti"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "royalty",
+      "tw_match": "royalty"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Vashti",
+      "tw_match": "Vashti"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "royalty",
+      "tw_match": "royalty"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Vashti",
+      "tw_match": "Vashti"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "Media",
+      "tw_match": "Media"
+    },
+    {
+      "surface": "seers",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Vashti",
+      "tw_match": "Vashti"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Vashti",
+      "tw_match": "Vashti"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "Vashti",
+      "tw_match": "Vashti"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "Media",
+      "tw_match": "Media"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "royalty",
+      "tw_match": "royalty"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "Media",
+      "tw_match": "Media"
+    },
+    {
+      "surface": "Vashti",
+      "tw_match": "Vashti"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "Vashti",
+      "tw_match": "Vashti"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Vashti",
+      "tw_match": "Vashti"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "delighted",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "royalty",
+      "tw_match": "royalty"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "royalty",
+      "tw_match": "royalty"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Vashti",
+      "tw_match": "Vashti"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "doorway",
+      "tw_match": "doorway"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "bowing",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prostrating",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "prostrate",
+      "tw_match": "prostrate"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "trespassing",
+      "tw_match": "trespass"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "prostrate",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "annihilate",
+      "tw_match": "annihilate"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "dispersed",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "annihilate",
+      "tw_match": "annihilate"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "spoils",
+      "tw_match": "spoils"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "outcry",
+      "tw_match": "outcry"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "lamenting",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "annihilate",
+      "tw_match": "annihilate"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "implore",
+      "tw_match": "implore"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "deliverance",
+      "tw_match": "deliverance"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "royalty",
+      "tw_match": "royalty"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "royalty",
+      "tw_match": "royalty"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "doorway",
+      "tw_match": "doorway"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "delighted",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "royalty",
+      "tw_match": "royalty"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Hang",
+      "tw_match": "hang"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "implored",
+      "tw_match": "implore"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "kindred",
+      "tw_match": "kindred"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Ethiopia",
+      "tw_match": "Ethiopia"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "mares",
+      "tw_match": "mare"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "annihilate",
+      "tw_match": "annihilate"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "revenge",
+      "tw_match": "revenge"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "royalty",
+      "tw_match": "royalty"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "9:7": [],
+  "9:8": [],
+  "9:9": [],
+  "9:10": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "feasting",
+      "tw_match": "feasting"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "feasting",
+      "tw_match": "feasting"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "feasting",
+      "tw_match": "feasting"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "feasting",
+      "tw_match": "feasting"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "annihilate",
+      "tw_match": "annihilate"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "fasts",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "outcry",
+      "tw_match": "outcry"
+    }
+  ],
+  "9:32": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "Esther",
+      "tw_match": "Esther"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Media",
+      "tw_match": "Media"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "favored",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_EXO.json
+++ b/sources/keyword_data/keywords_EXO.json
@@ -1,0 +1,19617 @@
+{
+  "1:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "multiplies",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "overseers",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "reeds",
+      "tw_match": "reed"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "reeds",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "shepherding",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Reuel",
+      "tw_match": "Reuel"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "shepherding",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "shepherding",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Jethro",
+      "tw_match": "Jethro"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Perizzites",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Perizzites",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:12": [],
+  "4:13": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "4:15": [],
+  "4:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Jethro",
+      "tw_match": "Jethro"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "dispersed",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "Work",
+      "tw_match": "work"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Shaddai",
+      "tw_match": "shaddai"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "sojourned",
+      "tw_match": "sojourn"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "enslaving",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "Mishael",
+      "tw_match": "Mishael"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Korahites",
+      "tw_match": "Korahite"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "6:28": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "harden",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Create",
+      "tw_match": "create"
+    },
+    {
+      "surface": "miracle",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "sorcerers",
+      "tw_match": "sorcerer"
+    },
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "magic",
+      "tw_match": "magic"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "serpents",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "staffs",
+      "tw_match": "staff"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "magic",
+      "tw_match": "magic"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "8:2": [],
+  "8:3": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "magic",
+      "tw_match": "magic"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "magic",
+      "tw_match": "magic"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distinguish",
+      "tw_match": "distinguish"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "9:2": [],
+  "9:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "distinguish",
+      "tw_match": "distinguish"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "exalting",
+      "tw_match": "exalt"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "9:32": [
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "9:33": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:34": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "9:35": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "distinguishes",
+      "tw_match": "distinguish"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "12:9": [],
+  "12:10": [],
+  "12:11": [
+    {
+      "surface": "belts",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "waist",
+      "tw_match": "waist"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "leavened",
+      "tw_match": "leaven"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "yeasted",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "12:26": [],
+  "12:27": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "households",
+      "tw_match": "household"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "12:30": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "12:31": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:32": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "12:33": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "12:34": [
+    {
+      "surface": "leaven",
+      "tw_match": "leaven"
+    }
+  ],
+  "12:35": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "12:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    }
+  ],
+  "12:37": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    }
+  ],
+  "12:38": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "12:39": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "leavened",
+      "tw_match": "leaven"
+    }
+  ],
+  "12:40": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "12:41": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "12:42": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "12:43": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "12:44": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "12:45": [],
+  "12:46": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "12:47": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:48": [
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "12:49": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    }
+  ],
+  "12:50": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "12:51": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leavened",
+      "tw_match": "leaven"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "14:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "14:31": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "Yah",
+      "tw_match": "Yah"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Philistia",
+      "tw_match": "Philistia"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "Terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    },
+    {
+      "surface": "prophetess",
+      "tw_match": "prophetess"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "Wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:13": [],
+  "16:14": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "community",
+      "tw_match": "community"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    }
+  ],
+  "16:29": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "16:30": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:31": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "16:32": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "16:33": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "16:34": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "16:35": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "16:36": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "community",
+      "tw_match": "community"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "quarreled",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "quarreling",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "conflict",
+      "tw_match": "conflict"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "blot out",
+      "tw_match": "blot out"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Yah",
+      "tw_match": "Yah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "Jethro",
+      "tw_match": "Jethro"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "Jethro",
+      "tw_match": "Jethro"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "Jethro",
+      "tw_match": "Jethro"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Jethro",
+      "tw_match": "Jethro"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "Jethro",
+      "tw_match": "Jethro"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "Jethro",
+      "tw_match": "Jethro"
+    },
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "Jethro",
+      "tw_match": "Jethro"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "18:18": [],
+  "18:19": [
+    {
+      "surface": "advise",
+      "tw_match": "advise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "disputes",
+      "tw_match": "disputes"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "dishonest",
+      "tw_match": "dishonest"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "instructs",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "eagles",
+      "tw_match": "eagle"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "19:25": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "carved figure",
+      "tw_match": "carved figure"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "unpunished",
+      "tw_match": "unpunished"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "Honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "20:15": [],
+  "20:16": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "false testimony",
+      "tw_match": "false testimony"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "covet",
+      "tw_match": "covet"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "doorpost",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "ransomed",
+      "tw_match": "ransomed"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "appoints",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "rights",
+      "tw_match": "right"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "21:12": [],
+  "21:13": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "cunning",
+      "tw_match": "cunning"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "21:15": [],
+  "21:16": [],
+  "21:17": [],
+  "21:18": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "avenged",
+      "tw_match": "avenge"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "avenged",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "21:23": [],
+  "21:24": [],
+  "21:25": [],
+  "21:26": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "21:29": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    }
+  ],
+  "21:30": [
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    }
+  ],
+  "21:31": [
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    }
+  ],
+  "21:32": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    }
+  ],
+  "21:33": [
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "21:34": [
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "21:35": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "21:36": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "slaughters",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    }
+  ],
+  "22:3": [],
+  "22:4": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "evidence",
+      "tw_match": "evidence"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "22:15": [],
+  "22:16": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "sorceress",
+      "tw_match": "sorceress"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "22:31": [
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "legal",
+      "tw_match": "legal"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "deception",
+      "tw_match": "deception"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "justify",
+      "tw_match": "justify"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "perverts",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "reminder",
+      "tw_match": "reminder"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "take heed",
+      "tw_match": "take heed"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "labors",
+      "tw_match": "labors"
+    },
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "Gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "leavened",
+      "tw_match": "leaven"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "guarded",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Perizzites",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "annihilate",
+      "tw_match": "annihilate"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "23:26": [
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "23:27": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "23:30": [
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:31": [
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:32": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "23:33": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "the twelve",
+      "tw_match": "the twelve"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "contributions",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "25:9": [],
+  "25:10": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    }
+  ],
+  "25:20": [
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    }
+  ],
+  "25:21": [
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "25:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    }
+  ],
+  "25:23": [
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "25:24": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:25": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:26": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:27": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "25:28": [
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:29": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:30": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "25:31": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "25:32": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "25:33": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "25:34": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "25:35": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "25:36": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:37": [
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    }
+  ],
+  "25:38": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:39": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "25:40": [],
+  "26:1": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "26:16": [],
+  "26:17": [],
+  "26:18": [],
+  "26:19": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "26:20": [],
+  "26:21": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "26:22": [],
+  "26:23": [],
+  "26:24": [],
+  "26:25": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "26:26": [
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "26:27": [],
+  "26:28": [],
+  "26:29": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "26:30": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "26:31": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "26:32": [
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "acacia",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "26:33": [
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Holies",
+      "tw_match": "holy"
+    }
+  ],
+  "26:34": [
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Holies",
+      "tw_match": "holy"
+    }
+  ],
+  "26:35": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "26:36": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "26:37": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "acacia",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "27:18": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "27:19": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "27:20": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    }
+  ],
+  "27:21": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "28:7": [],
+  "28:8": [
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "28:10": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "reminder",
+      "tw_match": "reminder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "28:16": [],
+  "28:17": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "28:18": [],
+  "28:19": [],
+  "28:20": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "28:21": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "28:22": [
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "28:23": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    }
+  ],
+  "28:24": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    }
+  ],
+  "28:25": [
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "28:26": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "28:27": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "28:28": [
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "28:29": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "reminder",
+      "tw_match": "reminder"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:30": [
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "28:31": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "28:32": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "28:33": [
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "28:34": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "pomegranate",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "28:35": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    }
+  ],
+  "28:36": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:37": [],
+  "28:38": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "acceptance",
+      "tw_match": "acceptance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:39": [
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "28:40": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "28:41": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "28:42": [
+    {
+      "surface": "waist",
+      "tw_match": "waist"
+    }
+  ],
+  "28:43": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "29:7": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "29:12": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "29:13": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "29:14": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    },
+    {
+      "surface": "purification offering",
+      "tw_match": "purification offering"
+    }
+  ],
+  "29:15": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "29:16": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "29:17": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "29:18": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "29:19": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "29:20": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "29:21": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "29:22": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "consecration",
+      "tw_match": "consecration"
+    }
+  ],
+  "29:23": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:24": [
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:25": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "29:26": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "consecration",
+      "tw_match": "consecration"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:27": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "consecration",
+      "tw_match": "consecration"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    }
+  ],
+  "29:28": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "requirement",
+      "tw_match": "requirements"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:29": [
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    }
+  ],
+  "29:30": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "29:31": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "consecration",
+      "tw_match": "consecration"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "29:32": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "29:33": [
+    {
+      "surface": "atoning",
+      "tw_match": "atone"
+    }
+  ],
+  "29:34": [
+    {
+      "surface": "consecration",
+      "tw_match": "consecration"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "29:35": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "29:36": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    }
+  ],
+  "29:37": [
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "29:38": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "29:39": [
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "29:40": [
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "29:41": [
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:42": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:43": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "29:44": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "29:45": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "29:46": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "30:1": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "30:2": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "30:6": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "Testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "30:7": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "30:8": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "Incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "30:9": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "30:10": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "30:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "30:13": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:14": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:15": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:16": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "ransoms",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "reminder",
+      "tw_match": "reminder"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "30:18": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "washing",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "30:19": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "30:20": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:21": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "30:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "30:23": [
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    }
+  ],
+  "30:24": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    }
+  ],
+  "30:25": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "30:26": [
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    }
+  ],
+  "30:27": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "altar of incense",
+      "tw_match": "altar of incense"
+    }
+  ],
+  "30:28": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "30:29": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "30:30": [
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "30:31": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "30:32": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "30:33": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "30:34": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    }
+  ],
+  "30:35": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "30:36": [
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "30:37": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:38": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "31:4": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "31:5": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "31:6": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "31:7": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "31:8": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "altar of incense",
+      "tw_match": "altar of incense"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "31:10": [
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "31:11": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "31:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "31:13": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "31:14": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "31:15": [
+    {
+      "surface": "Work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "31:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "31:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "31:18": [
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "32:2": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "32:3": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "32:4": [
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "32:5": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "32:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "32:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Descend",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    }
+  ],
+  "32:8": [
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "32:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    }
+  ],
+  "32:10": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "32:11": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "32:12": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    }
+  ],
+  "32:13": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "32:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "32:15": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "32:16": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:17": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "32:18": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "32:19": [
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "32:20": [
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "32:21": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "32:22": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "32:23": [
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "32:24": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    }
+  ],
+  "32:25": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "mockery",
+      "tw_match": "mockery"
+    }
+  ],
+  "32:26": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "32:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "32:28": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "32:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "32:30": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "atone",
+      "tw_match": "atone"
+    }
+  ],
+  "32:31": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "32:32": [
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "32:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "32:34": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "32:35": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plagued",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "33:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "33:2": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Perizzites",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "33:3": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "33:4": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    }
+  ],
+  "33:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "33:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    }
+  ],
+  "33:7": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "33:8": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "33:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "33:10": [
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "33:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "33:12": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "33:13": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "33:14": [],
+  "33:15": [],
+  "33:16": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "33:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "33:18": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "33:19": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "compassionate",
+      "tw_match": "compassionate"
+    }
+  ],
+  "33:20": [],
+  "33:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "33:22": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "33:23": [],
+  "34:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "34:2": [
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "34:3": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    }
+  ],
+  "34:4": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "34:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "34:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "compassionate",
+      "tw_match": "compassionate"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    }
+  ],
+  "34:7": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "forgiving",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "34:8": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "34:9": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    }
+  ],
+  "34:10": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "34:11": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Perizzites",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "34:12": [
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    }
+  ],
+  "34:13": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    }
+  ],
+  "34:14": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "34:15": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "34:16": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "34:17": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "34:18": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "34:19": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "34:20": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "34:21": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "plowing",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "34:22": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Festival of Weeks",
+      "tw_match": "Festival of Weeks"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "34:23": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "34:24": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "34:25": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "leavened",
+      "tw_match": "leaven"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "34:26": [
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    }
+  ],
+  "34:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "34:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "34:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "descending",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "34:30": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "34:31": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "34:32": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "34:33": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    }
+  ],
+  "34:34": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "34:35": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    }
+  ],
+  "35:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "35:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "35:3": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "35:4": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "35:5": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "35:6": [
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "35:7": [
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "35:8": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "35:9": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    }
+  ],
+  "35:10": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "35:11": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "35:12": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "35:13": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "35:14": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "35:15": [
+    {
+      "surface": "altar of incense",
+      "tw_match": "altar of incense"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "35:16": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "35:17": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "35:18": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "35:19": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "35:20": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "35:21": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "35:22": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "35:23": [
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    }
+  ],
+  "35:24": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "35:25": [
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "35:26": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "35:27": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    }
+  ],
+  "35:28": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "35:29": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "35:30": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "35:31": [
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "35:32": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "35:33": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "35:34": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "35:35": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "36:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    }
+  ],
+  "36:2": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "36:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "contributions",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    }
+  ],
+  "36:4": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    }
+  ],
+  "36:5": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "36:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    }
+  ],
+  "36:7": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "36:8": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "36:9": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "36:10": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "36:11": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "36:12": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "36:13": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "36:14": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "36:15": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "36:16": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "36:17": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "36:18": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "36:19": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    }
+  ],
+  "36:20": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "36:21": [],
+  "36:22": [],
+  "36:23": [],
+  "36:24": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "36:25": [],
+  "36:26": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "36:27": [],
+  "36:28": [],
+  "36:29": [],
+  "36:30": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "36:31": [
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "36:32": [],
+  "36:33": [],
+  "36:34": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "36:35": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "36:36": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "acacia",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "36:37": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "36:38": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "37:1": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "37:2": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:3": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:4": [
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:5": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "37:6": [
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:7": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    }
+  ],
+  "37:8": [
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    }
+  ],
+  "37:9": [
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    }
+  ],
+  "37:10": [
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "37:11": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:12": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:13": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:14": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "37:15": [
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "37:16": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:17": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "37:18": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "37:19": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "37:20": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "37:21": [],
+  "37:22": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:23": [
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:24": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:25": [
+    {
+      "surface": "altar of incense",
+      "tw_match": "altar of incense"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "37:26": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "37:27": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    }
+  ],
+  "37:28": [
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "37:29": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "38:1": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    }
+  ],
+  "38:2": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "38:3": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "38:4": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "38:5": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "38:6": [
+    {
+      "surface": "acacias",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "38:7": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "38:8": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "38:9": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "38:10": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "38:11": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "38:12": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "38:13": [],
+  "38:14": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "38:15": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "38:16": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "38:17": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "38:18": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "38:19": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "38:20": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "38:21": [
+    {
+      "surface": "Testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "38:22": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "38:23": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "38:24": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "38:25": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "38:26": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "38:27": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "38:28": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "38:29": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "38:30": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "38:31": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "39:1": [
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "39:2": [
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "39:3": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "39:4": [],
+  "39:5": [
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "39:6": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "39:7": [
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "reminder",
+      "tw_match": "reminder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "39:8": [
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "39:9": [
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    }
+  ],
+  "39:10": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "39:11": [],
+  "39:12": [],
+  "39:13": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "39:14": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "39:15": [
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "39:16": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    }
+  ],
+  "39:17": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    }
+  ],
+  "39:18": [
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "39:19": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "39:20": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "39:21": [
+    {
+      "surface": "tied",
+      "tw_match": "tied"
+    },
+    {
+      "surface": "breastpiece",
+      "tw_match": "breastpiece"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "39:22": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "39:23": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "39:24": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "39:25": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "39:26": [
+    {
+      "surface": "pomegranate",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "39:27": [
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "39:28": [],
+  "39:29": [
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "39:30": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "39:31": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "39:32": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "39:33": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "39:34": [
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "39:35": [
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    }
+  ],
+  "39:36": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "39:37": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "39:38": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "39:39": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "39:40": [
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "39:41": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "39:42": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "39:43": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "40:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "40:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "40:3": [
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "40:4": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    }
+  ],
+  "40:5": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:6": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "40:7": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "40:8": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:9": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "40:10": [
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "40:11": [
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    }
+  ],
+  "40:12": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "40:13": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "40:14": [
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    }
+  ],
+  "40:15": [
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "40:16": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "40:17": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "40:18": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "40:19": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "40:20": [
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    }
+  ],
+  "40:21": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "40:22": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "40:23": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "40:24": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "40:25": [
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "40:26": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "40:27": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "40:28": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:29": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "40:30": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "washing",
+      "tw_match": "wash"
+    }
+  ],
+  "40:31": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "40:32": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "40:33": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "40:34": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "40:35": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "40:36": [
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "40:37": [
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "40:38": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_EZK.json
+++ b/sources/keyword_data/keywords_EZK.json
@@ -1,0 +1,21651 @@
+{
+  "1:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Ezekiel",
+      "tw_match": "Ezekiel"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:4": [],
+  "1:5": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    }
+  ],
+  "1:17": [],
+  "1:18": [],
+  "1:19": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "awe",
+      "tw_match": "awe"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "1:25": [],
+  "1:26": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "figure",
+      "tw_match": "figure"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:1": [],
+  "2:2": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "lamentations",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "harder",
+      "tw_match": "harder"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "assigning",
+      "tw_match": "assign"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "assigning",
+      "tw_match": "assign"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "bonds",
+      "tw_match": "bonds"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "cow",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "manure",
+      "tw_match": "manure"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "Plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "whored",
+      "tw_match": "whored"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "7:6": [],
+  "7:7": [
+    {
+      "surface": "doom",
+      "tw_match": "doom"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "punishing",
+      "tw_match": "punish"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Doom",
+      "tw_match": "doom"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "7:17": [],
+  "7:18": [
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "idolatrous",
+      "tw_match": "idolatrous"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "bandits",
+      "tw_match": "bandits"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "Fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "provokes",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "doorway",
+      "tw_match": "doorway"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "8:8": [],
+  "8:9": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "Defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "courtyards",
+      "tw_match": "courtyard"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "perversions",
+      "tw_match": "perversion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "watched",
+      "tw_match": "watch"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:11": [],
+  "10:12": [],
+  "10:13": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "doorway",
+      "tw_match": "doorway"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "carried out",
+      "tw_match": "carried out"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Chaldea",
+      "tw_match": "Chaldea"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "12:5": [],
+  "12:6": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "disperse",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "favorable",
+      "tw_match": "favorable"
+    },
+    {
+      "surface": "divinations",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "12:27": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prophesies",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wastelands",
+      "tw_match": "wasteland"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "hailstones",
+      "tw_match": "hailstone"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "13:12": [],
+  "13:13": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "floods",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Hailstones",
+      "tw_match": "hailstone"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "annihilated",
+      "tw_match": "annihilate"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "annihilate",
+      "tw_match": "annihilate"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "magic",
+      "tw_match": "magic"
+    },
+    {
+      "surface": "veils",
+      "tw_match": "veil"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "magic",
+      "tw_match": "magic"
+    },
+    {
+      "surface": "ensnare",
+      "tw_match": "ensnare"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "trapped",
+      "tw_match": "trapped"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "veils",
+      "tw_match": "veil"
+    },
+    {
+      "surface": "trapped",
+      "tw_match": "trapped"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "discourage",
+      "tw_match": "discourage"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "discouragement",
+      "tw_match": "discouragement"
+    },
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "deserts",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "inquires",
+      "tw_match": "inquire"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "committing",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "punishments",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Unlike",
+      "tw_match": "unlike"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "compassionate",
+      "tw_match": "compassionate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:6": [],
+  "16:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "16:11": [],
+  "16:12": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "oils",
+      "tw_match": "oil"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "lofty",
+      "tw_match": "lofty"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "lustful",
+      "tw_match": "lustful"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "provoking",
+      "tw_match": "provoke"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "Assyrians",
+      "tw_match": "Assyrian"
+    }
+  ],
+  "16:29": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldea",
+      "tw_match": "Chaldea"
+    }
+  ],
+  "16:30": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "16:31": [
+    {
+      "surface": "lofty",
+      "tw_match": "lofty"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "16:32": [
+    {
+      "surface": "adulterous",
+      "tw_match": "adulterous"
+    }
+  ],
+  "16:33": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    }
+  ],
+  "16:34": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "16:35": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "16:36": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "lust",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "16:37": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "16:38": [
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    },
+    {
+      "surface": "passion",
+      "tw_match": "passions"
+    }
+  ],
+  "16:39": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "16:40": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    }
+  ],
+  "16:41": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    }
+  ],
+  "16:42": [
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "16:43": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "16:44": [
+    {
+      "surface": "proverbs",
+      "tw_match": "proverb"
+    }
+  ],
+  "16:45": [
+    {
+      "surface": "detested",
+      "tw_match": "detested"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    }
+  ],
+  "16:46": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    }
+  ],
+  "16:47": [],
+  "16:48": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "16:49": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    }
+  ],
+  "16:50": [
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "16:51": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "16:52": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    }
+  ],
+  "16:53": [
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "16:54": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    }
+  ],
+  "16:55": [
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "16:56": [
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    }
+  ],
+  "16:57": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "16:58": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:59": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "deserve",
+      "tw_match": "deserve"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "16:60": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    }
+  ],
+  "16:61": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "16:62": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "16:63": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "descendant",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "betrayed",
+      "tw_match": "betray"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "refugees",
+      "tw_match": "refugee"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "17:23": [
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "17:24": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Fathers",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "carries",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "monthly",
+      "tw_match": "monthly"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "carries",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "18:10": [],
+  "18:11": [
+    {
+      "surface": "defiles",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "robs",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "carries",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "carries",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "betrays",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "18:31": [
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    }
+  ],
+  "18:32": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "lioness",
+      "tw_match": "lioness"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "scepters",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "annihilate",
+      "tw_match": "annihilate"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Israelites",
+      "tw_match": "Israelites"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "disperse",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "20:29": [
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:30": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    }
+  ],
+  "20:31": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "20:32": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "20:33": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "20:34": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "20:35": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "20:36": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "20:37": [
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "requirements",
+      "tw_match": "requirements"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "20:38": [
+    {
+      "surface": "rebels",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "20:39": [
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "20:40": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    }
+  ],
+  "20:41": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "20:42": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "20:43": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "20:44": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "corrupt",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "20:45": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "20:46": [
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "20:47": [
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "quenched",
+      "tw_match": "quenched"
+    }
+  ],
+  "20:48": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "quenched",
+      "tw_match": "quenched"
+    }
+  ],
+  "20:49": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "sanctuaries",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "trial",
+      "tw_match": "trial"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "assign",
+      "tw_match": "assign"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "Babylonian",
+      "tw_match": "Babylonian"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "Ammonites",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Babylonians",
+      "tw_match": "Babylonian"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "besiege",
+      "tw_match": "besiege"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "committing",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "Exalt",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "21:29": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "21:30": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "21:31": [
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "21:32": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "laughingstock",
+      "tw_match": "laughingstock"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "reputation",
+      "tw_match": "reputation"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "dishonored",
+      "tw_match": "dishonored"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "mistreated",
+      "tw_match": "mistreat"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "22:9": [],
+  "22:10": [],
+  "22:11": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "bribes",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "dishonest",
+      "tw_match": "dishonest"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "disperse",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "distinguish",
+      "tw_match": "distinguish"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "robbery",
+      "tw_match": "robbery"
+    },
+    {
+      "surface": "mistreat",
+      "tw_match": "mistreat"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "22:31": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "23:2": [],
+  "23:3": [
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "lusted",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "Assyrians",
+      "tw_match": "Assyrian"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "lusted",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "lust",
+      "tw_match": "lust"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "Assyrians",
+      "tw_match": "Assyrian"
+    },
+    {
+      "surface": "lusted",
+      "tw_match": "lust"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "lusted",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "lusted",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "Assyrians",
+      "tw_match": "Assyrian"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "23:13": [],
+  "23:14": [
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "belts",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "waists",
+      "tw_match": "waist"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "Babylonia",
+      "tw_match": "Babylonia"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldea",
+      "tw_match": "Chaldea"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "lusted",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Chaldea",
+      "tw_match": "Chaldea"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "Babylonians",
+      "tw_match": "Babylonian"
+    },
+    {
+      "surface": "lust",
+      "tw_match": "lust"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "lusted",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "Babylonians",
+      "tw_match": "Babylonian"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Assyrians",
+      "tw_match": "Assyrian"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "reputation",
+      "tw_match": "reputation"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "23:26": [],
+  "23:27": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "23:30": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "lusting",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "23:31": [
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "23:32": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "laughingstock",
+      "tw_match": "laughingstock"
+    },
+    {
+      "surface": "subject",
+      "tw_match": "subject"
+    }
+  ],
+  "23:33": [
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "devastation",
+      "tw_match": "devastation"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "23:34": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "23:35": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    }
+  ],
+  "23:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "23:37": [
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "23:38": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "23:39": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "23:40": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    }
+  ],
+  "23:41": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "23:42": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "crowns",
+      "tw_match": "crown"
+    }
+  ],
+  "23:43": [
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    }
+  ],
+  "23:44": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    }
+  ],
+  "23:45": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "adulteresses",
+      "tw_match": "adulteress"
+    }
+  ],
+  "23:46": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "terrorized",
+      "tw_match": "terrorize"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    }
+  ],
+  "23:47": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "23:48": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    }
+  ],
+  "23:49": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "besieged",
+      "tw_match": "besieged"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    }
+  ],
+  "24:7": [],
+  "24:8": [
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "24:12": [],
+  "24:13": [
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "24:18": [],
+  "24:19": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "desecrate",
+      "tw_match": "desecrate"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "24:24": [
+    {
+      "surface": "Ezekiel",
+      "tw_match": "Ezekiel"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "24:25": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    }
+  ],
+  "24:26": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "refugee",
+      "tw_match": "refugee"
+    }
+  ],
+  "24:27": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "refugee",
+      "tw_match": "refugee"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Cherethites",
+      "tw_match": "Cherethites"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "sweep",
+      "tw_match": "sweep"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "famous",
+      "tw_match": "famous"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "26:18": [
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "26:20": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "26:21": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "perfected",
+      "tw_match": "perfect"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "oaks",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "Cyprus",
+      "tw_match": "Cyprus"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "hung",
+      "tw_match": "hung"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "hung",
+      "tw_match": "hung"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "Tubal",
+      "tw_match": "Tubal"
+    },
+    {
+      "surface": "Meshech",
+      "tw_match": "Meshech"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "stallions",
+      "tw_match": "stallion"
+    },
+    {
+      "surface": "mules",
+      "tw_match": "mule"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "27:18": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "27:19": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "27:20": [],
+  "27:21": [
+    {
+      "surface": "Arabia",
+      "tw_match": "Arabia"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Kedar",
+      "tw_match": "Kedar"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "27:22": [
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "27:23": [
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    },
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "Ashur",
+      "tw_match": "Ashur"
+    }
+  ],
+  "27:24": [
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "27:25": [
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    }
+  ],
+  "27:26": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "27:27": [
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "27:28": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "27:29": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "27:30": [],
+  "27:31": [
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "27:32": [
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "27:33": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "27:34": [],
+  "27:35": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    }
+  ],
+  "27:36": [
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:10": [
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "dishonest",
+      "tw_match": "dishonest"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "28:20": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "28:21": [
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "28:22": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "28:23": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "28:24": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "28:25": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "28:26": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    }
+  ],
+  "29:4": [],
+  "29:5": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "29:7": [],
+  "29:8": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "29:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wasted",
+      "tw_match": "wasted"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "disperse",
+      "tw_match": "disperse"
+    }
+  ],
+  "29:13": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "29:14": [
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "29:15": [
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "29:16": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "reminder",
+      "tw_match": "reminder"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "29:17": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "29:18": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "hard work",
+      "tw_match": "hard work"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "carried out",
+      "tw_match": "carried out"
+    }
+  ],
+  "29:19": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "29:20": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "29:21": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "30:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "30:2": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "doom",
+      "tw_match": "doom"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "Arabia",
+      "tw_match": "Arabia"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "30:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "30:7": [
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "30:8": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "30:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "terrorize",
+      "tw_match": "terrorize"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "doom",
+      "tw_match": "doom"
+    }
+  ],
+  "30:10": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "30:11": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "30:12": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:13": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Memphis",
+      "tw_match": "Memphis"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "30:14": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "30:15": [
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "30:16": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Memphis",
+      "tw_match": "Memphis"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "30:17": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "30:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "30:19": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "30:20": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "30:21": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "30:22": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "30:23": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "disperse",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "30:24": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "30:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "30:26": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "disperse",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "31:4": [],
+  "31:5": [],
+  "31:6": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "31:7": [],
+  "31:8": [
+    {
+      "surface": "Cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:10": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "31:11": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "deserves",
+      "tw_match": "deserve"
+    }
+  ],
+  "31:12": [
+    {
+      "surface": "Foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "31:13": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "31:14": [
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "31:15": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    }
+  ],
+  "31:16": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "31:17": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "31:18": [
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "32:1": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "32:2": [
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "stir up",
+      "tw_match": "stir up"
+    }
+  ],
+  "32:3": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "32:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "32:5": [],
+  "32:6": [],
+  "32:7": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "32:8": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "32:9": [
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "32:10": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "32:11": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "32:12": [
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "devastate",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "32:13": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "32:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "32:15": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "32:16": [
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "32:17": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "32:18": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "32:19": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    }
+  ],
+  "32:20": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    }
+  ],
+  "32:21": [
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "32:22": [
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "32:23": [
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "32:24": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "32:25": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "32:26": [
+    {
+      "surface": "Meshech",
+      "tw_match": "Meshech"
+    },
+    {
+      "surface": "Tubal",
+      "tw_match": "Tubal"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "32:27": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "32:28": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "32:29": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "32:30": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "32:31": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "32:32": [
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "33:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "33:2": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "33:3": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "33:4": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    }
+  ],
+  "33:5": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "33:6": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "33:7": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "33:8": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "33:9": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "33:10": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "33:11": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "repents",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "Repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    }
+  ],
+  "33:12": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "repents",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "33:13": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    }
+  ],
+  "33:14": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "repents",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "33:15": [
+    {
+      "surface": "restores",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "33:16": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "33:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "33:18": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "33:19": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "33:20": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    }
+  ],
+  "33:21": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "33:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "33:23": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "33:24": [
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "inherited",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "33:25": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "33:26": [
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "defiles",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "33:27": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    }
+  ],
+  "33:28": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "deserted",
+      "tw_match": "deserted"
+    }
+  ],
+  "33:29": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "33:30": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "33:31": [
+    {
+      "surface": "Right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "unjust",
+      "tw_match": "unjust"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "33:32": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "33:33": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "34:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "34:2": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "shepherding",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "34:3": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "34:4": [
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "34:5": [
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "34:6": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "dispersed",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    }
+  ],
+  "34:7": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "34:8": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "guarded",
+      "tw_match": "guard"
+    }
+  ],
+  "34:9": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "34:10": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "shepherding",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "34:11": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "34:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "34:13": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "34:14": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "34:15": [
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "34:16": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "34:17": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "34:18": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    }
+  ],
+  "34:19": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "34:20": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "34:21": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "34:22": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "34:23": [
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "34:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "34:25": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "34:26": [
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "34:27": [
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    }
+  ],
+  "34:28": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "frighten",
+      "tw_match": "frighten"
+    }
+  ],
+  "34:29": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "34:30": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "34:31": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "35:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "35:2": [
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "35:3": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    }
+  ],
+  "35:4": [
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "35:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "35:6": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    }
+  ],
+  "35:7": [
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "35:8": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "35:9": [
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "35:10": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "35:11": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "35:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "35:13": [
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    }
+  ],
+  "35:14": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    }
+  ],
+  "35:15": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "36:1": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "36:2": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "36:3": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "subject",
+      "tw_match": "subject"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    }
+  ],
+  "36:4": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "desolations",
+      "tw_match": "desolations"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "subject",
+      "tw_match": "subject"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "36:5": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "36:6": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "36:7": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "36:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "36:9": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "plowed",
+      "tw_match": "plowed"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "36:10": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "36:11": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "36:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "36:13": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "36:14": [
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "36:15": [
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "36:16": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "36:17": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "36:18": [
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "36:19": [
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "dispersed",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "36:20": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "36:21": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "36:22": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "36:23": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "36:24": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "36:25": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "36:26": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "36:27": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    }
+  ],
+  "36:28": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "36:29": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "36:30": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "36:31": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "36:32": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "disgraced",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    }
+  ],
+  "36:33": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "36:34": [
+    {
+      "surface": "plow",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "36:35": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "garden of Eden",
+      "tw_match": "garden of Eden"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "36:36": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "replanted",
+      "tw_match": "replanted"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "36:37": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "36:38": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "feasts",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "37:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "37:2": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "37:3": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "37:4": [
+    {
+      "surface": "Prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "37:5": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "37:6": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "37:7": [
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    }
+  ],
+  "37:8": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "37:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "37:10": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "37:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "37:12": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "37:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    }
+  ],
+  "37:14": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "37:15": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "37:16": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "37:17": [],
+  "37:18": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "37:19": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "37:20": [],
+  "37:21": [
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "37:22": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    }
+  ],
+  "37:23": [
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "faithless",
+      "tw_match": "faithless"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "37:24": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "37:25": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "37:26": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "37:27": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "37:28": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "38:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "38:2": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Meshech",
+      "tw_match": "Meshech"
+    },
+    {
+      "surface": "Tubal",
+      "tw_match": "Tubal"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "38:3": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Meshech",
+      "tw_match": "Meshech"
+    },
+    {
+      "surface": "Tubal",
+      "tw_match": "Tubal"
+    }
+  ],
+  "38:4": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    }
+  ],
+  "38:5": [
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    }
+  ],
+  "38:6": [],
+  "38:7": [
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "38:8": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "38:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    }
+  ],
+  "38:10": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "38:11": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "38:12": [
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "38:13": [
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "38:14": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "38:15": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "38:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "latter days",
+      "tw_match": "latter days"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "38:17": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "38:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "38:19": [
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "38:20": [
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "38:21": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "38:22": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "hailstones",
+      "tw_match": "hailstone"
+    },
+    {
+      "surface": "sulfur",
+      "tw_match": "sulfur"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "38:23": [
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "39:1": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Meshech",
+      "tw_match": "Meshech"
+    },
+    {
+      "surface": "Tubal",
+      "tw_match": "Tubal"
+    }
+  ],
+  "39:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "39:3": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "39:4": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "39:5": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "39:6": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "39:7": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    }
+  ],
+  "39:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "39:9": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "clubs",
+      "tw_match": "clubs"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "39:10": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "39:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "39:12": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "39:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "39:14": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    }
+  ],
+  "39:15": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gravediggers",
+      "tw_match": "gravediggers"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "39:16": [
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "39:17": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "39:18": [
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "39:19": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "39:20": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "39:21": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "39:22": [
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "39:23": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "betrayed",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "39:24": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "39:25": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "39:26": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "betrayed",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    }
+  ],
+  "39:27": [
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "39:28": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "39:29": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "40:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "40:2": [
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "40:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:4": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "40:5": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "40:6": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    }
+  ],
+  "40:7": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:8": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:9": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "40:10": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:11": [
+    {
+      "surface": "gateway",
+      "tw_match": "gateway"
+    }
+  ],
+  "40:12": [],
+  "40:13": [
+    {
+      "surface": "gateway",
+      "tw_match": "gateway"
+    }
+  ],
+  "40:14": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:15": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:16": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "40:17": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "40:18": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "40:19": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:20": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    }
+  ],
+  "40:21": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:22": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:23": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "40:24": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "40:25": [
+    {
+      "surface": "gateway",
+      "tw_match": "gateway"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:26": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "40:27": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "40:28": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "40:29": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:30": [],
+  "40:31": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "40:32": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "40:33": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:34": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "40:35": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "40:36": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gateway",
+      "tw_match": "gateway"
+    }
+  ],
+  "40:37": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "40:38": [
+    {
+      "surface": "gateways",
+      "tw_match": "gateway"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "40:39": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    }
+  ],
+  "40:40": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "40:41": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "40:42": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "40:43": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "40:44": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "40:45": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "40:46": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "40:47": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "40:48": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    }
+  ],
+  "40:49": [
+    {
+      "surface": "columns",
+      "tw_match": "column"
+    }
+  ],
+  "41:1": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    }
+  ],
+  "41:2": [
+    {
+      "surface": "doorway",
+      "tw_match": "doorway"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "41:3": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "doorway",
+      "tw_match": "doorway"
+    }
+  ],
+  "41:4": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "41:5": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "41:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "41:7": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "41:8": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    }
+  ],
+  "41:9": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "41:10": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "41:11": [
+    {
+      "surface": "doorway",
+      "tw_match": "doorway"
+    }
+  ],
+  "41:12": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "41:13": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "41:14": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "41:15": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "41:16": [],
+  "41:17": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "41:18": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    }
+  ],
+  "41:19": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "41:20": [
+    {
+      "surface": "doorway",
+      "tw_match": "doorway"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "41:21": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "41:22": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "41:23": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "41:24": [],
+  "41:25": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "41:26": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "42:1": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "42:2": [],
+  "42:3": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "42:4": [],
+  "42:5": [],
+  "42:6": [
+    {
+      "surface": "columns",
+      "tw_match": "column"
+    },
+    {
+      "surface": "unlike",
+      "tw_match": "unlike"
+    },
+    {
+      "surface": "courtyards",
+      "tw_match": "courtyard"
+    }
+  ],
+  "42:7": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "42:8": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "42:9": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "42:10": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "42:11": [],
+  "42:12": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "doorway",
+      "tw_match": "doorway"
+    }
+  ],
+  "42:13": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "42:14": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "42:15": [
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "42:16": [],
+  "42:17": [],
+  "42:18": [],
+  "42:19": [],
+  "42:20": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "43:1": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "43:2": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "43:3": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "43:4": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "43:5": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "43:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "43:7": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "43:8": [
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "gateposts",
+      "tw_match": "gateposts"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "43:9": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "43:10": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "43:11": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "43:12": [
+    {
+      "surface": "regulation",
+      "tw_match": "regulations"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "43:13": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "43:14": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "43:15": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "43:16": [],
+  "43:17": [],
+  "43:18": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "regulations",
+      "tw_match": "regulations"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "43:19": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "43:20": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "43:21": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "43:22": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    }
+  ],
+  "43:23": [
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "43:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "43:25": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "43:26": [
+    {
+      "surface": "atone",
+      "tw_match": "atone"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    }
+  ],
+  "43:27": [
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "44:1": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "44:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "44:3": [
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "44:4": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "44:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "regulations",
+      "tw_match": "regulations"
+    }
+  ],
+  "44:6": [
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    }
+  ],
+  "44:7": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "profaning",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "44:8": [
+    {
+      "surface": "carried out",
+      "tw_match": "carried out"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "44:9": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "44:10": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "44:11": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "44:12": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "44:13": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    }
+  ],
+  "44:14": [
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "44:15": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "44:16": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    }
+  ],
+  "44:17": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "44:18": [],
+  "44:19": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "44:20": [
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    }
+  ],
+  "44:21": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    }
+  ],
+  "44:22": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "44:23": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "44:24": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "44:25": [
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "44:26": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "44:27": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "44:28": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "44:29": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "44:30": [
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "contributions",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "44:31": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "45:1": [
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "45:2": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "45:3": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "45:4": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "45:5": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "45:6": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "45:7": [
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "45:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "45:9": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "45:10": [],
+  "45:11": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    }
+  ],
+  "45:12": [],
+  "45:13": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "45:14": [
+    {
+      "surface": "regulation",
+      "tw_match": "regulations"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    }
+  ],
+  "45:15": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "peace offering",
+      "tw_match": "peace offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "45:16": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "45:17": [
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "festivals",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "45:18": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "45:19": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    }
+  ],
+  "45:20": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "atone",
+      "tw_match": "atone"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "45:21": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "45:22": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "45:23": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "45:24": [
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "45:25": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "46:1": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    }
+  ],
+  "46:2": [
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "peace offering",
+      "tw_match": "peace offering"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    }
+  ],
+  "46:3": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "46:4": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "46:5": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "46:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "46:7": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "46:8": [
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "46:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "festivals",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "46:10": [
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "46:11": [
+    {
+      "surface": "festivals",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "46:12": [
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "peace offering",
+      "tw_match": "peace offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "46:13": [
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "46:14": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    }
+  ],
+  "46:15": [
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "46:16": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "46:17": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "liberty",
+      "tw_match": "liberty"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    }
+  ],
+  "46:18": [
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "46:19": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "46:20": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    }
+  ],
+  "46:21": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    }
+  ],
+  "46:22": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "courtyards",
+      "tw_match": "courtyard"
+    }
+  ],
+  "46:23": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "46:24": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "47:1": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "47:2": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "47:3": [],
+  "47:4": [],
+  "47:5": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    }
+  ],
+  "47:6": [],
+  "47:7": [],
+  "47:8": [
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "Salt Sea",
+      "tw_match": "Salt Sea"
+    }
+  ],
+  "47:9": [
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    }
+  ],
+  "47:10": [
+    {
+      "surface": "fishermen",
+      "tw_match": "fishermen"
+    },
+    {
+      "surface": "En Gedi",
+      "tw_match": "En Gedi"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "Salt Sea",
+      "tw_match": "Salt Sea"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    }
+  ],
+  "47:11": [
+    {
+      "surface": "Salt Sea",
+      "tw_match": "Salt Sea"
+    }
+  ],
+  "47:12": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "47:13": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the twelve",
+      "tw_match": "the twelve"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "47:14": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "47:15": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    }
+  ],
+  "47:16": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    }
+  ],
+  "47:17": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    }
+  ],
+  "47:18": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Jordan River",
+      "tw_match": "Jordan River"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "47:19": [
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "Meribah Kadesh",
+      "tw_match": "Meribah Kadesh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    }
+  ],
+  "47:20": [
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    },
+    {
+      "surface": "Lebo Hamath",
+      "tw_match": "Lebo Hamath"
+    }
+  ],
+  "47:21": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "47:22": [
+    {
+      "surface": "inheritances",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "47:23": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "48:1": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lebo Hamath",
+      "tw_match": "Lebo Hamath"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    }
+  ],
+  "48:2": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "48:3": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "48:4": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "48:5": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "48:6": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "48:7": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "48:8": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "48:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "48:10": [
+    {
+      "surface": "assignments",
+      "tw_match": "assignment"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "48:11": [
+    {
+      "surface": "consecration",
+      "tw_match": "consecration"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "48:12": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "48:13": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "48:14": [
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "48:15": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "48:16": [],
+  "48:17": [],
+  "48:18": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "48:19": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "48:20": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "48:21": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "48:22": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "48:23": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "48:24": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    }
+  ],
+  "48:25": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    }
+  ],
+  "48:26": [
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "48:27": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "48:28": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "Meribah Kadesh",
+      "tw_match": "Meribah Kadesh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    }
+  ],
+  "48:29": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "48:30": [],
+  "48:31": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "48:32": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "48:33": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "48:34": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "48:35": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_EZR.json
+++ b/sources/keyword_data/keywords_EZR.json
@@ -1,0 +1,5005 @@
+{
+  "1:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "Nehemiah",
+      "tw_match": "Nehemiah"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:3": [],
+  "2:4": [],
+  "2:5": [],
+  "2:6": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    }
+  ],
+  "2:8": [],
+  "2:9": [],
+  "2:10": [],
+  "2:11": [],
+  "2:12": [],
+  "2:13": [],
+  "2:14": [],
+  "2:15": [],
+  "2:16": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "2:17": [],
+  "2:18": [],
+  "2:19": [],
+  "2:20": [],
+  "2:21": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "2:22": [],
+  "2:23": [],
+  "2:24": [],
+  "2:25": [],
+  "2:26": [
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    }
+  ],
+  "2:27": [],
+  "2:28": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "2:29": [],
+  "2:30": [],
+  "2:31": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    }
+  ],
+  "2:32": [],
+  "2:33": [],
+  "2:34": [
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "2:35": [],
+  "2:36": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "2:37": [],
+  "2:38": [],
+  "2:39": [],
+  "2:40": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "2:41": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    }
+  ],
+  "2:42": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    }
+  ],
+  "2:43": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "2:44": [],
+  "2:45": [],
+  "2:46": [],
+  "2:47": [],
+  "2:48": [],
+  "2:49": [],
+  "2:50": [],
+  "2:51": [],
+  "2:52": [],
+  "2:53": [],
+  "2:54": [],
+  "2:55": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "2:56": [],
+  "2:57": [],
+  "2:58": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "2:59": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:60": [],
+  "2:61": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Gileadite",
+      "tw_match": "Gileadite"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "2:62": [
+    {
+      "surface": "desecrated",
+      "tw_match": "desecrated"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    }
+  ],
+  "2:63": [
+    {
+      "surface": "Tirshatha",
+      "tw_match": "Tirshatha"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "2:64": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "2:65": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "2:66": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "mules",
+      "tw_match": "mule"
+    }
+  ],
+  "2:67": [
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "2:68": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:69": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "2:70": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "Tyrians",
+      "tw_match": "Tyrians"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "overseers",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "overseers",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Ahasuerus",
+      "tw_match": "Ahasuerus"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "Aramaic",
+      "tw_match": "Aramaic"
+    },
+    {
+      "surface": "interpreted",
+      "tw_match": "interpret"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Persians",
+      "tw_match": "Persians"
+    },
+    {
+      "surface": "Babylonians",
+      "tw_match": "Babylonian"
+    },
+    {
+      "surface": "Elamites",
+      "tw_match": "Elamites"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "completing",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "4:18": [],
+  "4:19": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Haggai",
+      "tw_match": "Haggai"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "5:4": [],
+  "5:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Chaldean",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "house of God",
+      "tw_match": "house of God"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "house of God",
+      "tw_match": "house of God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Media",
+      "tw_match": "Media"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "house of God",
+      "tw_match": "house of God"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "house of God",
+      "tw_match": "house of God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "house of God",
+      "tw_match": "house of God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "prospering",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Haggai",
+      "tw_match": "Haggai"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "dedication",
+      "tw_match": "dedication"
+    },
+    {
+      "surface": "house of God",
+      "tw_match": "house of God"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "dedication",
+      "tw_match": "dedication"
+    },
+    {
+      "surface": "house of God",
+      "tw_match": "house of God"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "7:4": [],
+  "7:5": [
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "house of God",
+      "tw_match": "house of God"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "magistrates",
+      "tw_match": "magistrate"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "8:5": [],
+  "8:6": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "Athaliah",
+      "tw_match": "Athaliah"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    }
+  ],
+  "8:10": [],
+  "8:11": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "8:12": [],
+  "8:13": [],
+  "8:14": [],
+  "8:15": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:19": [],
+  "8:20": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:36": [
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Persia",
+      "tw_match": "Persia"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "confessed",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "10:4": [],
+  "10:5": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "magistrates",
+      "tw_match": "magistrate"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    }
+  ],
+  "10:20": [],
+  "10:21": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "10:27": [],
+  "10:28": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    }
+  ],
+  "10:29": [],
+  "10:30": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "10:31": [],
+  "10:32": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "10:34": [],
+  "10:35": [
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    }
+  ],
+  "10:36": [],
+  "10:37": [],
+  "10:38": [
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "10:39": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    }
+  ],
+  "10:40": [],
+  "10:41": [],
+  "10:42": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "10:43": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "Benaiah",
+      "tw_match": "Benaiah"
+    }
+  ],
+  "10:44": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_GAL.json
+++ b/sources/keyword_data/keywords_GAL.json
@@ -1,0 +1,2500 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Galatia",
+      "tw_match": "Galatia"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "pervert",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "proclaims",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Judaism",
+      "tw_match": "Judaism"
+    },
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Judaism",
+      "tw_match": "Judaism"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "traditions",
+      "tw_match": "tradition"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Arabia",
+      "tw_match": "Arabia"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Cephas",
+      "tw_match": "Cephas"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "Syria",
+      "tw_match": "Syria"
+    },
+    {
+      "surface": "Cilicia",
+      "tw_match": "Cilicia"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "unknown",
+      "tw_match": "unknown"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "enslave",
+      "tw_match": "enslave"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "in submission",
+      "tw_match": "in submission"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "apostleship",
+      "tw_match": "apostleship"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "Cephas",
+      "tw_match": "Cephas"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    }
+  ],
+  "2:10": [],
+  "2:11": [
+    {
+      "surface": "Cephas",
+      "tw_match": "Cephas"
+    },
+    {
+      "surface": "Antioch",
+      "tw_match": "Antioch"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Barnabas",
+      "tw_match": "Barnabas"
+    },
+    {
+      "surface": "hypocrisy",
+      "tw_match": "hypocrisy"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Cephas",
+      "tw_match": "Cephas"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Gentile",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in Jesus",
+      "tw_match": "in Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "Galatians",
+      "tw_match": "Galatians"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "3:4": [],
+  "3:5": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "justify",
+      "tw_match": "justify"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "preached",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "hanging",
+      "tw_match": "hang"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "seeds",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "mediator",
+      "tw_match": "mediator"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "mediator",
+      "tw_match": "mediator"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "Scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in Jesus",
+      "tw_match": "in Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "sons of God",
+      "tw_match": "sons of God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "3:29": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "heirs",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "heir",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "stewards",
+      "tw_match": "steward"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "principles",
+      "tw_match": "principle"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "adoption",
+      "tw_match": "adoption"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "heir",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "principles",
+      "tw_match": "principle"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "labored",
+      "tw_match": "labored"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "trial",
+      "tw_match": "trial"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "4:20": [],
+  "4:21": [
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "covenants",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "Arabia",
+      "tw_match": "Arabia"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "leaven",
+      "tw_match": "leaven"
+    },
+    {
+      "surface": "leavens",
+      "tw_match": "leaven"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "troubling",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "disturbing",
+      "tw_match": "disturb"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "idolatry",
+      "tw_match": "idolatry"
+    },
+    {
+      "surface": "sorcery",
+      "tw_match": "sorcery"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "self-control",
+      "tw_match": "self-control"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "passions",
+      "tw_match": "passions"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "boastful",
+      "tw_match": "boastful"
+    },
+    {
+      "surface": "provoking",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "envying",
+      "tw_match": "envy"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "trespass",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "tempted",
+      "tw_match": "tempt"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "deceives",
+      "tw_match": "deceive"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "sowing",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "6:11": [],
+  "6:12": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_GEN.json
+++ b/sources/keyword_data/keywords_GEN.json
@@ -1,0 +1,24139 @@
+{
+  "1:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Heavens",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "Land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "image of God",
+      "tw_match": "image of God"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "1:30": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "1:31": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "creating",
+      "tw_match": "create"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "breathed",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    }
+  ],
+  "2:14": [],
+  "2:15": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "3:11": [],
+  "3:12": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "3:15": [],
+  "3:16": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "thistles",
+      "tw_match": "thistle"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Eve",
+      "tw_match": "Eve"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Eve",
+      "tw_match": "Eve"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    },
+    {
+      "surface": "Lamech",
+      "tw_match": "Lamech"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "Lamech",
+      "tw_match": "Lamech"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "flutes",
+      "tw_match": "flute"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Tubal",
+      "tw_match": "Tubal"
+    },
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "Lamech",
+      "tw_match": "Lamech"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "avenged",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Lamech",
+      "tw_match": "Lamech"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Seth",
+      "tw_match": "Seth"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "Seth",
+      "tw_match": "Seth"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Seth",
+      "tw_match": "Seth"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "Seth",
+      "tw_match": "Seth"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "Seth",
+      "tw_match": "Seth"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "Seth",
+      "tw_match": "Seth"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Seth",
+      "tw_match": "Seth"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Lamech",
+      "tw_match": "Lamech"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "Lamech",
+      "tw_match": "Lamech"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "Lamech",
+      "tw_match": "Lamech"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "labors",
+      "tw_match": "labors"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Lamech",
+      "tw_match": "Lamech"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:31": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lamech",
+      "tw_match": "Lamech"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:32": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    },
+    {
+      "surface": "Japheth",
+      "tw_match": "Japheth"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "sons of God",
+      "tw_match": "sons of God"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "Nephilim",
+      "tw_match": "Nephilim"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sons of God",
+      "tw_match": "sons of God"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "renown",
+      "tw_match": "renown"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    },
+    {
+      "surface": "Japheth",
+      "tw_match": "Japheth"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "corrupt",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "6:21": [],
+  "6:22": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fountains",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    },
+    {
+      "surface": "Japheth",
+      "tw_match": "Japheth"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "7:20": [],
+  "7:21": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "fountains",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "Ararat",
+      "tw_match": "Ararat"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "drying",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "families",
+      "tw_match": "family"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    }
+  ],
+  "9:4": [],
+  "9:5": [
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "image of God",
+      "tw_match": "image of God"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    },
+    {
+      "surface": "Japheth",
+      "tw_match": "Japheth"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Japheth",
+      "tw_match": "Japheth"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "Praised",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Japheth",
+      "tw_match": "Japheth"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    },
+    {
+      "surface": "Japheth",
+      "tw_match": "Japheth"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "Japheth",
+      "tw_match": "Japheth"
+    },
+    {
+      "surface": "Tubal",
+      "tw_match": "Tubal"
+    },
+    {
+      "surface": "Meshech",
+      "tw_match": "Meshech"
+    }
+  ],
+  "10:3": [],
+  "10:4": [
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Babel",
+      "tw_match": "Babel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Shinar",
+      "tw_match": "Shinar"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    }
+  ],
+  "10:13": [],
+  "10:14": [],
+  "10:15": [
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Girgashites",
+      "tw_match": "Girgashites"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "Hamathites",
+      "tw_match": "Hamathites"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "Gerar",
+      "tw_match": "Gerar"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Japheth",
+      "tw_match": "Japheth"
+    },
+    {
+      "surface": "elder",
+      "tw_match": "elder"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "10:24": [],
+  "10:25": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "10:26": [],
+  "10:27": [],
+  "10:28": [
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    }
+  ],
+  "10:29": [],
+  "10:30": [],
+  "10:31": [
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Shinar",
+      "tw_match": "Shinar"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Babel",
+      "tw_match": "Babel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    },
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ur",
+      "tw_match": "Ur"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    },
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Ur",
+      "tw_match": "Ur"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "sojourn",
+      "tw_match": "sojourn"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "12:19": [],
+  "12:20": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Perizzites",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Zoar",
+      "tw_match": "Zoar"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Shinar",
+      "tw_match": "Shinar"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "Zoar",
+      "tw_match": "Zoar"
+    }
+  ],
+  "14:3": [],
+  "14:4": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Raphaites",
+      "tw_match": "Raphaites"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "Paran",
+      "tw_match": "Paran"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "Amalekites",
+      "tw_match": "Amalekite"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "Zoar",
+      "tw_match": "Zoar"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "Shinar",
+      "tw_match": "Shinar"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "pits",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "King’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "Melchizedek",
+      "tw_match": "Melchizedek"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "sandal",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    }
+  ],
+  "14:24": [],
+  "15:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "heir",
+      "tw_match": "heir"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "heir",
+      "tw_match": "heir"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "Ur",
+      "tw_match": "Ur"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "turtledove",
+      "tw_match": "turtledove"
+    },
+    {
+      "surface": "pigeon",
+      "tw_match": "pigeon"
+    }
+  ],
+  "15:10": [],
+  "15:11": [
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "15:17": [],
+  "15:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Euphrates River",
+      "tw_match": "Euphrates River"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Perizzites",
+      "tw_match": "Perizzite"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Girgashites",
+      "tw_match": "Girgashites"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "submit",
+      "tw_match": "submit"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Sarai",
+      "tw_match": "Sarai"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "17:23": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:24": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "17:25": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "17:26": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    }
+  ],
+  "17:27": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "outcry",
+      "tw_match": "outcry"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "outcry",
+      "tw_match": "outcry"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "sweep",
+      "tw_match": "sweep"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "sweep",
+      "tw_match": "sweep"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "18:29": [],
+  "18:30": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "18:31": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "18:32": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "18:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "sojourn",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "outcry",
+      "tw_match": "outcry"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "19:17": [],
+  "19:18": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "19:21": [],
+  "19:22": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Zoar",
+      "tw_match": "Zoar"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Zoar",
+      "tw_match": "Zoar"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "19:25": [],
+  "19:26": [
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "19:27": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:28": [
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    }
+  ],
+  "19:30": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Zoar",
+      "tw_match": "Zoar"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "19:31": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "19:32": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "19:33": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "19:34": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "19:35": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "19:36": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    }
+  ],
+  "19:37": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Moabites",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "19:38": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "sojourned",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "Gerar",
+      "tw_match": "Gerar"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Gerar",
+      "tw_match": "Gerar"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "married",
+      "tw_match": "married"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "distressing",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "21:15": [],
+  "21:16": [
+    {
+      "surface": "a bow",
+      "tw_match": "a bow"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Paran",
+      "tw_match": "Paran"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "ewe",
+      "tw_match": "ewe"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "21:29": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "ewe",
+      "tw_match": "ewe"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "21:30": [
+    {
+      "surface": "ewe",
+      "tw_match": "ewe"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "21:31": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    }
+  ],
+  "21:32": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "21:33": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "21:34": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "sojourned",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "Bethuel",
+      "tw_match": "Bethuel"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "Bethuel",
+      "tw_match": "Bethuel"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Maacah",
+      "tw_match": "Maacah"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "Kiriath Arba",
+      "tw_match": "Kiriath Arba"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "burial place",
+      "tw_match": "burial place"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "burial",
+      "tw_match": "burial"
+    },
+    {
+      "surface": "burial place",
+      "tw_match": "burial place"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "intercede",
+      "tw_match": "intercede"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "burial place",
+      "tw_match": "burial place"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Bury",
+      "tw_match": "bury"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "23:17": [],
+  "23:18": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "burial place",
+      "tw_match": "burial place"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Aram Naharaim",
+      "tw_match": "Aram Naharaim"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "kneel",
+      "tw_match": "kneel"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "Bethuel",
+      "tw_match": "Bethuel"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "watched",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "24:24": [
+    {
+      "surface": "Bethuel",
+      "tw_match": "Bethuel"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    }
+  ],
+  "24:25": [],
+  "24:26": [
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:27": [
+    {
+      "surface": "Praised",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "24:28": [
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    }
+  ],
+  "24:29": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "24:30": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "24:31": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "24:32": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "24:33": [],
+  "24:34": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "24:35": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "24:36": [
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    }
+  ],
+  "24:37": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "24:38": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "24:39": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "24:40": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "24:41": [
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "24:42": [
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "24:43": [
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "24:44": [
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "24:45": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "24:46": [
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "24:47": [
+    {
+      "surface": "Bethuel",
+      "tw_match": "Bethuel"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "24:48": [
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "24:49": [
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "24:50": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Bethuel",
+      "tw_match": "Bethuel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "24:51": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:52": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:53": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    }
+  ],
+  "24:54": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "24:55": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "24:56": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "24:57": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "24:58": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    }
+  ],
+  "24:59": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "24:60": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "24:61": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "24:62": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "24:63": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "24:64": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    }
+  ],
+  "24:65": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    }
+  ],
+  "24:66": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "24:67": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Hagar",
+      "tw_match": "Hagar"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Kedar",
+      "tw_match": "Kedar"
+    }
+  ],
+  "25:14": [],
+  "25:15": [],
+  "25:16": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "25:20": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "Bethuel",
+      "tw_match": "Bethuel"
+    },
+    {
+      "surface": "Aramean",
+      "tw_match": "Aramean"
+    },
+    {
+      "surface": "Paddan Aram",
+      "tw_match": "Paddan Aram"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    }
+  ],
+  "25:21": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    }
+  ],
+  "25:22": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "25:24": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "25:25": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "25:26": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "25:27": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "25:28": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "liked",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "25:29": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "25:30": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "25:31": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "birthright",
+      "tw_match": "birthright"
+    }
+  ],
+  "25:32": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "birthright",
+      "tw_match": "birthright"
+    }
+  ],
+  "25:33": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "birthright",
+      "tw_match": "birthright"
+    }
+  ],
+  "25:34": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "birthright",
+      "tw_match": "birthright"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Gerar",
+      "tw_match": "Gerar"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "Sojourn",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "confirm",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "requirements",
+      "tw_match": "requirements"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Gerar",
+      "tw_match": "Gerar"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "seeds",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "26:13": [],
+  "26:14": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "wells",
+      "tw_match": "well"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Gerar",
+      "tw_match": "Gerar"
+    }
+  ],
+  "26:18": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "wells",
+      "tw_match": "well"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "26:20": [
+    {
+      "surface": "Gerar",
+      "tw_match": "Gerar"
+    },
+    {
+      "surface": "quarreled",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "26:21": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "quarreled",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "26:22": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "quarrel",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "26:23": [
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "26:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "26:25": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "26:26": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Gerar",
+      "tw_match": "Gerar"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "26:27": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "26:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "26:29": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:30": [
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "26:31": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "26:32": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "26:33": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "26:34": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "26:35": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:8": [],
+  "27:9": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "kids",
+      "tw_match": "kids"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "27:18": [],
+  "27:19": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "27:20": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "27:21": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "27:22": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "27:23": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "27:24": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "27:25": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "27:26": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    }
+  ],
+  "27:27": [
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:28": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "27:29": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "27:30": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "27:31": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "27:32": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "27:33": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "27:34": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    }
+  ],
+  "27:35": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "27:36": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "birthright",
+      "tw_match": "birthright"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "27:37": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "27:38": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    }
+  ],
+  "27:39": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "27:40": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "27:41": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "27:42": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "27:43": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    }
+  ],
+  "27:44": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "27:45": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "27:46": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "Paddan Aram",
+      "tw_match": "Paddan Aram"
+    },
+    {
+      "surface": "Bethuel",
+      "tw_match": "Bethuel"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Paddan Aram",
+      "tw_match": "Paddan Aram"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Bethuel",
+      "tw_match": "Bethuel"
+    },
+    {
+      "surface": "Aramean",
+      "tw_match": "Aramean"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Paddan Aram",
+      "tw_match": "Paddan Aram"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Paddan Aram",
+      "tw_match": "Paddan Aram"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "28:10": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "descending",
+      "tw_match": "descend"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "awesome",
+      "tw_match": "awesome"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gateway",
+      "tw_match": "gateway"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "28:20": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "28:21": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "28:22": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "29:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    }
+  ],
+  "29:12": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    }
+  ],
+  "29:13": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "29:14": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "29:15": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    }
+  ],
+  "29:16": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    }
+  ],
+  "29:17": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    }
+  ],
+  "29:18": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "29:19": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "29:20": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "29:21": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "29:22": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "29:23": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    }
+  ],
+  "29:24": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Zilpah",
+      "tw_match": "Zilpah"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    }
+  ],
+  "29:25": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    }
+  ],
+  "29:26": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "29:27": [
+    {
+      "surface": "Fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "week",
+      "tw_match": "week"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "29:28": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "week",
+      "tw_match": "week"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    }
+  ],
+  "29:29": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Bilhah",
+      "tw_match": "Bilhah"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    }
+  ],
+  "29:30": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "29:31": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    }
+  ],
+  "29:32": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "29:33": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    }
+  ],
+  "29:34": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "29:35": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    }
+  ],
+  "30:1": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:2": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Bilhah",
+      "tw_match": "Bilhah"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "Bilhah",
+      "tw_match": "Bilhah"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "Bilhah",
+      "tw_match": "Bilhah"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:6": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "30:7": [
+    {
+      "surface": "Bilhah",
+      "tw_match": "Bilhah"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:8": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "30:9": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "Zilpah",
+      "tw_match": "Zilpah"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:10": [
+    {
+      "surface": "Zilpah",
+      "tw_match": "Zilpah"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:11": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "30:12": [
+    {
+      "surface": "Zilpah",
+      "tw_match": "Zilpah"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:13": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "30:14": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "30:15": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "30:16": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    }
+  ],
+  "30:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:18": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    }
+  ],
+  "30:19": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:20": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "30:21": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "30:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "30:23": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "30:24": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:25": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "30:26": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "30:27": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "30:28": [],
+  "30:29": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "30:30": [
+    {
+      "surface": "prospered",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    }
+  ],
+  "30:31": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "30:32": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "30:33": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "30:34": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    }
+  ],
+  "30:35": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "30:36": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "30:37": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:38": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "30:39": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "30:40": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    }
+  ],
+  "30:41": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "30:42": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:43": [
+    {
+      "surface": "prospered",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "maidservants",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "31:4": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "31:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:6": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    }
+  ],
+  "31:7": [
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "31:10": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "31:11": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "31:12": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    }
+  ],
+  "31:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "31:14": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "31:15": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "31:16": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:17": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "31:18": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Paddan Aram",
+      "tw_match": "Paddan Aram"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "31:19": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "31:20": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Aramean",
+      "tw_match": "Aramean"
+    }
+  ],
+  "31:21": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "31:22": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "31:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "31:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Aramean",
+      "tw_match": "Aramean"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "31:25": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "31:26": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "31:27": [
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    }
+  ],
+  "31:28": [
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    }
+  ],
+  "31:29": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "31:30": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "31:31": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    }
+  ],
+  "31:32": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    }
+  ],
+  "31:33": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    }
+  ],
+  "31:34": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "31:35": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "31:36": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "31:37": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "31:38": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "ewes",
+      "tw_match": "ewe"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "31:39": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "31:40": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "31:41": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "31:42": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "31:43": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "31:44": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "31:45": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "31:46": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "31:47": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "31:48": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "31:49": [
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "31:50": [
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "31:51": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "31:52": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "31:53": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "31:54": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "31:55": [
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "32:1": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:2": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "32:3": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "land of Seir",
+      "tw_match": "land of Seir"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "32:4": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    }
+  ],
+  "32:5": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "maidservants",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "32:6": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "32:7": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "distressing",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "32:8": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "32:9": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    }
+  ],
+  "32:10": [
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "32:11": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "32:12": [
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "32:13": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "32:14": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "ewes",
+      "tw_match": "ewe"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    }
+  ],
+  "32:15": [
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "32:16": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    }
+  ],
+  "32:17": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "32:18": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "32:19": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "32:20": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "32:21": [],
+  "32:22": [
+    {
+      "surface": "maidservants",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    }
+  ],
+  "32:23": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "32:24": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "32:25": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "32:26": [
+    {
+      "surface": "Release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "32:27": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "32:28": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:29": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "32:30": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:31": [],
+  "32:32": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "33:1": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "maidservants",
+      "tw_match": "maidservant"
+    }
+  ],
+  "33:2": [
+    {
+      "surface": "maidservants",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "33:3": [
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "33:4": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "33:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "33:6": [
+    {
+      "surface": "maidservants",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "33:7": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    }
+  ],
+  "33:8": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "33:9": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "33:10": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "33:11": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    }
+  ],
+  "33:12": [],
+  "33:13": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "33:14": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    }
+  ],
+  "33:15": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "33:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    }
+  ],
+  "33:17": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "shelters",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "33:18": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Paddan Aram",
+      "tw_match": "Paddan Aram"
+    }
+  ],
+  "33:19": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "33:20": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "34:1": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "34:2": [
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "34:3": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "34:4": [
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    }
+  ],
+  "34:5": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "34:6": [
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "34:7": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "34:8": [
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "34:9": [],
+  "34:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "34:11": [
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "34:12": [],
+  "34:13": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "34:14": [
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "34:15": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "34:16": [],
+  "34:17": [
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "34:18": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "34:19": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "delighted",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "34:20": [
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "34:21": [
+    {
+      "surface": "peaceful",
+      "tw_match": "peaceful"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "34:22": [
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "34:23": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "34:24": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "34:25": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "34:26": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "34:27": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "34:28": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "34:29": [
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "34:30": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Perizzites",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "34:31": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "35:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "35:2": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    }
+  ],
+  "35:3": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "35:4": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "35:5": [
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "35:6": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "35:7": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "35:8": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "35:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Paddan Aram",
+      "tw_match": "Paddan Aram"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "35:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "35:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "35:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "35:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "35:14": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "35:15": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "35:16": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ephrath",
+      "tw_match": "Ephrath"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    }
+  ],
+  "35:17": [
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "35:18": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "35:19": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Ephrath",
+      "tw_match": "Ephrath"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "35:20": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "35:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "35:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Bilhah",
+      "tw_match": "Bilhah"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "35:23": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "35:24": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "35:25": [
+    {
+      "surface": "Bilhah",
+      "tw_match": "Bilhah"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "35:26": [
+    {
+      "surface": "Zilpah",
+      "tw_match": "Zilpah"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Paddan Aram",
+      "tw_match": "Paddan Aram"
+    }
+  ],
+  "35:27": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Kiriath Arba",
+      "tw_match": "Kiriath Arba"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "sojourned",
+      "tw_match": "sojourn"
+    }
+  ],
+  "35:28": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "35:29": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "36:1": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "36:2": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    }
+  ],
+  "36:3": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    }
+  ],
+  "36:4": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Reuel",
+      "tw_match": "Reuel"
+    }
+  ],
+  "36:5": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "36:6": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "36:7": [
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "36:8": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "mountains of Seir",
+      "tw_match": "mountains of Seir"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "36:9": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Edomites",
+      "tw_match": "Edomite"
+    },
+    {
+      "surface": "mountains of Seir",
+      "tw_match": "mountains of Seir"
+    }
+  ],
+  "36:10": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Reuel",
+      "tw_match": "Reuel"
+    }
+  ],
+  "36:11": [],
+  "36:12": [
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    }
+  ],
+  "36:13": [
+    {
+      "surface": "Reuel",
+      "tw_match": "Reuel"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "36:14": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    }
+  ],
+  "36:15": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    }
+  ],
+  "36:16": [
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "36:17": [
+    {
+      "surface": "Reuel",
+      "tw_match": "Reuel"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "36:18": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    }
+  ],
+  "36:19": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "36:20": [
+    {
+      "surface": "sons of Seir",
+      "tw_match": "sons of Seir"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "36:21": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "sons of Seir",
+      "tw_match": "sons of Seir"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "36:22": [],
+  "36:23": [],
+  "36:24": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "36:25": [],
+  "36:26": [],
+  "36:27": [],
+  "36:28": [],
+  "36:29": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    }
+  ],
+  "36:30": [
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "land of Seir",
+      "tw_match": "land of Seir"
+    }
+  ],
+  "36:31": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "36:32": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "36:33": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "36:34": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "36:35": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Midianites",
+      "tw_match": "Midianite"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "36:36": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "36:37": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "36:38": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "36:39": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "36:40": [
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    }
+  ],
+  "36:41": [
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    }
+  ],
+  "36:42": [
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    }
+  ],
+  "36:43": [
+    {
+      "surface": "Chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "chiefs",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Edomites",
+      "tw_match": "Edomite"
+    }
+  ],
+  "37:1": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "37:2": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "shepherding",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Bilhah",
+      "tw_match": "Bilhah"
+    },
+    {
+      "surface": "Zilpah",
+      "tw_match": "Zilpah"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "37:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    }
+  ],
+  "37:4": [
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "37:5": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    }
+  ],
+  "37:6": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    }
+  ],
+  "37:7": [
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "37:8": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    }
+  ],
+  "37:9": [
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "bowing",
+      "tw_match": "bow"
+    }
+  ],
+  "37:10": [
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "37:11": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "37:12": [
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "37:13": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "shepherding",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "37:14": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "37:15": [],
+  "37:16": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "shepherding",
+      "tw_match": "shepherd"
+    }
+  ],
+  "37:17": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "37:18": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "37:19": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    }
+  ],
+  "37:20": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "cisterns",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    }
+  ],
+  "37:21": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "37:22": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "37:23": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    }
+  ],
+  "37:24": [
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    }
+  ],
+  "37:25": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Ishmaelites",
+      "tw_match": "Ishmaelite"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "37:26": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "37:27": [
+    {
+      "surface": "Ishmaelites",
+      "tw_match": "Ishmaelite"
+    }
+  ],
+  "37:28": [
+    {
+      "surface": "Midianite",
+      "tw_match": "Midianite"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "Ishmaelites",
+      "tw_match": "Ishmaelite"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "37:29": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "37:30": [],
+  "37:31": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "37:32": [
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "37:33": [
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "37:34": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "37:35": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "37:36": [
+    {
+      "surface": "Midianites",
+      "tw_match": "Midianite"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Potiphar",
+      "tw_match": "Potiphar"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    }
+  ],
+  "38:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "38:2": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    }
+  ],
+  "38:3": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "38:4": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "38:5": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "38:6": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    }
+  ],
+  "38:7": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "38:8": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "38:9": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "38:10": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "38:11": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "38:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "38:13": [
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "38:14": [
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    }
+  ],
+  "38:15": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "38:16": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "38:17": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "38:18": [
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    }
+  ],
+  "38:19": [
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    }
+  ],
+  "38:20": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "38:21": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "38:22": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "38:23": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "laughingstock",
+      "tw_match": "laughingstock"
+    }
+  ],
+  "38:24": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "prostituted",
+      "tw_match": "prostitute"
+    }
+  ],
+  "38:25": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "38:26": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "38:27": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "38:28": [
+    {
+      "surface": "tied",
+      "tw_match": "tied"
+    }
+  ],
+  "38:29": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "38:30": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "39:1": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Potiphar",
+      "tw_match": "Potiphar"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Ishmaelites",
+      "tw_match": "Ishmaelite"
+    }
+  ],
+  "39:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "39:3": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "39:4": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "39:5": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "39:6": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "39:7": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Lie",
+      "tw_match": "lie"
+    }
+  ],
+  "39:8": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "39:9": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "39:10": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "39:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "39:12": [
+    {
+      "surface": "Lie",
+      "tw_match": "lie"
+    }
+  ],
+  "39:13": [],
+  "39:14": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    }
+  ],
+  "39:15": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    }
+  ],
+  "39:16": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "39:17": [
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "39:18": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    }
+  ],
+  "39:19": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "39:20": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "39:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "39:22": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "39:23": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "40:1": [
+    {
+      "surface": "cupbearer",
+      "tw_match": "cupbearer"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "40:2": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "cupbearers",
+      "tw_match": "cupbearer"
+    }
+  ],
+  "40:3": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "40:4": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "40:5": [
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "cupbearer",
+      "tw_match": "cupbearer"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "40:6": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "40:7": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "40:8": [
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpret",
+      "tw_match": "interpret"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "interpretations",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "40:9": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "cupbearers",
+      "tw_match": "cupbearer"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "grapevine",
+      "tw_match": "grapevine"
+    }
+  ],
+  "40:10": [
+    {
+      "surface": "grapevine",
+      "tw_match": "grapevine"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "40:11": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "40:12": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "40:13": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "cupbearer",
+      "tw_match": "cupbearer"
+    }
+  ],
+  "40:14": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "40:15": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "40:16": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "interpreted",
+      "tw_match": "interpret"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "40:17": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    }
+  ],
+  "40:18": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "40:19": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    }
+  ],
+  "40:20": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "cupbearers",
+      "tw_match": "cupbearer"
+    }
+  ],
+  "40:21": [
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "cupbearers",
+      "tw_match": "cupbearer"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "40:22": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "interpreted",
+      "tw_match": "interpret"
+    }
+  ],
+  "40:23": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "cupbearers",
+      "tw_match": "cupbearer"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "41:1": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "dreaming",
+      "tw_match": "dream"
+    }
+  ],
+  "41:2": [
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "reeds",
+      "tw_match": "reed"
+    }
+  ],
+  "41:3": [
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    }
+  ],
+  "41:4": [
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "41:5": [
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "41:6": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "41:7": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    }
+  ],
+  "41:8": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpret",
+      "tw_match": "interpret"
+    }
+  ],
+  "41:9": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "cupbearers",
+      "tw_match": "cupbearer"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "41:10": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    }
+  ],
+  "41:11": [
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "41:12": [
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpreted",
+      "tw_match": "interpret"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    }
+  ],
+  "41:13": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "interpreted",
+      "tw_match": "interpret"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    }
+  ],
+  "41:14": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "41:15": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpret",
+      "tw_match": "interpret"
+    }
+  ],
+  "41:16": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "41:17": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    }
+  ],
+  "41:18": [
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "reeds",
+      "tw_match": "reed"
+    }
+  ],
+  "41:19": [
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:20": [
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    }
+  ],
+  "41:21": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "41:22": [
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "41:23": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "41:24": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "magicians",
+      "tw_match": "magician"
+    }
+  ],
+  "41:25": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "41:26": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    }
+  ],
+  "41:27": [
+    {
+      "surface": "cows",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "41:28": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "41:29": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:30": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "41:31": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "41:32": [
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "41:33": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:34": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "41:35": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "41:36": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:37": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "41:38": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "41:39": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "41:40": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "41:41": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:42": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "41:43": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:44": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:45": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:46": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:47": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "41:48": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:49": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "41:50": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "41:51": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "41:52": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "41:53": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:54": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "41:55": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "41:56": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:57": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "42:1": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "42:2": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "42:3": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "42:4": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "42:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "42:6": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "42:7": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "42:8": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "42:9": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "42:10": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "42:11": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "42:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "42:13": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "42:14": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "42:15": [
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "42:16": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "42:17": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "42:18": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "42:19": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "households",
+      "tw_match": "household"
+    }
+  ],
+  "42:20": [],
+  "42:21": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "pleaded",
+      "tw_match": "plead"
+    }
+  ],
+  "42:22": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "42:23": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "interpreter",
+      "tw_match": "interpreter"
+    }
+  ],
+  "42:24": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "42:25": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "42:26": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "42:27": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "42:28": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "42:29": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "42:30": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    }
+  ],
+  "42:31": [],
+  "42:32": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "42:33": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "households",
+      "tw_match": "household"
+    }
+  ],
+  "42:34": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "42:35": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "42:36": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "42:37": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "42:38": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "43:1": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "43:2": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "43:3": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    }
+  ],
+  "43:4": [],
+  "43:5": [],
+  "43:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    }
+  ],
+  "43:7": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "43:8": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "43:9": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "43:10": [],
+  "43:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    }
+  ],
+  "43:12": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "43:13": [],
+  "43:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "43:15": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "43:16": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "43:17": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "43:18": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "43:19": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "43:20": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "43:21": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "43:22": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "43:23": [
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    }
+  ],
+  "43:24": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "43:25": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "43:26": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "43:27": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    }
+  ],
+  "43:28": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "43:29": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    }
+  ],
+  "43:30": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "43:31": [
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "Serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "43:32": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "43:33": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "birthright",
+      "tw_match": "birthright"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "43:34": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    }
+  ],
+  "44:1": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "44:2": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "44:3": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "44:4": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "44:5": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "divines",
+      "tw_match": "divine"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "44:6": [],
+  "44:7": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "44:8": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "44:9": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "44:10": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "44:11": [],
+  "44:12": [
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "44:13": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "44:14": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "44:15": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "divines",
+      "tw_match": "divine"
+    }
+  ],
+  "44:16": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "justify",
+      "tw_match": "justify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "44:17": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "44:18": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "44:19": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "44:20": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "44:21": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "44:22": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    }
+  ],
+  "44:23": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "44:24": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "44:25": [],
+  "44:26": [],
+  "44:27": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "44:28": [],
+  "44:29": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "44:30": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "44:31": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "44:32": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "44:33": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "44:34": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "45:1": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "45:2": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "45:3": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "45:4": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "45:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "45:6": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "plowing",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "harvesting",
+      "tw_match": "harvest"
+    }
+  ],
+  "45:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "deliverance",
+      "tw_match": "deliverance"
+    }
+  ],
+  "45:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "45:9": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "45:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    }
+  ],
+  "45:11": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    }
+  ],
+  "45:12": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "45:13": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "45:14": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "45:15": [
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "45:16": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "45:17": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "45:18": [
+    {
+      "surface": "households",
+      "tw_match": "household"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "45:19": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "45:20": [
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "45:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "45:22": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "45:23": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "45:24": [
+    {
+      "surface": "quarrel",
+      "tw_match": "quarrel"
+    }
+  ],
+  "45:25": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "45:26": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "45:27": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "45:28": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "46:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "46:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "46:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "46:4": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    }
+  ],
+  "46:5": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "46:6": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "46:7": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "46:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "46:9": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "46:10": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    }
+  ],
+  "46:11": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "46:12": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "46:13": [
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "46:14": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "46:15": [
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Paddan Aram",
+      "tw_match": "Paddan Aram"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "46:16": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "46:17": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "46:18": [
+    {
+      "surface": "Zilpah",
+      "tw_match": "Zilpah"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "46:19": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "46:20": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "46:21": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    }
+  ],
+  "46:22": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "46:23": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "46:24": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "46:25": [
+    {
+      "surface": "Bilhah",
+      "tw_match": "Bilhah"
+    },
+    {
+      "surface": "Laban",
+      "tw_match": "Laban"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "46:26": [
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "46:27": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "46:28": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "46:29": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "46:30": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "46:31": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "46:32": [
+    {
+      "surface": "herders",
+      "tw_match": "herder"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    }
+  ],
+  "46:33": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "46:34": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    },
+    {
+      "surface": "herder",
+      "tw_match": "herder"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "47:1": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    }
+  ],
+  "47:2": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "47:3": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "herders",
+      "tw_match": "herder"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "47:4": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "sojourn",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    }
+  ],
+  "47:5": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "47:6": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "overseers",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "47:7": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "47:8": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "47:9": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "47:10": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "47:11": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "47:12": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "47:13": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "47:14": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "47:15": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "47:16": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "47:17": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "47:18": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "47:19": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "47:20": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "47:21": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "47:22": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "47:23": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    }
+  ],
+  "47:24": [
+    {
+      "surface": "harvests",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "47:25": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "47:26": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "47:27": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    }
+  ],
+  "47:28": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "47:29": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "47:30": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "47:31": [
+    {
+      "surface": "Swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "48:1": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "48:2": [
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "48:3": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "48:4": [
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "48:5": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    }
+  ],
+  "48:6": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "48:7": [
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Ephrath",
+      "tw_match": "Ephrath"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "48:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "48:9": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "48:10": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "48:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "48:12": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "48:13": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "48:14": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "48:15": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "shepherding",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "48:16": [
+    {
+      "surface": "Angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "48:17": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "48:18": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "48:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "48:20": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "48:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "48:22": [
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "49:1": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "49:2": [
+    {
+      "surface": "Assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "49:3": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "49:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "49:5": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    }
+  ],
+  "49:6": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "council",
+      "tw_match": "council"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "49:7": [
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "49:8": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "49:9": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lioness",
+      "tw_match": "lioness"
+    }
+  ],
+  "49:10": [
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    }
+  ],
+  "49:11": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "grapevine",
+      "tw_match": "grapevine"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "49:12": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "49:13": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    }
+  ],
+  "49:14": [
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "49:15": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "49:16": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "49:17": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "viper",
+      "tw_match": "viper"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    }
+  ],
+  "49:18": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "49:19": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "49:20": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    }
+  ],
+  "49:21": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "doe",
+      "tw_match": "doe"
+    }
+  ],
+  "49:22": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "49:23": [
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    }
+  ],
+  "49:24": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "49:25": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "49:26": [
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    }
+  ],
+  "49:27": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "wolf",
+      "tw_match": "wolf"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "49:28": [
+    {
+      "surface": "the twelve",
+      "tw_match": "the twelve"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "49:29": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "49:30": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "burial place",
+      "tw_match": "burial place"
+    }
+  ],
+  "49:31": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    }
+  ],
+  "49:32": [],
+  "49:33": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "50:1": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "50:2": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "50:3": [
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "50:4": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "50:5": [
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "50:6": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    }
+  ],
+  "50:7": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "50:8": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    }
+  ],
+  "50:9": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "50:10": [
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "lamented",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "50:11": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "50:12": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "50:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "burial place",
+      "tw_match": "burial place"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    }
+  ],
+  "50:14": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "50:15": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "50:16": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "50:17": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "50:18": [
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "50:19": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "50:20": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "50:21": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "50:22": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "50:23": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "50:24": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "50:25": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "50:26": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_HAB.json
+++ b/sources/keyword_data/keywords_HAB.json
@@ -1,0 +1,1037 @@
+{
+  "1:1": [
+    {
+      "surface": "Habakkuk",
+      "tw_match": "Habakkuk"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "Destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "leopards",
+      "tw_match": "leopard"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "mockery",
+      "tw_match": "mockery"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "sweep",
+      "tw_match": "sweep"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "ordained",
+      "tw_match": "ordained"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "betray",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "watchtower",
+      "tw_match": "watchtower"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "betrays",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "create",
+      "tw_match": "create"
+    },
+    {
+      "surface": "ridicule",
+      "tw_match": "ridicule"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "pledges",
+      "tw_match": "pledges"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "safe",
+      "tw_match": "safe"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "Habakkuk",
+      "tw_match": "Habakkuk"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Paran",
+      "tw_match": "Paran"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "3:10": [],
+  "3:11": [
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "threshed",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "deer",
+      "tw_match": "deer"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_HAG.json
+++ b/sources/keyword_data/keywords_HAG.json
@@ -1,0 +1,789 @@
+{
+  "1:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Haggai",
+      "tw_match": "Haggai"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Haggai",
+      "tw_match": "Haggai"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Haggai",
+      "tw_match": "Haggai"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Haggai",
+      "tw_match": "Haggai"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Haggai",
+      "tw_match": "Haggai"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "covenanted",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Haggai",
+      "tw_match": "Haggai"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "carries",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Haggai",
+      "tw_match": "Haggai"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Haggai",
+      "tw_match": "Haggai"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:16": [],
+  "2:17": [
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "storehouse",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "pomegranate",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Haggai",
+      "tw_match": "Haggai"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_HEB.json
+++ b/sources/keyword_data/keywords_HEB.json
@@ -1,0 +1,5188 @@
+{
+  "1:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "heir",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "inherited",
+      "tw_match": "inherit"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "lawlessness",
+      "tw_match": "lawlessness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "crowned",
+      "tw_match": "crowned"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "subjecting",
+      "tw_match": "subjecting"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "crowned",
+      "tw_match": "crowned"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "sanctifying",
+      "tw_match": "sanctify"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "tempted",
+      "tw_match": "tempt"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "confession",
+      "tw_match": "confession"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "harden",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "provocation",
+      "tw_match": "provocation"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "unbelief",
+      "tw_match": "unbelief"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "exhort",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "harden",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "unbelief",
+      "tw_match": "unbelief"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "4:5": [],
+  "4:6": [
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "harden",
+      "tw_match": "harden"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "people of God",
+      "tw_match": "people of God"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "confession",
+      "tw_match": "confession"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "tempted",
+      "tw_match": "tempt"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "subject",
+      "tw_match": "subject"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Melchizedek",
+      "tw_match": "Melchizedek"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "source",
+      "tw_match": "source"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "Melchizedek",
+      "tw_match": "Melchizedek"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "principles",
+      "tw_match": "principle"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "distinguishing",
+      "tw_match": "distinguish"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "baptisms",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "crucifying",
+      "tw_match": "crucify"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "thistles",
+      "tw_match": "thistle"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "unjust",
+      "tw_match": "unjust"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "inheriting",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "disputes",
+      "tw_match": "disputes"
+    },
+    {
+      "surface": "confirmation",
+      "tw_match": "confirmation"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heirs",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "encouragement",
+      "tw_match": "encouragement"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Melchizedek",
+      "tw_match": "Melchizedek"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Melchizedek",
+      "tw_match": "Melchizedek"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "patriarch",
+      "tw_match": "patriarch"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "loin",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "tithes",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "tithes",
+      "tw_match": "tithe"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "tithes",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "loin",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "Melchizedek",
+      "tw_match": "Melchizedek"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Melchizedek",
+      "tw_match": "Melchizedek"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "Melchizedek",
+      "tw_match": "Melchizedek"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Melchizedek",
+      "tw_match": "Melchizedek"
+    }
+  ],
+  "7:18": [],
+  "7:19": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "perfected",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "swearing",
+      "tw_match": "swearing"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "intercede",
+      "tw_match": "intercede"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "appoints",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "swearing",
+      "tw_match": "swearing"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    },
+    {
+      "surface": "mediator",
+      "tw_match": "mediator"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "citizen",
+      "tw_match": "citizen"
+    },
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "regulations",
+      "tw_match": "regulations"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Holies",
+      "tw_match": "holy"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "incense altar",
+      "tw_match": "incense altar"
+    },
+    {
+      "surface": "ark of the covenant",
+      "tw_match": "ark of the covenant"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "baptisms",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "regulations",
+      "tw_match": "regulations"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "sanctifies",
+      "tw_match": "sanctify"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "mediator",
+      "tw_match": "mediator"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "covenanted",
+      "tw_match": "covenant"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "covenanting",
+      "tw_match": "covenant"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "reminder",
+      "tw_match": "reminder"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "Sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "Sacrifices",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "10:9": [],
+  "10:10": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "perfected",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "testifies",
+      "tw_match": "testify"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "confession",
+      "tw_match": "confession"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "exhorting",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "deserve",
+      "tw_match": "deserve"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "insulted",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "10:30": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "10:31": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    }
+  ],
+  "10:34": [
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "seizure",
+      "tw_match": "seizure"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "10:35": [
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "10:36": [
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "10:37": [],
+  "10:38": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "10:39": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    },
+    {
+      "surface": "proof",
+      "tw_match": "proof"
+    }
+  ],
+  "11:2": [],
+  "11:3": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "reverent",
+      "tw_match": "reverent"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "heir",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "heirs",
+      "tw_match": "heir"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "conception",
+      "tw_match": "conception"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "confessed",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "people of God",
+      "tw_match": "people of God"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Red Sea",
+      "tw_match": "Red Sea"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "11:33": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "11:34": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "11:35": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "11:36": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "trial",
+      "tw_match": "trial"
+    }
+  ],
+  "11:37": [
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "sheepskins",
+      "tw_match": "sheepskins"
+    },
+    {
+      "surface": "goatskins",
+      "tw_match": "goatskins"
+    },
+    {
+      "surface": "mistreated",
+      "tw_match": "mistreat"
+    }
+  ],
+  "11:38": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "deserts",
+      "tw_match": "desert"
+    }
+  ],
+  "11:39": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "11:40": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "founder",
+      "tw_match": "founder"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "exhortation",
+      "tw_match": "exhortation"
+    },
+    {
+      "surface": "instructs",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "reproved",
+      "tw_match": "reprove"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "welcomes",
+      "tw_match": "welcome"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "Endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:8": [],
+  "12:9": [
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "peaceful",
+      "tw_match": "peaceful"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "12:12": [],
+  "12:13": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "sanctification",
+      "tw_match": "sanctification"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "birthright",
+      "tw_match": "birthright"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    }
+  ],
+  "12:18": [],
+  "12:19": [
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "mediator",
+      "tw_match": "mediator"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "12:27": [
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reverence",
+      "tw_match": "reverence"
+    },
+    {
+      "surface": "awe",
+      "tw_match": "awe"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "consuming",
+      "tw_match": "consume"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "mistreated",
+      "tw_match": "mistreat"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "Marriage",
+      "tw_match": "marriage"
+    },
+    {
+      "surface": "marriage",
+      "tw_match": "marriage"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    },
+    {
+      "surface": "adulterers",
+      "tw_match": "adulterer"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "teachings",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "sanctify",
+      "tw_match": "sanctify"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "acknowledging",
+      "tw_match": "acknowledge"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "submit",
+      "tw_match": "submit"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "unprofitable",
+      "tw_match": "unprofitable"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "exhortation",
+      "tw_match": "exhortation"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_HOS.json
+++ b/sources/keyword_data/keywords_HOS.json
@@ -1,0 +1,4103 @@
+{
+  "1:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Hosea",
+      "tw_match": "Hosea"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jeroboam",
+      "tw_match": "Jeroboam"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Hosea",
+      "tw_match": "Hosea"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "committing",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "forsaking",
+      "tw_match": "forsake"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jehu",
+      "tw_match": "Jehu"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Hosea",
+      "tw_match": "Hosea"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "feasts",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "festivals",
+      "tw_match": "festival"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "adulteress",
+      "tw_match": "adulteress"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "last days",
+      "tw_match": "last days"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    },
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "bounds",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "mourns",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "wasting",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "oaks",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "harlots",
+      "tw_match": "harlot"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "rebels",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "testifies",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "alarm",
+      "tw_match": "alarm"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "horrible",
+      "tw_match": "horrible"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "adulterers",
+      "tw_match": "adulterer"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "leavened",
+      "tw_match": "leaven"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "testifies",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Maker",
+      "tw_match": "Maker"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    },
+    {
+      "surface": "forsaking",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "mourners",
+      "tw_match": "mourner"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Memphis",
+      "tw_match": "Memphis"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "Baal Peor",
+      "tw_match": "Baal Peor"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "conception",
+      "tw_match": "conception"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "slaughters",
+      "tw_match": "slaughter"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "rebels",
+      "tw_match": "rebel"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "prospered",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "covenants",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "oaths",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "idolatrous",
+      "tw_match": "idolatrous"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "thistles",
+      "tw_match": "thistle"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "thresh",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "plow",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "plowed",
+      "tw_match": "plowed"
+    },
+    {
+      "surface": "reaped",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "compassions",
+      "tw_match": "compassion"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "multiplies",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "labors",
+      "tw_match": "labors"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "cast metal images",
+      "tw_match": "cast metal images"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "savior",
+      "tw_match": "savior"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "13:6": [],
+  "13:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "leopard",
+      "tw_match": "leopard"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stumbled",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_ISA.json
+++ b/sources/keyword_data/keywords_ISA.json
@@ -1,0 +1,23919 @@
+{
+  "1:1": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "besieged",
+      "tw_match": "besieged"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "assemblies",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "feasts",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "rebels",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "bribes",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "payoffs",
+      "tw_match": "payoffs"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "1:25": [],
+  "1:26": [
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "rebels",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "sacred",
+      "tw_match": "sacred"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "1:30": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    }
+  ],
+  "1:31": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "quench",
+      "tw_match": "quench"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "last days",
+      "tw_match": "last days"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "plowshares",
+      "tw_match": "plowshares"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "House",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "lofty",
+      "tw_match": "lofty"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "oaks",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "2:14": [],
+  "2:15": [
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "awe",
+      "tw_match": "awe"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "awe",
+      "tw_match": "awe"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "diviner",
+      "tw_match": "diviner"
+    },
+    {
+      "surface": "elder",
+      "tw_match": "elder"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "counselor",
+      "tw_match": "counselor"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "insult",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "dishonorable",
+      "tw_match": "dishonorable"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "stumbled",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "veils",
+      "tw_match": "veil"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "boxes",
+      "tw_match": "box"
+    }
+  ],
+  "3:21": [],
+  "3:22": [],
+  "3:23": [],
+  "3:24": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "create",
+      "tw_match": "create"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "strong drink",
+      "tw_match": "strong drink"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "feasts",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "discerned",
+      "tw_match": "discern"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "descend",
+      "tw_match": "descend"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "lofty",
+      "tw_match": "lofty"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "rights",
+      "tw_match": "right"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "stumbles",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "belts",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "seraphim",
+      "tw_match": "seraphim"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "thresholds",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "doomed",
+      "tw_match": "doom"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "seraphim",
+      "tw_match": "seraphim"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "atoned",
+      "tw_match": "atoned"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "house of David",
+      "tw_match": "house of David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "conceive",
+      "tw_match": "conceive"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "laborer",
+      "tw_match": "laborer"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "cow",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    },
+    {
+      "surface": "silvers",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "prophetess",
+      "tw_match": "prophetess"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "sweep",
+      "tw_match": "sweep"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "flooding",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "advised",
+      "tw_match": "advise"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "sanctify",
+      "tw_match": "sanctify"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "ensnared",
+      "tw_match": "ensnare"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "Bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "soothsayers",
+      "tw_match": "soothsayer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "9:5": [],
+  "9:6": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Counselor",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Prince",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "stir up",
+      "tw_match": "stir up"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "Arameans",
+      "tw_match": "Aramean"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "elder",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "9:16": [],
+  "9:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "godless",
+      "tw_match": "godless"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "rights",
+      "tw_match": "right"
+    },
+    {
+      "surface": "robbing",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "preying",
+      "tw_match": "prey"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "day of judgment",
+      "tw_match": "day of judgment"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "club",
+      "tw_match": "clubs"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "prey on",
+      "tw_match": "prey on"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "idolatrous",
+      "tw_match": "idolatrous"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "vanities",
+      "tw_match": "vanity"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "ax",
+      "tw_match": "ax"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "club",
+      "tw_match": "clubs"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wasting",
+      "tw_match": "waste"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "refugees",
+      "tw_match": "refugee"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Decreed",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Assyrian",
+      "tw_match": "Assyrian"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "10:28": [],
+  "10:29": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "trembles",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Saul",
+      "tw_match": "Saul"
+    }
+  ],
+  "10:30": [],
+  "10:31": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "lofty",
+      "tw_match": "lofty"
+    }
+  ],
+  "10:34": [
+    {
+      "surface": "ax",
+      "tw_match": "ax"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "breathing",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "slay",
+      "tw_match": "slay"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "waist",
+      "tw_match": "waist"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "wolf",
+      "tw_match": "wolf"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "leopard",
+      "tw_match": "leopard"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "cow",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "Shinar",
+      "tw_match": "Shinar"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "dispersed",
+      "tw_match": "disperse"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "revere",
+      "tw_match": "revere"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yah",
+      "tw_match": "Yah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "wells",
+      "tw_match": "well"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "Cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "exulting",
+      "tw_match": "exult"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "Medes",
+      "tw_match": "Medes"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "trembles",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "burial",
+      "tw_match": "burial"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "sweep",
+      "tw_match": "sweep"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "14:30": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "slay",
+      "tw_match": "slay"
+    }
+  ],
+  "14:31": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Philistia",
+      "tw_match": "Philistia"
+    }
+  ],
+  "14:32": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "laments",
+      "tw_match": "lament"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "trembles",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Zoar",
+      "tw_match": "Zoar"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "refugees",
+      "tw_match": "refugee"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "refugees",
+      "tw_match": "refugee"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "boasts",
+      "tw_match": "boast"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "frighten",
+      "tw_match": "frighten"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "reaps",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "gleans",
+      "tw_match": "glean"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "gleanings",
+      "tw_match": "gleanings"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Maker",
+      "tw_match": "Maker"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "rob",
+      "tw_match": "rob"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "trampling",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "grape",
+      "tw_match": "grape"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "trampling",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "stir up",
+      "tw_match": "stir up"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "reeds",
+      "tw_match": "reed"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "reeds",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "the Nile",
+      "tw_match": "the Nile"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "fishermen",
+      "tw_match": "fishermen"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "the Nile",
+      "tw_match": "the Nile"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "Memphis",
+      "tw_match": "Memphis"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "cornerstones",
+      "tw_match": "cornerstone"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "perversion",
+      "tw_match": "perversion"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "staggering",
+      "tw_match": "stagger"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "remind",
+      "tw_match": "remind"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "swearing",
+      "tw_match": "swearing"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "savior",
+      "tw_match": "savior"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "afflicting",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "implored",
+      "tw_match": "implore"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Assyrian",
+      "tw_match": "Assyrian"
+    },
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Assyrians",
+      "tw_match": "Assyrian"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "19:25": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "waist",
+      "tw_match": "waist"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sweeping",
+      "tw_match": "sweep"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "besiege",
+      "tw_match": "besiege"
+    },
+    {
+      "surface": "Media",
+      "tw_match": "Media"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "disturbed",
+      "tw_match": "disturb"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "watchtower",
+      "tw_match": "watchtower"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    }
+  ],
+  "21:12": [],
+  "21:13": [
+    {
+      "surface": "Arabia",
+      "tw_match": "Arabia"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Kedar",
+      "tw_match": "Kedar"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "archers",
+      "tw_match": "archer"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "Kedar",
+      "tw_match": "Kedar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "Vision",
+      "tw_match": "vision"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "a bow",
+      "tw_match": "a bow"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "trampling",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "House",
+      "tw_match": "house"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "slaughtering",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "22:19": [],
+  "22:20": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Cyprus",
+      "tw_match": "Cyprus"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "the Nile",
+      "tw_match": "the Nile"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "labored",
+      "tw_match": "labored"
+    },
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "Cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "crowns",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "Cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the Nile",
+      "tw_match": "the Nile"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "Cyprus",
+      "tw_match": "Cyprus"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Assyrians",
+      "tw_match": "Assyrian"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "profits",
+      "tw_match": "profits"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "devastate",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "desecrate",
+      "tw_match": "desecrate"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "dries",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "dries",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "strong drink",
+      "tw_match": "strong drink"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "gleanings",
+      "tw_match": "gleanings"
+    },
+    {
+      "surface": "grape",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "Terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "stagger",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "drunkard",
+      "tw_match": "drunkard"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "disgraced",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "planned long ago",
+      "tw_match": "planned long ago"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "wines",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "Trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Yah",
+      "tw_match": "Yah"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    }
+  ],
+  "26:5": [],
+  "26:6": [
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reputation",
+      "tw_match": "reputation"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "favored",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "consuming",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "ruled",
+      "tw_match": "rule"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:18": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    }
+  ],
+  "26:20": [
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "26:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "Leviathan",
+      "tw_match": "Leviathan"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "hurts",
+      "tw_match": "hurt"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "slaying",
+      "tw_match": "slay"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "slayed",
+      "tw_match": "slay"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "deserted",
+      "tw_match": "deserted"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "consumes",
+      "tw_match": "consume"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "Maker",
+      "tw_match": "Maker"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "creator",
+      "tw_match": "creator"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "thresh",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Euphrates River",
+      "tw_match": "Euphrates River"
+    },
+    {
+      "surface": "Wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "drunkards",
+      "tw_match": "drunkard"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "drunkards",
+      "tw_match": "drunkard"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "stagger",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "strong drink",
+      "tw_match": "strong drink"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "staggering",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "reeling",
+      "tw_match": "reeling"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "28:10": [],
+  "28:11": [
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "ensnared",
+      "tw_match": "ensnare"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cornerstone",
+      "tw_match": "cornerstone"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "believes",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "sweep",
+      "tw_match": "sweep"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "28:20": [],
+  "28:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "28:22": [
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "bonds",
+      "tw_match": "bonds"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "28:23": [],
+  "28:24": [
+    {
+      "surface": "plows",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    }
+  ],
+  "28:25": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "28:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "instructs",
+      "tw_match": "instruct"
+    }
+  ],
+  "28:27": [
+    {
+      "surface": "threshed",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "28:28": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "thresh",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "28:29": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "festivals",
+      "tw_match": "festival"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "lamenting",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    }
+  ],
+  "29:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "stagger",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "strong drink",
+      "tw_match": "strong drink"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "seers",
+      "tw_match": "seer"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "29:12": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "29:13": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "honors",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "29:14": [
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    }
+  ],
+  "29:15": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "burying",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "29:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "creator",
+      "tw_match": "creator"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "29:17": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "29:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "29:19": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "29:20": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "29:21": [
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "29:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "29:23": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "sanctify",
+      "tw_match": "sanctify"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "29:24": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "30:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "30:2": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "30:6": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "lioness",
+      "tw_match": "lioness"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "viper",
+      "tw_match": "viper"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "30:7": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    }
+  ],
+  "30:8": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "30:9": [
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    }
+  ],
+  "30:10": [
+    {
+      "surface": "seers",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "illusions",
+      "tw_match": "illusions"
+    }
+  ],
+  "30:11": [
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "30:12": [
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "corruption",
+      "tw_match": "corruption"
+    }
+  ],
+  "30:13": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "30:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    }
+  ],
+  "30:15": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "30:16": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "30:17": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "30:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "30:19": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "30:20": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    }
+  ],
+  "30:21": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "30:22": [
+    {
+      "surface": "desecrate",
+      "tw_match": "desecrate"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "30:23": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "30:24": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "plowers",
+      "tw_match": "plowers"
+    },
+    {
+      "surface": "winnowed",
+      "tw_match": "winnow"
+    }
+  ],
+  "30:25": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    }
+  ],
+  "30:26": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    }
+  ],
+  "30:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    }
+  ],
+  "30:28": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sift",
+      "tw_match": "sift"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "30:29": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "30:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "raging",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "consuming",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    }
+  ],
+  "30:31": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "30:32": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    }
+  ],
+  "30:33": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "31:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "descend",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    }
+  ],
+  "31:5": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "31:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "31:8": [
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "32:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "32:2": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "32:3": [],
+  "32:4": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "32:5": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    }
+  ],
+  "32:6": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "32:7": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "32:8": [
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    }
+  ],
+  "32:9": [
+    {
+      "surface": "Haughty",
+      "tw_match": "haughty"
+    }
+  ],
+  "32:10": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "grape",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "32:11": [
+    {
+      "surface": "Tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "haughty",
+      "tw_match": "haughty"
+    },
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "waists",
+      "tw_match": "waist"
+    }
+  ],
+  "32:12": [
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    }
+  ],
+  "32:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "32:14": [
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "deserted",
+      "tw_match": "deserted"
+    },
+    {
+      "surface": "watchtower",
+      "tw_match": "watchtower"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "32:15": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "32:16": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "32:17": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "32:18": [
+    {
+      "surface": "peaceful",
+      "tw_match": "peaceful"
+    }
+  ],
+  "32:19": [
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "annihilated",
+      "tw_match": "annihilate"
+    }
+  ],
+  "32:20": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "33:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "betrayer",
+      "tw_match": "betrayer"
+    },
+    {
+      "surface": "betrayed",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "betraying",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "betray",
+      "tw_match": "betray"
+    }
+  ],
+  "33:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "33:3": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "33:4": [
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    }
+  ],
+  "33:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "33:6": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "33:7": [
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "33:8": [
+    {
+      "surface": "deserted",
+      "tw_match": "deserted"
+    },
+    {
+      "surface": "covenants",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "33:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "mourns",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "Sharon",
+      "tw_match": "Sharon"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    }
+  ],
+  "33:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "33:11": [
+    {
+      "surface": "conceive",
+      "tw_match": "conceive"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "33:12": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "33:13": [
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "33:14": [
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "godless",
+      "tw_match": "godless"
+    },
+    {
+      "surface": "consuming",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "33:15": [
+    {
+      "surface": "shakes",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "33:16": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "33:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "33:18": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    }
+  ],
+  "33:19": [
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "interpreting",
+      "tw_match": "interpret"
+    }
+  ],
+  "33:20": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "festivals",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "33:21": [
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "33:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "33:23": [
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "33:24": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "34:1": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "34:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "34:3": [
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "34:4": [
+    {
+      "surface": "host of the heavens",
+      "tw_match": "host of the heavens"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    }
+  ],
+  "34:5": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "descends",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "34:6": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "34:7": [
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "34:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "34:9": [
+    {
+      "surface": "sulfur",
+      "tw_match": "sulfur"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "34:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    }
+  ],
+  "34:11": [],
+  "34:12": [
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "34:13": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "thistles",
+      "tw_match": "thistle"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "34:14": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "34:15": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "34:16": [
+    {
+      "surface": "Search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "34:17": [
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "35:1": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    }
+  ],
+  "35:2": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "Sharon",
+      "tw_match": "Sharon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "35:3": [],
+  "35:4": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "35:5": [],
+  "35:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "deer",
+      "tw_match": "deer"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    }
+  ],
+  "35:7": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "reeds",
+      "tw_match": "reed"
+    }
+  ],
+  "35:8": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "35:9": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "35:10": [
+    {
+      "surface": "ransomed",
+      "tw_match": "ransomed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    }
+  ],
+  "36:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "36:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "36:3": [
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    }
+  ],
+  "36:4": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    }
+  ],
+  "36:5": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    }
+  ],
+  "36:6": [
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "36:7": [
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "36:8": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "36:9": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "36:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "36:11": [
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Aramaic",
+      "tw_match": "Aramaic"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "36:12": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "36:13": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "36:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    }
+  ],
+  "36:15": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "36:16": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    }
+  ],
+  "36:17": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    }
+  ],
+  "36:18": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "36:19": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "36:20": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "36:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "36:22": [
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "37:1": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "37:2": [
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "37:3": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "37:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    }
+  ],
+  "37:5": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    }
+  ],
+  "37:6": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "insulted",
+      "tw_match": "insult"
+    }
+  ],
+  "37:7": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "37:8": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "37:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "37:10": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "37:11": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "37:12": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    },
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    }
+  ],
+  "37:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    }
+  ],
+  "37:14": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "37:15": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "37:16": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "37:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "37:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "37:19": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "37:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "37:21": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "37:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "shakes",
+      "tw_match": "shake"
+    }
+  ],
+  "37:23": [
+    {
+      "surface": "insulted",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "37:24": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "cypresses",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    }
+  ],
+  "37:25": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "37:26": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "devastate",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "fortressed",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "37:27": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "37:28": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "raging",
+      "tw_match": "rage"
+    }
+  ],
+  "37:29": [
+    {
+      "surface": "raging",
+      "tw_match": "rage"
+    }
+  ],
+  "37:30": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "37:31": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "37:32": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "37:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "siegeworks",
+      "tw_match": "siegeworks"
+    }
+  ],
+  "37:34": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "37:35": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "37:36": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "37:37": [
+    {
+      "surface": "Sennacherib",
+      "tw_match": "Sennacherib"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    }
+  ],
+  "37:38": [
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ararat",
+      "tw_match": "Ararat"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "38:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Amoz",
+      "tw_match": "Amoz"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "38:2": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "38:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "38:4": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    }
+  ],
+  "38:5": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "38:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "38:7": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "38:8": [
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    }
+  ],
+  "38:9": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "38:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "38:11": [
+    {
+      "surface": "Yah",
+      "tw_match": "Yah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "38:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "38:13": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "38:14": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "38:15": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "38:16": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    }
+  ],
+  "38:17": [
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "38:18": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    }
+  ],
+  "38:19": [
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    }
+  ],
+  "38:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "38:21": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    }
+  ],
+  "38:22": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "39:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "39:2": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "storehouse",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "39:3": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "39:4": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "39:5": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "39:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "39:7": [
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "39:8": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "40:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "40:2": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "pardoned",
+      "tw_match": "pardoned"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "40:3": [
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "40:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "40:5": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "40:6": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "40:7": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "40:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "40:9": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "40:10": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "40:11": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "ewes",
+      "tw_match": "ewe"
+    }
+  ],
+  "40:12": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "40:13": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "counselor",
+      "tw_match": "counselor"
+    }
+  ],
+  "40:14": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "40:15": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "40:16": [
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "40:17": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "40:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    }
+  ],
+  "40:19": [
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "40:20": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "chooses",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    }
+  ],
+  "40:21": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "40:22": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "40:23": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "40:24": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "carries",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "40:25": [
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    }
+  ],
+  "40:26": [
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "40:27": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "40:28": [
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Creator",
+      "tw_match": "creator"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "40:29": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "40:30": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "40:31": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "eagles",
+      "tw_match": "eagle"
+    }
+  ],
+  "41:1": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "trial",
+      "tw_match": "trial"
+    }
+  ],
+  "41:2": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "tramples",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "41:3": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "41:4": [
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "41:5": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    }
+  ],
+  "41:6": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "41:7": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "41:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "41:9": [
+    {
+      "surface": "seizing",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "41:10": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "41:11": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "disgraced",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "41:12": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "quarreled",
+      "tw_match": "quarrel"
+    }
+  ],
+  "41:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "41:14": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    }
+  ],
+  "41:15": [
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "thresh",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    }
+  ],
+  "41:16": [
+    {
+      "surface": "winnow",
+      "tw_match": "winnow"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "41:17": [
+    {
+      "surface": "look for",
+      "tw_match": "look for"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "41:18": [
+    {
+      "surface": "fountains",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "41:19": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "acacia",
+      "tw_match": "acacia"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    }
+  ],
+  "41:20": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    }
+  ],
+  "41:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "41:22": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "41:23": [
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "41:24": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "chooses",
+      "tw_match": "choose"
+    }
+  ],
+  "41:25": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "41:26": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    }
+  ],
+  "41:27": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "41:28": [
+    {
+      "surface": "counseled",
+      "tw_match": "counsel"
+    }
+  ],
+  "41:29": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    }
+  ],
+  "42:1": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "42:2": [
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "42:3": [
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "quench",
+      "tw_match": "quench"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "42:4": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "42:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "42:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "42:7": [
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "42:8": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "42:9": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    }
+  ],
+  "42:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "descend",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "42:11": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Kedar",
+      "tw_match": "Kedar"
+    }
+  ],
+  "42:12": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "42:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "stir up",
+      "tw_match": "stir up"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "42:14": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "42:15": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "42:16": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "42:17": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "42:18": [],
+  "42:19": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "42:20": [],
+  "42:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    }
+  ],
+  "42:22": [
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "trapped",
+      "tw_match": "trapped"
+    },
+    {
+      "surface": "pits",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "42:23": [],
+  "42:24": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "robber",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "42:25": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "43:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "creator",
+      "tw_match": "creator"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "43:2": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "43:3": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    }
+  ],
+  "43:4": [
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "43:5": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "43:6": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "43:7": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "43:8": [],
+  "43:9": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "43:10": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "43:11": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "savior",
+      "tw_match": "savior"
+    }
+  ],
+  "43:12": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "43:13": [],
+  "43:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "43:15": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Creator",
+      "tw_match": "creator"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    }
+  ],
+  "43:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "43:17": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "quenched",
+      "tw_match": "quenched"
+    }
+  ],
+  "43:18": [],
+  "43:19": [
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "43:20": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "chosen people",
+      "tw_match": "chosen people"
+    }
+  ],
+  "43:21": [
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    }
+  ],
+  "43:22": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "43:23": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "43:24": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "43:25": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "43:26": [
+    {
+      "surface": "Remind",
+      "tw_match": "remind"
+    }
+  ],
+  "43:27": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    }
+  ],
+  "43:28": [
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "reviling",
+      "tw_match": "revile"
+    }
+  ],
+  "44:1": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "44:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "44:3": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "44:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "44:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "44:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "44:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "44:8": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "44:9": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "44:10": [
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    }
+  ],
+  "44:11": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "44:12": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "44:13": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "figure",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "44:14": [
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "fir",
+      "tw_match": "fir"
+    }
+  ],
+  "44:15": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "kneels",
+      "tw_match": "kneel"
+    }
+  ],
+  "44:16": [],
+  "44:17": [
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "carved image",
+      "tw_match": "carved image"
+    },
+    {
+      "surface": "kneels",
+      "tw_match": "kneel"
+    },
+    {
+      "surface": "worships",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "prays",
+      "tw_match": "pray"
+    }
+  ],
+  "44:18": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "44:19": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "44:20": [
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "44:21": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "44:22": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rebellions",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "44:23": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "44:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "44:25": [
+    {
+      "surface": "disgracing",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "soothsayers",
+      "tw_match": "soothsayer"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "mockery",
+      "tw_match": "mockery"
+    }
+  ],
+  "44:26": [
+    {
+      "surface": "confirming",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "fulfilling",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "44:27": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "44:28": [
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    }
+  ],
+  "45:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "Cyrus",
+      "tw_match": "Cyrus"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "45:2": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "45:3": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "45:4": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "45:5": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    }
+  ],
+  "45:6": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "45:7": [
+    {
+      "surface": "creating",
+      "tw_match": "create"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "45:8": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    }
+  ],
+  "45:9": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "creator",
+      "tw_match": "creator"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "45:10": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "begetting",
+      "tw_match": "beget"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "45:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Maker",
+      "tw_match": "Maker"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "45:12": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "45:13": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "45:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "45:15": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    }
+  ],
+  "45:16": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "disgraced",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "45:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    }
+  ],
+  "45:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "creator",
+      "tw_match": "creator"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "45:19": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    }
+  ],
+  "45:20": [
+    {
+      "surface": "Assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "refugees",
+      "tw_match": "refugee"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    }
+  ],
+  "45:21": [
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    }
+  ],
+  "45:22": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "45:23": [
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "45:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "raged",
+      "tw_match": "rage"
+    }
+  ],
+  "45:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "46:1": [
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "46:2": [
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "kneel",
+      "tw_match": "kneel"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "46:3": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "46:4": [
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "46:5": [],
+  "46:6": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "46:7": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "46:8": [
+    {
+      "surface": "rebels",
+      "tw_match": "rebel"
+    }
+  ],
+  "46:9": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "46:10": [
+    {
+      "surface": "announcing",
+      "tw_match": "announce"
+    }
+  ],
+  "46:11": [
+    {
+      "surface": "Calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "46:12": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "46:13": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "47:1": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "47:2": [
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "47:3": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    }
+  ],
+  "47:4": [
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "47:5": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    }
+  ],
+  "47:6": [
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "47:7": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "47:8": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "47:9": [
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sorceries",
+      "tw_match": "sorceries"
+    }
+  ],
+  "47:10": [
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "47:11": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "47:12": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "sorceries",
+      "tw_match": "sorceries"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    }
+  ],
+  "47:13": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "seers",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "47:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "47:15": [
+    {
+      "surface": "labored",
+      "tw_match": "labored"
+    }
+  ],
+  "48:1": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "48:2": [
+    {
+      "surface": "holy city",
+      "tw_match": "holy city"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "48:3": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "48:4": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "48:5": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "carved figure",
+      "tw_match": "carved figure"
+    },
+    {
+      "surface": "figure",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "ordained",
+      "tw_match": "ordained"
+    }
+  ],
+  "48:6": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "48:7": [
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "48:8": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "48:9": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "48:10": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "48:11": [
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "48:12": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "48:13": [
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "48:14": [
+    {
+      "surface": "Assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "48:15": [],
+  "48:16": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "48:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "48:18": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "48:19": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "grains",
+      "tw_match": "grain"
+    }
+  ],
+  "48:20": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "48:21": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "48:22": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "49:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "49:2": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "49:3": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "49:4": [
+    {
+      "surface": "labored",
+      "tw_match": "labored"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "49:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "49:6": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "49:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "49:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "49:9": [],
+  "49:10": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "49:11": [],
+  "49:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "49:13": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "49:14": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "49:15": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "49:16": [
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    }
+  ],
+  "49:17": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "49:18": [
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    }
+  ],
+  "49:19": [
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "devastation",
+      "tw_match": "devastation"
+    }
+  ],
+  "49:20": [],
+  "49:21": [
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    }
+  ],
+  "49:22": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "49:23": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "queens",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "49:24": [
+    {
+      "surface": "spoils",
+      "tw_match": "spoils"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    }
+  ],
+  "49:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "spoils",
+      "tw_match": "spoils"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "49:26": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "50:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    }
+  ],
+  "50:2": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "50:3": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "50:4": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "50:5": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    }
+  ],
+  "50:6": [
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "50:7": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "disgraced",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "50:8": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    }
+  ],
+  "50:9": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "condemns",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "50:10": [
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "50:11": [
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "51:1": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    }
+  ],
+  "51:2": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "51:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Eden",
+      "tw_match": "Eden"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "51:4": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "51:5": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "51:6": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "51:7": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    }
+  ],
+  "51:8": [
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "51:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "51:10": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "51:11": [
+    {
+      "surface": "ransomed",
+      "tw_match": "ransomed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "51:12": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "51:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Maker",
+      "tw_match": "Maker"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "51:14": [
+    {
+      "surface": "freed",
+      "tw_match": "freed"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "51:15": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "51:16": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "51:17": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "staggering",
+      "tw_match": "stagger"
+    }
+  ],
+  "51:18": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "51:19": [
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "51:20": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "51:21": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "51:22": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "staggering",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "51:23": [
+    {
+      "surface": "tormentors",
+      "tw_match": "tormentors"
+    },
+    {
+      "surface": "Lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "52:1": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "holy city",
+      "tw_match": "holy city"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    }
+  ],
+  "52:2": [
+    {
+      "surface": "Shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "52:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "52:4": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "52:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "52:6": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "52:7": [
+    {
+      "surface": "bearer",
+      "tw_match": "bearer"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "announcing",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    }
+  ],
+  "52:8": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "52:9": [
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "52:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "52:11": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "bearers",
+      "tw_match": "bearers"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "52:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "52:13": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "52:14": [],
+  "52:15": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "53:1": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "53:2": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "53:3": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "53:4": [
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    }
+  ],
+  "53:5": [
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "53:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "53:7": [
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "53:8": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "53:9": [
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "53:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "53:11": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "justify",
+      "tw_match": "justify"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "53:12": [
+    {
+      "surface": "spoils",
+      "tw_match": "spoils"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "intercession",
+      "tw_match": "intercession"
+    }
+  ],
+  "54:1": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "54:2": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "54:3": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "54:4": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    },
+    {
+      "surface": "disgraced",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "54:5": [
+    {
+      "surface": "Maker",
+      "tw_match": "Maker"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "54:6": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "54:7": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "54:8": [
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "54:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "rebuking",
+      "tw_match": "rebuke"
+    }
+  ],
+  "54:10": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "54:11": [
+    {
+      "surface": "Afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    }
+  ],
+  "54:12": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "54:13": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "54:14": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "54:15": [],
+  "54:16": [
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "54:17": [
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "55:1": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "55:2": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "55:3": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "covenant loyalty",
+      "tw_match": "covenant loyalty"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "55:4": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "55:5": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    }
+  ],
+  "55:6": [
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "55:7": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "55:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "55:9": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "55:10": [
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "sower",
+      "tw_match": "sower"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "55:11": [],
+  "55:12": [
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    }
+  ],
+  "55:13": [
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "56:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "56:2": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "defiling",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "56:3": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "56:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "pleases",
+      "tw_match": "please"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "56:5": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    }
+  ],
+  "56:6": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "defiling",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "56:7": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "welcome",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "56:8": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "56:9": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "56:10": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    }
+  ],
+  "56:11": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "discernment",
+      "tw_match": "discernment"
+    }
+  ],
+  "56:12": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "strong drink",
+      "tw_match": "strong drink"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "57:1": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "understands",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "57:2": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    }
+  ],
+  "57:3": [
+    {
+      "surface": "sorcerer",
+      "tw_match": "sorcerer"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "adulterer",
+      "tw_match": "adulterer"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "57:4": [
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "57:5": [
+    {
+      "surface": "oaks",
+      "tw_match": "oak"
+    }
+  ],
+  "57:6": [
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "57:7": [
+    {
+      "surface": "lofty",
+      "tw_match": "lofty"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "57:8": [
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "57:9": [
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "57:10": [],
+  "57:11": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "57:12": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "57:13": [
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "57:14": [
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    }
+  ],
+  "57:15": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "57:16": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "57:17": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "57:18": [
+    {
+      "surface": "mourners",
+      "tw_match": "mourner"
+    }
+  ],
+  "57:19": [
+    {
+      "surface": "Creator",
+      "tw_match": "creator"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "57:20": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "57:21": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "58:1": [
+    {
+      "surface": "Cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "58:2": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "58:3": [
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "laborers",
+      "tw_match": "laborer"
+    }
+  ],
+  "58:4": [
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "quarrel",
+      "tw_match": "quarrel"
+    }
+  ],
+  "58:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    }
+  ],
+  "58:6": [
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "bonds",
+      "tw_match": "bonds"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "58:7": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "58:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "58:9": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "58:10": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "58:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "58:12": [
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "58:13": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    }
+  ],
+  "58:14": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "59:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "59:2": [
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "59:3": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "59:4": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "pleads",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "vanity",
+      "tw_match": "vanity"
+    },
+    {
+      "surface": "conceiving",
+      "tw_match": "conceive"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "59:5": [
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    }
+  ],
+  "59:6": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "59:7": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "59:8": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "59:9": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "59:10": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "59:11": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "59:12": [
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "59:13": [
+    {
+      "surface": "rebelling",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "conceiving",
+      "tw_match": "conceive"
+    }
+  ],
+  "59:14": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "stumbles",
+      "tw_match": "stumble"
+    }
+  ],
+  "59:15": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "59:16": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "59:17": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "breastplate",
+      "tw_match": "breastplate"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    }
+  ],
+  "59:18": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "59:19": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "59:20": [
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "59:21": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "60:1": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "60:2": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "60:3": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "60:4": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "60:5": [
+    {
+      "surface": "awe",
+      "tw_match": "awe"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "60:6": [
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "60:7": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Kedar",
+      "tw_match": "Kedar"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "acceptance",
+      "tw_match": "acceptance"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "60:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    }
+  ],
+  "60:9": [
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "60:10": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "60:11": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "60:12": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "60:13": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "fir",
+      "tw_match": "fir"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    }
+  ],
+  "60:14": [
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "60:15": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "60:16": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "60:17": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    }
+  ],
+  "60:18": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "devastation",
+      "tw_match": "devastation"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    }
+  ],
+  "60:19": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "60:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "60:21": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "planting",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "60:22": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "61:1": [
+    {
+      "surface": "Spirit of the Lord",
+      "tw_match": "Spirit of the Lord"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "61:2": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "61:3": [
+    {
+      "surface": "mourners",
+      "tw_match": "mourner"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "oaks",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "planting",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "61:4": [
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "desolations",
+      "tw_match": "desolations"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "61:5": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "61:6": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "61:7": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "61:8": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "unjust",
+      "tw_match": "unjust"
+    },
+    {
+      "surface": "robbery",
+      "tw_match": "robbery"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "61:9": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "61:10": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    }
+  ],
+  "61:11": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "sowing",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "62:1": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "62:2": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "62:3": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "62:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "Married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "married",
+      "tw_match": "married"
+    }
+  ],
+  "62:5": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "marries",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "62:6": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "reminding",
+      "tw_match": "remind"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "62:7": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "62:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    }
+  ],
+  "62:9": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "62:10": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "62:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "announces",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "62:12": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "63:1": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "63:2": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    }
+  ],
+  "63:3": [
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "63:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "63:5": [
+    {
+      "surface": "wondered",
+      "tw_match": "wonder"
+    }
+  ],
+  "63:6": [
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "63:7": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praiseworthy",
+      "tw_match": "praiseworthy"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "63:8": [
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    }
+  ],
+  "63:9": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "63:10": [
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "63:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "63:12": [
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    }
+  ],
+  "63:13": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "63:14": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "63:15": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "63:16": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    }
+  ],
+  "63:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "harden",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "63:18": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "63:19": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "64:1": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "64:2": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    }
+  ],
+  "64:3": [
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    }
+  ],
+  "64:4": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "64:5": [
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "64:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "64:7": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "64:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "64:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "64:10": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "64:11": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "64:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "humiliate",
+      "tw_match": "humiliate"
+    }
+  ],
+  "65:1": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "65:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "65:3": [
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "65:4": [
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "pig",
+      "tw_match": "pig"
+    }
+  ],
+  "65:5": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "65:6": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "65:7": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    }
+  ],
+  "65:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "65:9": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "65:10": [
+    {
+      "surface": "Sharon",
+      "tw_match": "Sharon"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "65:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "65:12": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "65:13": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "65:14": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "65:15": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "65:16": [
+    {
+      "surface": "blesses",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    }
+  ],
+  "65:17": [
+    {
+      "surface": "create",
+      "tw_match": "create"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "65:18": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "create",
+      "tw_match": "create"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "65:19": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "65:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "elder",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "65:21": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "65:22": [
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "65:23": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "65:24": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "65:25": [
+    {
+      "surface": "wolf",
+      "tw_match": "wolf"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "66:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "66:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "trembles",
+      "tw_match": "tremble"
+    }
+  ],
+  "66:3": [
+    {
+      "surface": "slaughters",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "pig",
+      "tw_match": "pig"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "blesses",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    }
+  ],
+  "66:4": [
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "66:5": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "66:6": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "66:7": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "delivers",
+      "tw_match": "deliver"
+    }
+  ],
+  "66:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "66:9": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "66:10": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    }
+  ],
+  "66:11": [
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    }
+  ],
+  "66:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "66:13": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "66:14": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "66:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "66:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "66:17": [
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "pig",
+      "tw_match": "pig"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "66:18": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "66:19": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Tubal",
+      "tw_match": "Tubal"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "66:20": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "mules",
+      "tw_match": "mule"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "66:21": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "66:22": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "66:23": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "66:24": [
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "quenched",
+      "tw_match": "quenched"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_JAS.json
+++ b/sources/keyword_data/keywords_JAS.json
@@ -1,0 +1,1665 @@
+{
+  "1:1": [
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "the twelve",
+      "tw_match": "the twelve"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "dispersion",
+      "tw_match": "dispersion"
+    },
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "trials",
+      "tw_match": "trial"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reproaching",
+      "tw_match": "reproach"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "minded",
+      "tw_match": "mind"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "exaltation",
+      "tw_match": "exaltation"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "lowliness",
+      "tw_match": "lowliness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "trial",
+      "tw_match": "trial"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "tempted",
+      "tw_match": "tempt"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "tempts",
+      "tw_match": "tempt"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "tempted",
+      "tw_match": "tempt"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "word of truth",
+      "tw_match": "word of truth"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "1:22": [],
+  "1:23": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "deceiving",
+      "tw_match": "deceive"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "Pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "favoritism",
+      "tw_match": "favoritism"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "distinguished",
+      "tw_match": "distinguish"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "heirs",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "dishonored",
+      "tw_match": "dishonored"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "blaspheme",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "committing",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "boasts",
+      "tw_match": "boast"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "2:15": [],
+  "2:16": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "perfected",
+      "tw_match": "perfect"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "member",
+      "tw_match": "member"
+    },
+    {
+      "surface": "boasts",
+      "tw_match": "boast"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "olives",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "grapevine",
+      "tw_match": "grapevine"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "lusts",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "covet",
+      "tw_match": "covet"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "lusts",
+      "tw_match": "lust"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "adulteresses",
+      "tw_match": "adulteress"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "submitted",
+      "tw_match": "submitted"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "minded",
+      "tw_match": "mind"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "5:1": [],
+  "5:2": [],
+  "5:3": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "last days",
+      "tw_match": "last days"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "reaped",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "harvesting",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "compassionate",
+      "tw_match": "compassionate"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "passions",
+      "tw_match": "passions"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "5:19": [],
+  "5:20": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_JDG.json
+++ b/sources/keyword_data/keywords_JDG.json
@@ -1,0 +1,10932 @@
+{
+  "1:1": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Kiriath Arba",
+      "tw_match": "Kiriath Arba"
+    }
+  ],
+  "1:11": [],
+  "1:12": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "Palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "Ashkelon",
+      "tw_match": "Ashkelon"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Anak",
+      "tw_match": "Anak"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    }
+  ],
+  "1:30": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "1:31": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    }
+  ],
+  "1:32": [
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    }
+  ],
+  "1:33": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "1:34": [
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "1:35": [
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "1:36": [
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Ashtoreths",
+      "tw_match": "Ashtoreth"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "whored",
+      "tw_match": "whored"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Lebo Hamath",
+      "tw_match": "Lebo Hamath"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Asherahs",
+      "tw_match": "Asherah"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram Naharaim",
+      "tw_match": "Aram Naharaim"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "savior",
+      "tw_match": "savior"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "Palms",
+      "tw_match": "palm"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "savior",
+      "tw_match": "savior"
+    },
+    {
+      "surface": "Benjaminite",
+      "tw_match": "Benjaminite"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "bearers",
+      "tw_match": "bearers"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "3:23": [],
+  "3:24": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "images",
+      "tw_match": "image"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "3:29": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "3:30": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "3:31": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "prophetess",
+      "tw_match": "prophetess"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    }
+  ],
+  "4:8": [],
+  "4:9": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "sheepfolds",
+      "tw_match": "sheepfold"
+    },
+    {
+      "surface": "piping",
+      "tw_match": "pipe"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "sojourn",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "reproaching",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "Kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "Curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Cursing",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "princesses",
+      "tw_match": "princess"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    }
+  ],
+  "5:31": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:28": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    }
+  ],
+  "6:31": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "6:32": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "6:33": [
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "6:34": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    }
+  ],
+  "6:35": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "6:36": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "6:37": [
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "6:38": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:39": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "6:40": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "kneels",
+      "tw_match": "kneel"
+    }
+  ],
+  "7:6": [],
+  "7:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dreamed",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "7:16": [],
+  "7:17": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    }
+  ],
+  "7:21": [],
+  "7:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gleanings",
+      "tw_match": "gleanings"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Crossing",
+      "tw_match": "cross"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "Rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Ishmaelites",
+      "tw_match": "Ishmaelite"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "whored",
+      "tw_match": "whored"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "Joash",
+      "tw_match": "Joash"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "whored",
+      "tw_match": "whored"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Gideon",
+      "tw_match": "Gideon"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "Reign",
+      "tw_match": "reign"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "deserving",
+      "tw_match": "deserve"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "ruled",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "9:32": [],
+  "9:33": [],
+  "9:34": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "9:35": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:36": [],
+  "9:37": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "Diviners",
+      "tw_match": "diviner"
+    }
+  ],
+  "9:38": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "9:39": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:40": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "9:41": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "9:42": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:43": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "9:44": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "9:45": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    }
+  ],
+  "9:46": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:47": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    }
+  ],
+  "9:48": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "axes",
+      "tw_match": "ax"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "9:49": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "9:50": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "9:51": [
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    }
+  ],
+  "9:52": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "9:53": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:54": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "9:55": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    }
+  ],
+  "9:56": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    }
+  ],
+  "9:57": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Abimelech",
+      "tw_match": "Abimelech"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "Gileadite",
+      "tw_match": "Gileadite"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Ashtoreths",
+      "tw_match": "Ashtoreth"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "Gileadite",
+      "tw_match": "Gileadite"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "begotten",
+      "tw_match": "begotten"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:33": [
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:34": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "11:35": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "troubling",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "vengeances",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "11:37": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "virginity",
+      "tw_match": "virginity"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    }
+  ],
+  "11:38": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "virginity",
+      "tw_match": "virginity"
+    }
+  ],
+  "11:39": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:40": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "Gileadite",
+      "tw_match": "Gileadite"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "savior",
+      "tw_match": "savior"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Ephraimite",
+      "tw_match": "Ephraimite"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "Jephthah",
+      "tw_match": "Jephthah"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Gileadite",
+      "tw_match": "Gileadite"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Amalekite",
+      "tw_match": "Amalekite"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "conceive",
+      "tw_match": "conceive"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "conceive",
+      "tw_match": "conceive"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "Nazirite",
+      "tw_match": "Nazirite"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "awesome",
+      "tw_match": "awesome"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "conceive",
+      "tw_match": "conceive"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "Nazirite",
+      "tw_match": "Nazirite"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:11": [],
+  "13:12": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "plowed",
+      "tw_match": "plowed"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ashkelon",
+      "tw_match": "Ashkelon"
+    },
+    {
+      "surface": "spoils",
+      "tw_match": "spoils"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    }
+  ],
+  "15:8": [],
+  "15:9": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "Swear",
+      "tw_match": "swear"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bonds",
+      "tw_match": "bonds"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "harlot",
+      "tw_match": "harlot"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Delilah",
+      "tw_match": "Delilah"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "Delilah",
+      "tw_match": "Delilah"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "Delilah",
+      "tw_match": "Delilah"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "Delilah",
+      "tw_match": "Delilah"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "Delilah",
+      "tw_match": "Delilah"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Nazirite",
+      "tw_match": "Nazirite"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "Delilah",
+      "tw_match": "Delilah"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "16:22": [],
+  "16:23": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "columns",
+      "tw_match": "column"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "columns",
+      "tw_match": "column"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "16:29": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "columns",
+      "tw_match": "column"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "16:30": [
+    {
+      "surface": "Samson",
+      "tw_match": "Samson"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "16:31": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "burial place",
+      "tw_match": "burial place"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Consecrating",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "molded",
+      "tw_match": "molded"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "molded",
+      "tw_match": "molded"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "sojourn",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "sojourn",
+      "tw_match": "sojourn"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "possessing",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "humiliating",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "18:8": [],
+  "18:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "molded",
+      "tw_match": "molded"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "molded",
+      "tw_match": "molded"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "molded",
+      "tw_match": "molded"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "deliverer",
+      "tw_match": "deliverer"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "18:31": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "whored",
+      "tw_match": "whored"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "Jebus",
+      "tw_match": "Jebus"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "Jebus",
+      "tw_match": "Jebus"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Benjaminite",
+      "tw_match": "Benjaminite"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "maidservant",
+      "tw_match": "maidservant"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "19:25": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "19:26": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "19:27": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    }
+  ],
+  "19:28": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "19:30": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "cornerstones",
+      "tw_match": "cornerstone"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "people of God",
+      "tw_match": "people of God"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "murdered",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:29": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    }
+  ],
+  "20:30": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "20:31": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:32": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:33": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    }
+  ],
+  "20:34": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "20:35": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "20:36": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    }
+  ],
+  "20:37": [
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "20:38": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:39": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "20:40": [
+    {
+      "surface": "column",
+      "tw_match": "column"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "20:41": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "alarmed",
+      "tw_match": "alarmed"
+    }
+  ],
+  "20:42": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "20:43": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    }
+  ],
+  "20:44": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "20:45": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    },
+    {
+      "surface": "gleaned",
+      "tw_match": "glean"
+    }
+  ],
+  "20:46": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "20:47": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "20:48": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "21:11": [],
+  "21:12": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "catch",
+      "tw_match": "catch"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_JER.json
+++ b/sources/keyword_data/keywords_JER.json
@@ -1,0 +1,28697 @@
+{
+  "1:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "appointing",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worshipped",
+      "tw_match": "worship"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "profitable",
+      "tw_match": "profitable"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Kedar",
+      "tw_match": "Kedar"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "evils",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "cisterns",
+      "tw_match": "cistern"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Memphis",
+      "tw_match": "Memphis"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:30": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "2:31": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "2:32": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:33": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "2:34": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "2:35": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "2:36": [
+    {
+      "surface": "shamed",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "2:37": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "evils",
+      "tw_match": "evil"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "prostituted",
+      "tw_match": "prostitute"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Box of the Covenant of Yahweh",
+      "tw_match": "Box of the Covenant of Yahweh"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Plow",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "unplowed",
+      "tw_match": "unplowed"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "winnow",
+      "tw_match": "winnow"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "eagles",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "unjust",
+      "tw_match": "unjust"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "announces",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "Report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "alarm",
+      "tw_match": "alarm"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "devastation",
+      "tw_match": "devastation"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "horseman",
+      "tw_match": "horseman"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "lusting",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "harden",
+      "tw_match": "harden"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "wolf",
+      "tw_match": "wolf"
+    },
+    {
+      "surface": "deserts",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "devastate",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "leopard",
+      "tw_match": "leopard"
+    },
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "betrayed",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    },
+    {
+      "surface": "weeks",
+      "tw_match": "week"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "trespass",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "legal",
+      "tw_match": "legal"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "Desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "5:31": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "siegeworks",
+      "tw_match": "siegeworks"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "dishonest",
+      "tw_match": "dishonest"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "compassionate",
+      "tw_match": "compassionate"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "reports",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    }
+  ],
+  "6:28": [
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "gossip",
+      "tw_match": "gossip"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "Temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "murdering",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "committing",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "swearing",
+      "tw_match": "swearing"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "provoking",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "consecration",
+      "tw_match": "consecration"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "7:30": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    }
+  ],
+  "7:31": [],
+  "7:32": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "7:33": [
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "7:34": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "groom",
+      "tw_match": "groom"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stallion",
+      "tw_match": "stallion"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "possessing",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "dishonest",
+      "tw_match": "dishonest"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "Gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "Hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "stallions",
+      "tw_match": "stallion"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "snakes",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:18": [],
+  "8:19": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "horrible",
+      "tw_match": "horrible"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "adulterers",
+      "tw_match": "adulterer"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "deceives",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "slander",
+      "tw_match": "slander"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "Committing",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "understands",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Baals",
+      "tw_match": "Baal"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "storehouse",
+      "tw_match": "storehouse"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "mockery",
+      "tw_match": "mockery"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "molder",
+      "tw_match": "molder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prospered",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "desolated",
+      "tw_match": "desolated"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "slaughtering",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "slaughtering",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "betrayed",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "mourns",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "consuming",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "harvested",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "thorn",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "13:4": [],
+  "13:5": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "hardness",
+      "tw_match": "hardness"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "hoping",
+      "tw_match": "hope"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "crowns",
+      "tw_match": "crown"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "leopard",
+      "tw_match": "leopard"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "perishes",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    }
+  ],
+  "13:26": [],
+  "13:27": [
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "trenches",
+      "tw_match": "trenches"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "dishonored",
+      "tw_match": "dishonored"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "doe",
+      "tw_match": "doe"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "faithless",
+      "tw_match": "faithless"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "Hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "saves",
+      "tw_match": "save"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "admit",
+      "tw_match": "admit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "assign",
+      "tw_match": "assign"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "winnow",
+      "tw_match": "winnow"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "persecute",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "patient",
+      "tw_match": "patient"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "celebrated",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "16:2": [],
+  "16:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "groom",
+      "tw_match": "groom"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "fishermen",
+      "tw_match": "fishermen"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "inherited",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "enslave",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "searches",
+      "tw_match": "search"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "tests",
+      "tw_match": "test"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "proclamations",
+      "tw_match": "proclamation"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "17:23": [],
+  "17:24": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "17:25": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "17:26": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:27": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "spoiled",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "proclamation",
+      "tw_match": "proclamation"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "horrible",
+      "tw_match": "horrible"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "proclaims",
+      "tw_match": "proclaim"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "traps",
+      "tw_match": "trap"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "19:10": [],
+  "19:11": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "object of horror",
+      "tw_match": "object of horror"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "laughingstock",
+      "tw_match": "laughingstock"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "mocks",
+      "tw_match": "mock"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "consuming",
+      "tw_match": "consume"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "Report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "revenge",
+      "tw_match": "revenge"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "stagger",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Zephaniah",
+      "tw_match": "Zephaniah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "House",
+      "tw_match": "house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "quench",
+      "tw_match": "quench"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "mistreat",
+      "tw_match": "mistreat"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "unjust",
+      "tw_match": "unjust"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "burial",
+      "tw_match": "burial"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "safe",
+      "tw_match": "safe"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "pleases",
+      "tw_match": "please"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "Land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "shepherding",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "adulterers",
+      "tw_match": "adulterer"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "horrible",
+      "tw_match": "horrible"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "announcing",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "council",
+      "tw_match": "council"
+    },
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "carried out",
+      "tw_match": "carried out"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "council",
+      "tw_match": "council"
+    },
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "corrupt",
+      "tw_match": "corrupt"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    }
+  ],
+  "23:26": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    }
+  ],
+  "23:27": [
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:30": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "23:31": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "proclamations",
+      "tw_match": "proclamation"
+    }
+  ],
+  "23:32": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    }
+  ],
+  "23:33": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:34": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "23:35": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "23:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "perverted",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "23:37": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:38": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:39": [],
+  "23:40": [
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "insult",
+      "tw_match": "insult"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Figs",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldea",
+      "tw_match": "Chaldea"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "frightening",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "subject",
+      "tw_match": "subject"
+    },
+    {
+      "surface": "proverbs",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "corruption",
+      "tw_match": "corruption"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "groom",
+      "tw_match": "groom"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "stagger",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    }
+  ],
+  "25:20": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistia",
+      "tw_match": "Philistia"
+    },
+    {
+      "surface": "Ashkelon",
+      "tw_match": "Ashkelon"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    }
+  ],
+  "25:21": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "25:22": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "25:23": [],
+  "25:24": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Arabia",
+      "tw_match": "Arabia"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "25:25": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "Medes",
+      "tw_match": "Medes"
+    }
+  ],
+  "25:26": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "25:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "25:28": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "25:29": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "25:30": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "25:31": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "25:32": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "25:33": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "25:34": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "25:35": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "25:36": [
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "25:37": [
+    {
+      "surface": "peaceful",
+      "tw_match": "peaceful"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:38": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "announcing",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "announcing",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "gateway",
+      "tw_match": "gateway"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "26:18": [
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "plowed",
+      "tw_match": "plowed"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "26:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "26:21": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "26:22": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    }
+  ],
+  "26:23": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    }
+  ],
+  "26:24": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "diviners",
+      "tw_match": "diviner"
+    },
+    {
+      "surface": "seers",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "soothsayers",
+      "tw_match": "soothsayer"
+    },
+    {
+      "surface": "sorcerers",
+      "tw_match": "sorcerer"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "serves",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "27:18": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "27:19": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "27:20": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    }
+  ],
+  "27:21": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "27:22": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "confirm",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "prophesies",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:10": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "29:6": [],
+  "29:7": [
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "intercede",
+      "tw_match": "intercede"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "diviners",
+      "tw_match": "diviner"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "ruled",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "29:12": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "29:13": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "29:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    }
+  ],
+  "29:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "29:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "29:17": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    }
+  ],
+  "29:18": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "horrible",
+      "tw_match": "horrible"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "29:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "29:20": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "29:21": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "29:22": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "persons",
+      "tw_match": "person"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "29:23": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:24": [],
+  "29:25": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Zephaniah",
+      "tw_match": "Zephaniah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "29:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Jehoiada",
+      "tw_match": "Jehoiada"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "29:27": [
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "29:28": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "29:29": [
+    {
+      "surface": "Zephaniah",
+      "tw_match": "Zephaniah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "29:30": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "29:31": [
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "29:32": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    }
+  ],
+  "30:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "30:6": [
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    }
+  ],
+  "30:7": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "30:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "enslave",
+      "tw_match": "enslave"
+    }
+  ],
+  "30:9": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "30:10": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "30:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "unpunished",
+      "tw_match": "unpunished"
+    }
+  ],
+  "30:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:13": [
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    }
+  ],
+  "30:14": [
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "look for",
+      "tw_match": "look for"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "30:15": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "30:16": [
+    {
+      "surface": "consumes",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    }
+  ],
+  "30:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "30:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    }
+  ],
+  "30:19": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    }
+  ],
+  "30:20": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "tormenting",
+      "tw_match": "torment"
+    }
+  ],
+  "30:21": [
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "30:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "30:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "carried out",
+      "tw_match": "carried out"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "31:4": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:5": [
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "31:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:8": [
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "31:10": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "31:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ransomed",
+      "tw_match": "ransomed"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "31:12": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "31:13": [
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "31:14": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    }
+  ],
+  "31:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "31:17": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "31:18": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:19": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    }
+  ],
+  "31:20": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:21": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:22": [
+    {
+      "surface": "faithless",
+      "tw_match": "faithless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "31:23": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "31:24": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "31:25": [],
+  "31:26": [],
+  "31:27": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "31:28": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:29": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Fathers",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "31:30": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "31:31": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "31:32": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:33": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:34": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "31:35": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "31:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "31:37": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "31:38": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    }
+  ],
+  "31:39": [],
+  "31:40": [
+    {
+      "surface": "Kidron Valley",
+      "tw_match": "Kidron Valley"
+    },
+    {
+      "surface": "Horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "32:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    }
+  ],
+  "32:2": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "besieging",
+      "tw_match": "besiege"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "32:3": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "32:4": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    }
+  ],
+  "32:5": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "32:6": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "32:7": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "32:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "32:9": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "32:10": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "32:11": [
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "unsealed",
+      "tw_match": "unsealed"
+    }
+  ],
+  "32:12": [
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "32:13": [
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    }
+  ],
+  "32:14": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "unsealed",
+      "tw_match": "unsealed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "32:15": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "32:16": [
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "32:17": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "32:18": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "32:19": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "deserve",
+      "tw_match": "deserve"
+    }
+  ],
+  "32:20": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "famous",
+      "tw_match": "famous"
+    }
+  ],
+  "32:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "32:22": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "32:23": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "32:24": [
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "32:25": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "32:26": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "32:27": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "32:29": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    }
+  ],
+  "32:30": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "32:31": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "provocation",
+      "tw_match": "provocation"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "32:32": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "32:33": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "32:34": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "abominable",
+      "tw_match": "abominable"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    }
+  ],
+  "32:35": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "32:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "32:37": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "32:38": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:39": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "32:40": [
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "32:41": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "32:42": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "32:43": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "32:44": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "scrolls",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "33:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "33:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "33:3": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mysteries",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "33:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "33:5": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "33:6": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "33:7": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "33:8": [
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "pardon",
+      "tw_match": "pardon"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    }
+  ],
+  "33:9": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "33:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "33:11": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "groom",
+      "tw_match": "groom"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "33:12": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "33:13": [
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "33:14": [
+    {
+      "surface": "Days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "33:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "33:16": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "33:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "33:18": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "33:19": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "33:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "33:21": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "33:22": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "33:23": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "33:24": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "33:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "33:26": [
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "34:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "34:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "34:3": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "34:4": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "34:5": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "34:6": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "34:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "34:8": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    }
+  ],
+  "34:9": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    }
+  ],
+  "34:10": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    }
+  ],
+  "34:11": [
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "freed",
+      "tw_match": "freed"
+    }
+  ],
+  "34:12": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "34:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "34:14": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    }
+  ],
+  "34:15": [
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "34:16": [
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "34:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "Israelites",
+      "tw_match": "Israelites"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "horrible",
+      "tw_match": "horrible"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "34:18": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    }
+  ],
+  "34:19": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    }
+  ],
+  "34:20": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "34:21": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "34:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "35:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "35:2": [
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "35:3": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    }
+  ],
+  "35:4": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "gatekeeper",
+      "tw_match": "gatekeeper"
+    }
+  ],
+  "35:5": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "35:6": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "35:7": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "seeds",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    }
+  ],
+  "35:8": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "35:9": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "35:10": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "35:11": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Chaldean",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Aramean",
+      "tw_match": "Aramean"
+    }
+  ],
+  "35:12": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "35:13": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "35:14": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "proclamations",
+      "tw_match": "proclamation"
+    }
+  ],
+  "35:15": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "35:16": [
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "35:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "35:18": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "35:19": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "36:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "36:2": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "36:3": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "36:4": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "36:5": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    }
+  ],
+  "36:6": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "36:7": [
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    }
+  ],
+  "36:8": [
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "36:9": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "36:10": [
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "36:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "36:12": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    }
+  ],
+  "36:13": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    }
+  ],
+  "36:14": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "36:15": [
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "36:16": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "36:17": [
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "36:18": [
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "36:19": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "36:20": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "36:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    }
+  ],
+  "36:22": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "36:23": [
+    {
+      "surface": "columns",
+      "tw_match": "column"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "36:24": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    }
+  ],
+  "36:25": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "36:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "36:27": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    }
+  ],
+  "36:28": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "36:29": [
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "36:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "descendant",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "36:31": [
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "36:32": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "37:1": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "37:2": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "37:3": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Zephaniah",
+      "tw_match": "Zephaniah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "37:4": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "37:5": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "besieging",
+      "tw_match": "besiege"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "37:6": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "37:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "37:8": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "37:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "37:10": [
+    {
+      "surface": "Chaldean",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "37:11": [
+    {
+      "surface": "Chaldean",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "37:12": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "37:13": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "deserting",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "37:14": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "deserting",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    }
+  ],
+  "37:15": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    }
+  ],
+  "37:16": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "37:17": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "37:18": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "37:19": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "37:20": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    }
+  ],
+  "37:21": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "38:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    }
+  ],
+  "38:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "38:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "38:4": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "38:5": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "38:6": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "38:7": [
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    }
+  ],
+  "38:8": [
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "38:9": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    }
+  ],
+  "38:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    }
+  ],
+  "38:11": [
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    }
+  ],
+  "38:12": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "38:13": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "38:14": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "38:15": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    }
+  ],
+  "38:16": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "38:17": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    }
+  ],
+  "38:18": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "38:19": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "deserted",
+      "tw_match": "deserted"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "38:20": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "38:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "38:22": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "38:23": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "38:24": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "38:25": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "38:26": [
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "38:27": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    }
+  ],
+  "38:28": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "39:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "besieged",
+      "tw_match": "besieged"
+    }
+  ],
+  "39:2": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "39:3": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    }
+  ],
+  "39:4": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    }
+  ],
+  "39:5": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Jordan River",
+      "tw_match": "Jordan River"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    }
+  ],
+  "39:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "noblemen",
+      "tw_match": "noblemen"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "39:7": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "39:8": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "39:9": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "deserted",
+      "tw_match": "deserted"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "39:10": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "39:11": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    }
+  ],
+  "39:12": [
+    {
+      "surface": "tells",
+      "tw_match": "tell"
+    }
+  ],
+  "39:13": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "eunuch",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "39:14": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "39:15": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "39:16": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "39:17": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "39:18": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "40:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "40:2": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    }
+  ],
+  "40:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "40:4": [
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "40:5": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    }
+  ],
+  "40:6": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "40:7": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    }
+  ],
+  "40:8": [
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "40:9": [
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Chaldean",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "40:10": [
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "40:11": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "40:12": [
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "harvested",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "40:13": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "40:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "40:15": [
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "40:16": [
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    }
+  ],
+  "41:1": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "41:2": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "41:3": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Chaldean",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "41:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "41:5": [
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    }
+  ],
+  "41:6": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "41:7": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "41:8": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    }
+  ],
+  "41:9": [
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Asa",
+      "tw_match": "Asa"
+    },
+    {
+      "surface": "Baasha",
+      "tw_match": "Baasha"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "41:10": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "41:11": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    }
+  ],
+  "41:12": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "41:13": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    }
+  ],
+  "41:14": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "41:15": [
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "41:16": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "41:17": [
+    {
+      "surface": "for a while",
+      "tw_match": "for a while"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "41:18": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Ishmael",
+      "tw_match": "Ishmael"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "42:1": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "42:2": [
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "42:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "42:4": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "42:5": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tells",
+      "tw_match": "tell"
+    }
+  ],
+  "42:6": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "42:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "42:8": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    }
+  ],
+  "42:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    }
+  ],
+  "42:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "42:11": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "42:12": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "42:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "42:14": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    }
+  ],
+  "42:15": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "42:16": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "42:17": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "42:18": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "dishonorable",
+      "tw_match": "dishonorable"
+    }
+  ],
+  "42:19": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "42:20": [
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "42:21": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "42:22": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "43:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "43:2": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "43:3": [
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "43:4": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "43:5": [
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "43:6": [
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    }
+  ],
+  "43:7": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "43:8": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "43:9": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "43:10": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "43:11": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "43:12": [
+    {
+      "surface": "temples",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    }
+  ],
+  "43:13": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "temples",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "44:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Memphis",
+      "tw_match": "Memphis"
+    }
+  ],
+  "44:2": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "44:3": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "44:4": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "abominable",
+      "tw_match": "abominable"
+    }
+  ],
+  "44:5": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "44:6": [
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "devastations",
+      "tw_match": "devastation"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "44:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    }
+  ],
+  "44:8": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "44:9": [
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "44:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    }
+  ],
+  "44:11": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "44:12": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "swearing",
+      "tw_match": "swearing"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    },
+    {
+      "surface": "reproaching",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "horrible",
+      "tw_match": "horrible"
+    }
+  ],
+  "44:13": [
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "44:14": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "44:15": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "44:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "44:17": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    }
+  ],
+  "44:18": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "44:19": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    }
+  ],
+  "44:20": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    }
+  ],
+  "44:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "44:22": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "44:23": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "44:24": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "44:25": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "carried out",
+      "tw_match": "carried out"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    }
+  ],
+  "44:26": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    }
+  ],
+  "44:27": [
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "44:28": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "44:29": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "44:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "45:1": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "45:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    }
+  ],
+  "45:3": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "45:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "45:5": [
+    {
+      "surface": "hoping",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "46:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "46:2": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "46:3": [
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    }
+  ],
+  "46:4": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    }
+  ],
+  "46:5": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "Terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "46:6": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "Euphrates River",
+      "tw_match": "Euphrates River"
+    }
+  ],
+  "46:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the Nile",
+      "tw_match": "the Nile"
+    }
+  ],
+  "46:8": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the Nile",
+      "tw_match": "the Nile"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "46:9": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "bending",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    }
+  ],
+  "46:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord of hosts",
+      "tw_match": "Lord of hosts"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Euphrates River",
+      "tw_match": "Euphrates River"
+    }
+  ],
+  "46:11": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "46:12": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "laments",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "soldier",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "stumbles",
+      "tw_match": "stumble"
+    }
+  ],
+  "46:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "46:14": [
+    {
+      "surface": "Announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Memphis",
+      "tw_match": "Memphis"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "46:15": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "46:16": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "soldier",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "46:17": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "king of Egypt",
+      "tw_match": "king of Egypt"
+    }
+  ],
+  "46:18": [
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Mount Carmel",
+      "tw_match": "Mount Carmel"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "46:19": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Memphis",
+      "tw_match": "Memphis"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "46:20": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "cow",
+      "tw_match": "cow"
+    }
+  ],
+  "46:21": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "46:22": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "axes",
+      "tw_match": "ax"
+    }
+  ],
+  "46:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    }
+  ],
+  "46:24": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "46:25": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Pharaohs",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    }
+  ],
+  "46:26": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "46:27": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    }
+  ],
+  "46:28": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "unpunished",
+      "tw_match": "unpunished"
+    }
+  ],
+  "47:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    }
+  ],
+  "47:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "floods",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    }
+  ],
+  "47:3": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "47:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "devastate",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "devastating",
+      "tw_match": "devastate"
+    }
+  ],
+  "47:5": [
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "Ashkelon",
+      "tw_match": "Ashkelon"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "47:6": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "47:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ashkelon",
+      "tw_match": "Ashkelon"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "48:1": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "disgraced",
+      "tw_match": "disgrace"
+    }
+  ],
+  "48:2": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "48:3": [
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "48:4": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    }
+  ],
+  "48:5": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "48:6": [
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "48:7": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    }
+  ],
+  "48:8": [
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "48:9": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    }
+  ],
+  "48:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "48:11": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "48:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "48:13": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    }
+  ],
+  "48:14": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    }
+  ],
+  "48:15": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "48:16": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    }
+  ],
+  "48:17": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "48:18": [
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    }
+  ],
+  "48:19": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "48:20": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "shamed",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    }
+  ],
+  "48:21": [
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "48:22": [],
+  "48:23": [],
+  "48:24": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "48:25": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "48:26": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "ridicule",
+      "tw_match": "ridicule"
+    }
+  ],
+  "48:27": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "48:28": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    }
+  ],
+  "48:29": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "48:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "48:31": [
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "48:32": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "Salt Sea",
+      "tw_match": "Salt Sea"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "48:33": [
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "winepresses",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "48:34": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Zoar",
+      "tw_match": "Zoar"
+    }
+  ],
+  "48:35": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "48:36": [
+    {
+      "surface": "lamenting",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "flutes",
+      "tw_match": "flute"
+    }
+  ],
+  "48:37": [
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "waists",
+      "tw_match": "waist"
+    }
+  ],
+  "48:38": [
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "48:39": [
+    {
+      "surface": "lamenting",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "48:40": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "48:41": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "48:42": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "48:43": [
+    {
+      "surface": "Terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "48:44": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "48:45": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "boastful",
+      "tw_match": "boastful"
+    }
+  ],
+  "48:46": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "48:47": [
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "49:1": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "49:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "deserted",
+      "tw_match": "deserted"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    }
+  ],
+  "49:3": [
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "Lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    }
+  ],
+  "49:4": [
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "faithless",
+      "tw_match": "faithless"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    }
+  ],
+  "49:5": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "49:6": [
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "49:7": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    }
+  ],
+  "49:8": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    }
+  ],
+  "49:9": [
+    {
+      "surface": "grape",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "49:10": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "49:11": [
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    }
+  ],
+  "49:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "deserve",
+      "tw_match": "deserve"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "49:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "devastation",
+      "tw_match": "devastation"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    },
+    {
+      "surface": "devastations",
+      "tw_match": "devastation"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "49:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    }
+  ],
+  "49:15": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "49:16": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "49:17": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    }
+  ],
+  "49:18": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "49:19": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "49:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "49:21": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "shakes",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    }
+  ],
+  "49:22": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "49:23": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "49:24": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "49:25": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "49:26": [
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "49:27": [
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    }
+  ],
+  "49:28": [
+    {
+      "surface": "Kedar",
+      "tw_match": "Kedar"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "49:29": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "Terror",
+      "tw_match": "terror"
+    }
+  ],
+  "49:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "49:31": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "49:32": [
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "49:33": [
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    }
+  ],
+  "49:34": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "49:35": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    }
+  ],
+  "49:36": [
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "49:37": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "annihilated",
+      "tw_match": "annihilate"
+    }
+  ],
+  "49:38": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "49:39": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "50:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "50:2": [
+    {
+      "surface": "Report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    }
+  ],
+  "50:3": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "50:4": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "50:5": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "50:6": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    }
+  ],
+  "50:7": [
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "50:8": [
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "50:9": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    }
+  ],
+  "50:10": [
+    {
+      "surface": "Chaldea",
+      "tw_match": "Chaldea"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "50:11": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "plundering",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    }
+  ],
+  "50:12": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    }
+  ],
+  "50:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "devastation",
+      "tw_match": "devastation"
+    }
+  ],
+  "50:14": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "bends",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "a bow",
+      "tw_match": "a bow"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "50:15": [
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "50:16": [
+    {
+      "surface": "Destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "sows",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "50:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "50:18": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    }
+  ],
+  "50:19": [
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "50:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    }
+  ],
+  "50:21": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "50:22": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "50:23": [
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "50:24": [
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "50:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "armory",
+      "tw_match": "armory"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "50:26": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    }
+  ],
+  "50:27": [
+    {
+      "surface": "Kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "50:28": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "50:29": [
+    {
+      "surface": "archers",
+      "tw_match": "archer"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "50:30": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "50:31": [
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    }
+  ],
+  "50:32": [
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "50:33": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "50:34": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "50:35": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    }
+  ],
+  "50:36": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "50:37": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    }
+  ],
+  "50:38": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "50:39": [
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "50:40": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "50:41": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "50:42": [
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "50:43": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "reports",
+      "tw_match": "report"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "Anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "50:44": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "50:45": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "50:46": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "shakes",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "51:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stir up",
+      "tw_match": "stir up"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "51:2": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "devastate",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "51:3": [
+    {
+      "surface": "archers",
+      "tw_match": "archer"
+    },
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "51:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "51:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    }
+  ],
+  "51:6": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    }
+  ],
+  "51:7": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "51:8": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "51:9": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "51:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "51:11": [
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Medes",
+      "tw_match": "Medes"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "51:12": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "51:13": [],
+  "51:14": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "51:15": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "51:16": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "storehouses",
+      "tw_match": "storehouse"
+    }
+  ],
+  "51:17": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "images",
+      "tw_match": "image"
+    }
+  ],
+  "51:18": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "mockers",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "51:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "molder",
+      "tw_match": "molder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "51:20": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    }
+  ],
+  "51:21": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "51:22": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    }
+  ],
+  "51:23": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    }
+  ],
+  "51:24": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Chaldea",
+      "tw_match": "Chaldea"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "51:25": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "51:26": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "devastation",
+      "tw_match": "devastation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "51:27": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Ararat",
+      "tw_match": "Ararat"
+    },
+    {
+      "surface": "Appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    }
+  ],
+  "51:28": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Medes",
+      "tw_match": "Medes"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "51:29": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    }
+  ],
+  "51:30": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "51:31": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "tells",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "51:32": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "51:33": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "51:34": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    }
+  ],
+  "51:35": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Chaldea",
+      "tw_match": "Chaldea"
+    }
+  ],
+  "51:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "51:37": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    }
+  ],
+  "51:38": [
+    {
+      "surface": "Babylonians",
+      "tw_match": "Babylonian"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "51:39": [
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "51:40": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "51:41": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "51:42": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "51:43": [
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "51:44": [
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "51:45": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "51:46": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "51:47": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    }
+  ],
+  "51:48": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "51:49": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "51:50": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "51:51": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    }
+  ],
+  "51:52": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "51:53": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "51:54": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "51:55": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "51:56": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "51:57": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "King’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "51:58": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "51:59": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "51:60": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "51:61": [
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "51:62": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "51:63": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "51:64": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "52:1": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "52:2": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jehoiakim",
+      "tw_match": "Jehoiakim"
+    }
+  ],
+  "52:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "52:4": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    }
+  ],
+  "52:5": [
+    {
+      "surface": "besieged",
+      "tw_match": "besieged"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "52:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "52:7": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    }
+  ],
+  "52:8": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "Jordan River",
+      "tw_match": "Jordan River"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "52:9": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    }
+  ],
+  "52:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "52:11": [
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "52:12": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "52:13": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "52:14": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Babylonians",
+      "tw_match": "Babylonian"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "52:15": [
+    {
+      "surface": "deserted",
+      "tw_match": "deserted"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "52:16": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    }
+  ],
+  "52:17": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "52:18": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    }
+  ],
+  "52:19": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "lampstands",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "52:20": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "the twelve",
+      "tw_match": "the twelve"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "52:21": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "52:22": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    }
+  ],
+  "52:23": [
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    }
+  ],
+  "52:24": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "Zephaniah",
+      "tw_match": "Zephaniah"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    }
+  ],
+  "52:25": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "advised",
+      "tw_match": "advise"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "52:26": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "52:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "52:28": [
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "52:29": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "52:30": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    }
+  ],
+  "52:31": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    }
+  ],
+  "52:32": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "52:33": [
+    {
+      "surface": "Jehoiachin",
+      "tw_match": "Jehoiachin"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    }
+  ],
+  "52:34": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_JHN.json
+++ b/sources/keyword_data/keywords_JHN.json
@@ -1,0 +1,12266 @@
+{
+  "1:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:3": [],
+  "1:4": [],
+  "1:5": [],
+  "1:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "children of God",
+      "tw_match": "children of God"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "testifies",
+      "tw_match": "testify"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "confessed",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "baptize",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "baptize",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "sandal",
+      "tw_match": "sandal"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "baptizing",
+      "tw_match": "baptize"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lamb of God",
+      "tw_match": "Lamb of God"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "1:30": [],
+  "1:31": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "baptizing",
+      "tw_match": "baptize"
+    }
+  ],
+  "1:32": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "descending",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "1:33": [
+    {
+      "surface": "baptize",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "descending",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "baptizing",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "1:34": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:35": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "1:36": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lamb of God",
+      "tw_match": "Lamb of God"
+    }
+  ],
+  "1:37": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:38": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    }
+  ],
+  "1:39": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "1:40": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    },
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    }
+  ],
+  "1:41": [
+    {
+      "surface": "Messiah",
+      "tw_match": "Messiah"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:42": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Cephas",
+      "tw_match": "Cephas"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "1:43": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    }
+  ],
+  "1:44": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "1:45": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    }
+  ],
+  "1:46": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    }
+  ],
+  "1:47": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:48": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    }
+  ],
+  "1:49": [
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:50": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "1:51": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "descending",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "Cana",
+      "tw_match": "Cana"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "washing",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "2:8": [],
+  "2:9": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "serves",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Cana",
+      "tw_match": "Cana"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "pigeons",
+      "tw_match": "pigeon"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "pigeons",
+      "tw_match": "pigeon"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "born again",
+      "tw_match": "born again"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "born again",
+      "tw_match": "born again"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "3:9": [],
+  "3:10": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Son of God",
+      "tw_match": "Son of God"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "baptizing",
+      "tw_match": "baptize"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "baptizing",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "washing",
+      "tw_match": "wash"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "baptizing",
+      "tw_match": "baptize"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:29": [
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "3:30": [],
+  "3:31": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "3:32": [
+    {
+      "surface": "testifies",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "3:33": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:34": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "3:35": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "3:36": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "baptizing",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "baptizing",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "Samaritan",
+      "tw_match": "Samaritan"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Samaritans",
+      "tw_match": "Samaritan"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "Sir",
+      "tw_match": "sir"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "springing",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Sir",
+      "tw_match": "sir"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:18": [],
+  "4:19": [
+    {
+      "surface": "Sir",
+      "tw_match": "sir"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Messiah",
+      "tw_match": "Messiah"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "4:28": [],
+  "4:29": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "4:30": [],
+  "4:31": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "4:33": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "4:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "4:35": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "4:36": [
+    {
+      "surface": "harvesting",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "sowing",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "4:37": [
+    {
+      "surface": "sowing",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "harvesting",
+      "tw_match": "harvest"
+    }
+  ],
+  "4:38": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "labored",
+      "tw_match": "labored"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "4:39": [
+    {
+      "surface": "Samaritans",
+      "tw_match": "Samaritan"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    }
+  ],
+  "4:40": [
+    {
+      "surface": "Samaritans",
+      "tw_match": "Samaritan"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "4:41": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "4:42": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "4:43": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "4:44": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "4:45": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Galileans",
+      "tw_match": "Galilean"
+    },
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    }
+  ],
+  "4:46": [
+    {
+      "surface": "Cana",
+      "tw_match": "Cana"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "royal official",
+      "tw_match": "royal official"
+    },
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    }
+  ],
+  "4:47": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "4:48": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "4:49": [
+    {
+      "surface": "royal official",
+      "tw_match": "royal official"
+    },
+    {
+      "surface": "Sir",
+      "tw_match": "sir"
+    }
+  ],
+  "4:50": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "4:51": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "4:52": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "4:53": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "4:54": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "5:3": [],
+  "5:4": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "Sir",
+      "tw_match": "sir"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "5:11": [],
+  "5:12": [],
+  "5:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "persecute",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "honoring",
+      "tw_match": "honor"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "tombs",
+      "tw_match": "tomb"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "5:31": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "5:32": [
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "testifies",
+      "tw_match": "testify"
+    }
+  ],
+  "5:33": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "5:34": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "5:35": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "5:36": [
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    }
+  ],
+  "5:37": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "5:38": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "5:39": [
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    }
+  ],
+  "5:40": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "5:41": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "5:42": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:43": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "5:44": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:45": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    }
+  ],
+  "5:46": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "5:47": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Sea of Galilee",
+      "tw_match": "Sea of Galilee"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    },
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "perishes",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    }
+  ],
+  "6:28": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "6:31": [
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "6:32": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "6:33": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "6:34": [
+    {
+      "surface": "Sir",
+      "tw_match": "sir"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "6:35": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "6:36": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "6:37": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "throw out",
+      "tw_match": "throw out"
+    }
+  ],
+  "6:38": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:39": [
+    {
+      "surface": "last day",
+      "tw_match": "last day"
+    }
+  ],
+  "6:40": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "last day",
+      "tw_match": "last day"
+    }
+  ],
+  "6:41": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "6:42": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "6:43": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "6:44": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "last day",
+      "tw_match": "last day"
+    }
+  ],
+  "6:45": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "6:46": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:47": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "6:48": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "6:49": [
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "6:50": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:51": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "6:52": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "6:53": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "6:54": [
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "last day",
+      "tw_match": "last day"
+    }
+  ],
+  "6:55": [],
+  "6:56": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "6:57": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "6:58": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "6:59": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    }
+  ],
+  "6:60": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    }
+  ],
+  "6:61": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "6:62": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "6:63": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "profits",
+      "tw_match": "profits"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "6:64": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "betraying",
+      "tw_match": "betray"
+    }
+  ],
+  "6:65": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "6:66": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "6:67": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "6:68": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "6:69": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:70": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    }
+  ],
+  "6:71": [
+    {
+      "surface": "betray",
+      "tw_match": "betray"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "circumcise",
+      "tw_match": "circumcise"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "7:30": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "7:31": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "7:32": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "7:33": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "7:34": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "7:35": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "dispersion",
+      "tw_match": "dispersion"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    }
+  ],
+  "7:36": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "7:37": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "7:38": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    }
+  ],
+  "7:39": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "7:40": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "7:41": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "7:42": [
+    {
+      "surface": "Scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "7:43": [],
+  "7:44": [],
+  "7:45": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "7:46": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "7:47": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    }
+  ],
+  "7:48": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "7:49": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "7:50": [],
+  "7:51": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "7:52": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "7:53": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Mount of Olives",
+      "tw_match": "Mount of Olives"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "8:8": [],
+  "8:9": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "testifies",
+      "tw_match": "testify"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "committing",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "8:36": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "frees",
+      "tw_match": "free"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "8:37": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "8:38": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "8:39": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "8:40": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "8:41": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:42": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "8:43": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "8:44": [
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "8:45": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "8:46": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "8:47": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:48": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Samaritan",
+      "tw_match": "Samaritan"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    }
+  ],
+  "8:49": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    }
+  ],
+  "8:50": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    }
+  ],
+  "8:51": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "8:52": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "8:53": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "8:54": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:55": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "8:56": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "8:57": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "8:58": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "8:59": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "9:1": [],
+  "9:2": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "9:6": [],
+  "9:7": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "beggar",
+      "tw_match": "beggar"
+    },
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "9:10": [],
+  "9:11": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "9:19": [],
+  "9:20": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    }
+  ],
+  "9:23": [],
+  "9:24": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    }
+  ],
+  "9:26": [],
+  "9:27": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "reviled",
+      "tw_match": "revile"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "9:32": [
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "9:33": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:34": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "9:35": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "9:36": [
+    {
+      "surface": "sir",
+      "tw_match": "sir"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "9:37": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "9:38": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    }
+  ],
+  "9:39": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:40": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "9:41": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "robber",
+      "tw_match": "robber"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "gatekeeper",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "robber",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "wolf",
+      "tw_match": "wolf"
+    },
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "scatters",
+      "tw_match": "scatter"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "demon-possessed",
+      "tw_match": "demon-possessed"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Dedication",
+      "tw_match": "dedication"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "10:30": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "10:31": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "stoning",
+      "tw_match": "stoning"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "stoning",
+      "tw_match": "stoning"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "blasphemy",
+      "tw_match": "blasphemy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "10:35": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "Scripture",
+      "tw_match": "scripture"
+    }
+  ],
+  "10:36": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "blaspheming",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:37": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "10:38": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "10:39": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    }
+  ],
+  "10:40": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "baptizing",
+      "tw_match": "baptize"
+    }
+  ],
+  "10:41": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "10:42": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    },
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "Sir",
+      "tw_match": "sir"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "hours",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "stumbles",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "Thomas",
+      "tw_match": "Thomas"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "last day",
+      "tw_match": "last day"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "11:29": [],
+  "11:30": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "11:33": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "disturbed",
+      "tw_match": "disturb"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "11:34": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "11:35": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "11:36": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "11:37": [],
+  "11:38": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disturbed",
+      "tw_match": "disturb"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "11:39": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:40": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:41": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "11:42": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "11:43": [
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    }
+  ],
+  "11:44": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "11:45": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "11:46": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "11:47": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "11:48": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "Romans",
+      "tw_match": "Roman"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "11:49": [
+    {
+      "surface": "Caiaphas",
+      "tw_match": "Caiaphas"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "11:50": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "11:51": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "11:52": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "children of God",
+      "tw_match": "children of God"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "11:53": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "11:54": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "11:55": [
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    }
+  ],
+  "11:56": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    }
+  ],
+  "11:57": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "Judas Iscariot",
+      "tw_match": "Judas Iscariot"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "betray",
+      "tw_match": "betray"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "burial",
+      "tw_match": "burial"
+    }
+  ],
+  "12:8": [],
+  "12:9": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in Jesus",
+      "tw_match": "in Jesus"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Sir",
+      "tw_match": "sir"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "serves",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "12:27": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "12:30": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "12:31": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "12:32": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "12:33": [],
+  "12:34": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Son of Man",
+      "tw_match": "Son of Man"
+    }
+  ],
+  "12:35": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "12:36": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "12:37": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "12:38": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "12:39": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    }
+  ],
+  "12:40": [
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "12:41": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "12:42": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "confessing",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    }
+  ],
+  "12:43": [
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:44": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "believes",
+      "tw_match": "believe"
+    }
+  ],
+  "12:45": [],
+  "12:46": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "12:47": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "12:48": [
+    {
+      "surface": "rejecting",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "last day",
+      "tw_match": "last day"
+    }
+  ],
+  "12:49": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "12:50": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "betray",
+      "tw_match": "betray"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:4": [],
+  "13:5": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "tied",
+      "tw_match": "tied"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "betraying",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "betray",
+      "tw_match": "betray"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "wondering",
+      "tw_match": "wonder"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "13:26": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "13:27": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "13:29": [
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "13:30": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "13:31": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "13:32": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "13:33": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "13:34": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "13:35": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "13:36": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "13:37": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "13:38": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "Thomas",
+      "tw_match": "Thomas"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "14:14": [],
+  "14:15": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "14:25": [],
+  "14:26": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "remind",
+      "tw_match": "remind"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "14:30": [
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "14:31": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "15:7": [],
+  "15:8": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "persecute",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "16:5": [],
+  "16:6": [],
+  "16:7": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "reprove",
+      "tw_match": "reprove"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    }
+  ],
+  "16:16": [],
+  "16:17": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    }
+  ],
+  "16:29": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    }
+  ],
+  "16:30": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:31": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "16:32": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "16:33": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "courage",
+      "tw_match": "courage"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "17:10": [],
+  "17:11": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "Sanctify",
+      "tw_match": "sanctify"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "17:19": [],
+  "17:20": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "17:23": [
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "17:24": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "17:25": [
+    {
+      "surface": "Righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "17:26": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "betraying",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    },
+    {
+      "surface": "betraying",
+      "tw_match": "betray"
+    }
+  ],
+  "18:6": [],
+  "18:7": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "tied",
+      "tw_match": "tied"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "Annas",
+      "tw_match": "Annas"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Caiaphas",
+      "tw_match": "Caiaphas"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "Caiaphas",
+      "tw_match": "Caiaphas"
+    },
+    {
+      "surface": "advised",
+      "tw_match": "advise"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "Annas",
+      "tw_match": "Annas"
+    },
+    {
+      "surface": "tied up",
+      "tw_match": "tied up"
+    },
+    {
+      "surface": "Caiaphas",
+      "tw_match": "Caiaphas"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Caiaphas",
+      "tw_match": "Caiaphas"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    }
+  ],
+  "18:30": [],
+  "18:31": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "not lawful",
+      "tw_match": "not lawful"
+    }
+  ],
+  "18:32": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "18:33": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "18:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "18:35": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    }
+  ],
+  "18:36": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "18:37": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "bear witness",
+      "tw_match": "bear witness"
+    }
+  ],
+  "18:38": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "18:39": [
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "18:40": [
+    {
+      "surface": "Barabbas",
+      "tw_match": "Barabbas"
+    },
+    {
+      "surface": "robber",
+      "tw_match": "robber"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "Hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "Crucify",
+      "tw_match": "crucify"
+    },
+    {
+      "surface": "crucify",
+      "tw_match": "crucify"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "crucify",
+      "tw_match": "crucify"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "Crucify",
+      "tw_match": "crucify"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "crucify",
+      "tw_match": "crucify"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "Golgotha",
+      "tw_match": "Golgotha"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "soldier",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    }
+  ],
+  "19:25": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "Mary Magdalene",
+      "tw_match": "Mary Magdalene"
+    }
+  ],
+  "19:26": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "19:27": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "19:28": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "19:30": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "19:31": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    }
+  ],
+  "19:32": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "19:33": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "19:34": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "19:35": [
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "19:36": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "19:37": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    }
+  ],
+  "19:38": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "19:39": [
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    }
+  ],
+  "19:40": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "burial",
+      "tw_match": "burial"
+    }
+  ],
+  "19:41": [
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "19:42": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "week",
+      "tw_match": "week"
+    },
+    {
+      "surface": "Mary Magdalene",
+      "tw_match": "Mary Magdalene"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "20:5": [],
+  "20:6": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "20:7": [],
+  "20:8": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "Sir",
+      "tw_match": "sir"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "Mary Magdalene",
+      "tw_match": "Mary Magdalene"
+    },
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "week",
+      "tw_match": "week"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "breathed",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "Receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "Thomas",
+      "tw_match": "Thomas"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Thomas",
+      "tw_match": "Thomas"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "Thomas",
+      "tw_match": "Thomas"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "Thomas",
+      "tw_match": "Thomas"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:29": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "20:30": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "20:31": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Sea of Tiberias",
+      "tw_match": "Sea of Tiberias"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "Thomas",
+      "tw_match": "Thomas"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Cana",
+      "tw_match": "Cana"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Zebedee",
+      "tw_match": "Zebedee"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "betraying",
+      "tw_match": "betray"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_JOB.json
+++ b/sources/keyword_data/keywords_JOB.json
@@ -1,0 +1,10362 @@
+{
+  "1:1": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "1:2": [],
+  "1:3": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sons of God",
+      "tw_match": "sons of God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "plowing",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Chaldeans",
+      "tw_match": "Chaldean"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sons of God",
+      "tw_match": "sons of God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "2:8": [],
+  "2:9": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Leviathan",
+      "tw_match": "Leviathan"
+    }
+  ],
+  "3:9": [],
+  "3:10": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "welcome",
+      "tw_match": "welcome"
+    }
+  ],
+  "3:13": [],
+  "3:14": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "troubling",
+      "tw_match": "trouble"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "Captives",
+      "tw_match": "captive"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "3:21": [],
+  "3:22": [
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "dreaded",
+      "tw_match": "dread"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "4:1": [],
+  "4:2": [],
+  "4:3": [
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "panic",
+      "tw_match": "panic"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "plowing",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "sowing",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "perishes",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "lioness",
+      "tw_match": "lioness"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "troubling",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "image",
+      "tw_match": "image"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "Maker",
+      "tw_match": "Maker"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "5:12": [],
+  "5:13": [
+    {
+      "surface": "catching",
+      "tw_match": "catch"
+    },
+    {
+      "surface": "cunning",
+      "tw_match": "cunning"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "saves",
+      "tw_match": "save"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "binds",
+      "tw_match": "bind"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "sheepfold",
+      "tw_match": "sheepfold"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    }
+  ],
+  "6:3": [],
+  "6:4": [
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "6:6": [],
+  "6:7": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    }
+  ],
+  "6:11": [],
+  "6:12": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "6:13": [],
+  "6:14": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "forsakes",
+      "tw_match": "forsake"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "wadis",
+      "tw_match": "wadi"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "annihilated",
+      "tw_match": "annihilate"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "6:22": [],
+  "6:23": [
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "6:28": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "discern",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "7:5": [],
+  "7:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "7:8": [],
+  "7:9": [
+    {
+      "surface": "descending",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "7:13": [],
+  "7:14": [
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "chooses",
+      "tw_match": "choose"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "7:17": [],
+  "7:18": [
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "moments",
+      "tw_match": "moment"
+    }
+  ],
+  "7:19": [],
+  "7:20": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "pardon",
+      "tw_match": "pardon"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "8:1": [],
+  "8:2": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "pervert",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "8:7": [],
+  "8:8": [
+    {
+      "surface": "inquire",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "8:10": [],
+  "8:11": [
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "godless",
+      "tw_match": "godless"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "8:16": [],
+  "8:17": [
+    {
+      "surface": "wrapped around",
+      "tw_match": "wrapped around"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "8:21": [],
+  "8:22": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "seals",
+      "tw_match": "seal"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "Bear",
+      "tw_match": "bear"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    },
+    {
+      "surface": "distinguished",
+      "tw_match": "distinguish"
+    }
+  ],
+  "9:11": [],
+  "9:12": [],
+  "9:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "mocks",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    }
+  ],
+  "9:27": [],
+  "9:28": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    }
+  ],
+  "9:31": [],
+  "9:32": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "9:33": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "9:34": [
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "frighten",
+      "tw_match": "frighten"
+    }
+  ],
+  "9:35": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "10:4": [],
+  "10:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:11": [],
+  "10:12": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "guarded",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "distinguish",
+      "tw_match": "distinguish"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "11:1": [],
+  "11:2": [],
+  "11:3": [
+    {
+      "surface": "boastings",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "shaming",
+      "tw_match": "shame"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "doctrine",
+      "tw_match": "doctrine"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "assembles",
+      "tw_match": "assemble"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "11:13": [],
+  "11:14": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "carries",
+      "tw_match": "carry"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "test",
+      "tw_match": "test"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "12:14": [],
+  "12:15": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "prudence",
+      "tw_match": "prudence"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "bond",
+      "tw_match": "bond"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "discernment",
+      "tw_match": "discernment"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "12:22": [],
+  "12:23": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "drunkard",
+      "tw_match": "drunkard"
+    }
+  ],
+  "13:1": [],
+  "13:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "deceiving",
+      "tw_match": "deceive"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "Reproving",
+      "tw_match": "reprove"
+    },
+    {
+      "surface": "reprove",
+      "tw_match": "reprove"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "proverbs",
+      "tw_match": "proverb"
+    }
+  ],
+  "13:13": [],
+  "13:14": [],
+  "13:15": [
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "godless",
+      "tw_match": "godless"
+    }
+  ],
+  "13:17": [],
+  "13:18": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "13:19": [],
+  "13:20": [],
+  "13:21": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "13:26": [
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "13:27": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "fulfills",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "14:10": [],
+  "14:11": [
+    {
+      "surface": "dries",
+      "tw_match": "dry"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "14:18": [],
+  "14:19": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "flooding",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "washes",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "mourns",
+      "tw_match": "mourn"
+    }
+  ],
+  "15:1": [],
+  "15:2": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "condemns",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    }
+  ],
+  "15:7": [],
+  "15:8": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "abominable",
+      "tw_match": "abominable"
+    },
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "15:17": [],
+  "15:18": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "Distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    }
+  ],
+  "15:27": [],
+  "15:28": [
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "deceiving",
+      "tw_match": "deceive"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grapevine",
+      "tw_match": "grapevine"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    }
+  ],
+  "15:34": [
+    {
+      "surface": "godless",
+      "tw_match": "godless"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "bribery",
+      "tw_match": "bribery"
+    }
+  ],
+  "15:35": [
+    {
+      "surface": "conceive",
+      "tw_match": "conceive"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    }
+  ],
+  "16:5": [],
+  "16:6": [],
+  "16:7": [
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "testifies",
+      "tw_match": "testify"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "delivers",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "archers",
+      "tw_match": "archer"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "Earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "mockers",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "provocations",
+      "tw_match": "provocation"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "17:6": [],
+  "17:7": [
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "wonder",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "godless",
+      "tw_match": "godless"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "descend",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "18:1": [],
+  "18:2": [],
+  "18:3": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    }
+  ],
+  "18:7": [],
+  "18:8": [
+    {
+      "surface": "pitfall",
+      "tw_match": "pitfall"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "Terrors",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "frighten",
+      "tw_match": "frighten"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "sulfur",
+      "tw_match": "sulfur"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "18:19": [],
+  "18:20": [
+    {
+      "surface": "wonder",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "reproached",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "mistreat",
+      "tw_match": "mistreat"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wronged",
+      "tw_match": "wronged"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "19:8": [],
+  "19:9": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "19:13": [],
+  "19:14": [
+    {
+      "surface": "kin",
+      "tw_match": "kin"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "19:18": [],
+  "19:19": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "19:20": [],
+  "19:21": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "19:25": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    }
+  ],
+  "19:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:27": [],
+  "19:28": [
+    {
+      "surface": "persecute",
+      "tw_match": "persecute"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "20:1": [],
+  "20:2": [],
+  "20:3": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "godless",
+      "tw_match": "godless"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "20:9": [],
+  "20:10": [],
+  "20:11": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    }
+  ],
+  "20:14": [],
+  "20:15": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "viper",
+      "tw_match": "viper"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "20:20": [],
+  "20:21": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "troubling",
+      "tw_match": "trouble"
+    }
+  ],
+  "20:23": [],
+  "20:24": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "a bow",
+      "tw_match": "a bow"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "Terrors",
+      "tw_match": "terror"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:29": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "21:2": [],
+  "21:3": [
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "wonder",
+      "tw_match": "wonder"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cow",
+      "tw_match": "cow"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "carries",
+      "tw_match": "carry"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "21:23": [],
+  "21:24": [],
+  "21:25": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "alike",
+      "tw_match": "alike"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "21:29": [
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "21:30": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "21:31": [],
+  "21:32": [
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "burial",
+      "tw_match": "burial"
+    }
+  ],
+  "21:33": [],
+  "21:34": [
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "22:1": [],
+  "22:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "quenched",
+      "tw_match": "quenched"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "22:9": [],
+  "22:10": [
+    {
+      "surface": "snares",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "terrifies",
+      "tw_match": "terrify"
+    }
+  ],
+  "22:11": [],
+  "22:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "Reconcile",
+      "tw_match": "reconcile"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "golds",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "23:2": [],
+  "23:3": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "23:4": [],
+  "23:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "23:6": [],
+  "23:7": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "arguing",
+      "tw_match": "arguing"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    }
+  ],
+  "23:8": [],
+  "23:9": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "23:11": [],
+  "23:12": [],
+  "23:13": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "23:17": [],
+  "24:1": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "winepresses",
+      "tw_match": "winepress"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "rebelling",
+      "tw_match": "rebel"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "adulterer",
+      "tw_match": "adulterer"
+    },
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "24:23": [],
+  "24:24": [
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "24:25": [],
+  "25:1": [],
+  "25:2": [
+    {
+      "surface": "Dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "25:3": [],
+  "25:4": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "advised",
+      "tw_match": "advise"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "Raphaites",
+      "tw_match": "Raphaites"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "hanging",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    }
+  ],
+  "26:9": [],
+  "26:10": [],
+  "26:11": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "justify",
+      "tw_match": "justify"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "godless",
+      "tw_match": "godless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "vanity",
+      "tw_match": "vanity"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "27:18": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "27:19": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "27:20": [
+    {
+      "surface": "Terrors",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "carries",
+      "tw_match": "carry"
+    }
+  ],
+  "27:21": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    }
+  ],
+  "27:22": [],
+  "27:23": [],
+  "28:1": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "Iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "28:4": [],
+  "28:5": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "28:9": [],
+  "28:10": [],
+  "28:11": [
+    {
+      "surface": "binds",
+      "tw_match": "bind"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "Gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "28:20": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "28:21": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "28:22": [],
+  "28:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "understands",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "28:24": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "28:25": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "28:26": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    }
+  ],
+  "28:27": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "28:28": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "29:7": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "29:12": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    }
+  ],
+  "29:13": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    }
+  ],
+  "29:14": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "29:15": [],
+  "29:16": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "29:17": [
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    }
+  ],
+  "29:18": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "29:19": [],
+  "29:20": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "29:21": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "29:22": [],
+  "29:23": [],
+  "29:24": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "29:25": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "mourners",
+      "tw_match": "mourner"
+    }
+  ],
+  "30:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "30:2": [
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    }
+  ],
+  "30:6": [
+    {
+      "surface": "wadis",
+      "tw_match": "wadi"
+    }
+  ],
+  "30:7": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "thorn",
+      "tw_match": "thorn"
+    }
+  ],
+  "30:8": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "30:9": [],
+  "30:10": [],
+  "30:11": [
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    }
+  ],
+  "30:12": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "30:13": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    }
+  ],
+  "30:14": [
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "30:15": [
+    {
+      "surface": "Terrors",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "deliverance",
+      "tw_match": "deliverance"
+    }
+  ],
+  "30:16": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    }
+  ],
+  "30:17": [],
+  "30:18": [
+    {
+      "surface": "binds",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    }
+  ],
+  "30:19": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "30:20": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "30:21": [],
+  "30:22": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "30:23": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "30:24": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "30:25": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "30:26": [
+    {
+      "surface": "hoped",
+      "tw_match": "hoped"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "30:27": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "30:28": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "30:29": [
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    }
+  ],
+  "30:30": [],
+  "30:31": [
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    }
+  ],
+  "31:4": [],
+  "31:5": [],
+  "31:6": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "31:7": [],
+  "31:8": [
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "31:10": [
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "31:11": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "31:12": [
+    {
+      "surface": "consumes",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "31:13": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "31:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:15": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "31:16": [],
+  "31:17": [],
+  "31:18": [],
+  "31:19": [
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    }
+  ],
+  "31:20": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "31:21": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "31:22": [],
+  "31:23": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "31:24": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "31:25": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    }
+  ],
+  "31:26": [
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "31:27": [
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "31:28": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:29": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "31:30": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "31:31": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "31:32": [],
+  "31:33": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    }
+  ],
+  "31:34": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "31:35": [
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "31:36": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "crowns",
+      "tw_match": "crown"
+    }
+  ],
+  "31:37": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    }
+  ],
+  "31:38": [
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    }
+  ],
+  "31:39": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    }
+  ],
+  "31:40": [
+    {
+      "surface": "thorn",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "32:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "32:2": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:3": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "32:4": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "32:5": [],
+  "32:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "32:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "32:8": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "32:9": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "32:10": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "32:11": [
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    }
+  ],
+  "32:12": [
+    {
+      "surface": "proving",
+      "tw_match": "proving"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "32:13": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "32:14": [],
+  "32:15": [],
+  "32:16": [],
+  "32:17": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "32:18": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "32:19": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "wineskins",
+      "tw_match": "wineskin"
+    }
+  ],
+  "32:20": [],
+  "32:21": [],
+  "32:22": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Maker",
+      "tw_match": "Maker"
+    }
+  ],
+  "33:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "33:2": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "33:3": [
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "33:4": [
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "33:5": [],
+  "33:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "33:7": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    }
+  ],
+  "33:8": [],
+  "33:9": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "33:10": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "33:11": [
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    }
+  ],
+  "33:12": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "33:13": [],
+  "33:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "33:15": [
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    }
+  ],
+  "33:16": [
+    {
+      "surface": "seals",
+      "tw_match": "seal"
+    }
+  ],
+  "33:17": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    }
+  ],
+  "33:18": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    }
+  ],
+  "33:19": [],
+  "33:20": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "33:21": [
+    {
+      "surface": "wastes",
+      "tw_match": "waste"
+    }
+  ],
+  "33:22": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "33:23": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "interpreter",
+      "tw_match": "interpreter"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    }
+  ],
+  "33:24": [
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "Redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    }
+  ],
+  "33:25": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "33:26": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "33:27": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    }
+  ],
+  "33:28": [
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "33:29": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "33:30": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "33:31": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "33:32": [
+    {
+      "surface": "justify",
+      "tw_match": "justify"
+    }
+  ],
+  "33:33": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "34:1": [],
+  "34:2": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "34:3": [
+    {
+      "surface": "tests",
+      "tw_match": "test"
+    }
+  ],
+  "34:4": [
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "34:5": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "34:6": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    }
+  ],
+  "34:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "34:8": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "34:9": [
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "34:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "34:11": [],
+  "34:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "pervert",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "34:13": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "34:14": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "34:15": [],
+  "34:16": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "34:17": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "govern",
+      "tw_match": "govern"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "Righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "34:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    }
+  ],
+  "34:19": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "34:20": [
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "34:21": [],
+  "34:22": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "34:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "34:24": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "34:25": [],
+  "34:26": [],
+  "34:27": [],
+  "34:28": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "34:29": [
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "alike",
+      "tw_match": "alike"
+    }
+  ],
+  "34:30": [
+    {
+      "surface": "reigning",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "godless",
+      "tw_match": "godless"
+    },
+    {
+      "surface": "snares",
+      "tw_match": "snare"
+    }
+  ],
+  "34:31": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    }
+  ],
+  "34:32": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "34:33": [
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "34:34": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "34:35": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "34:36": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "34:37": [
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "multiplies",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "35:1": [],
+  "35:2": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "35:3": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "35:4": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "35:5": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "35:6": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    }
+  ],
+  "35:7": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "35:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    }
+  ],
+  "35:9": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "35:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Maker",
+      "tw_match": "Maker"
+    }
+  ],
+  "35:11": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "35:12": [
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "35:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vanity",
+      "tw_match": "vanity"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "35:14": [],
+  "35:15": [
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    }
+  ],
+  "35:16": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "multiplies",
+      "tw_match": "multiply"
+    }
+  ],
+  "36:1": [],
+  "36:2": [
+    {
+      "surface": "patient",
+      "tw_match": "patient"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "36:3": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Maker",
+      "tw_match": "Maker"
+    }
+  ],
+  "36:4": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "36:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "36:6": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "36:7": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "36:8": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "36:9": [
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    }
+  ],
+  "36:10": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "36:11": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "36:12": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "36:13": [
+    {
+      "surface": "godless",
+      "tw_match": "godless"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "binds",
+      "tw_match": "bind"
+    }
+  ],
+  "36:14": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    }
+  ],
+  "36:15": [
+    {
+      "surface": "delivers",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "36:16": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "36:17": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "36:18": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "36:19": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "36:20": [],
+  "36:21": [
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "36:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "36:23": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    }
+  ],
+  "36:24": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "36:25": [],
+  "36:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    }
+  ],
+  "36:27": [],
+  "36:28": [],
+  "36:29": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "36:30": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "36:31": [
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "36:32": [],
+  "36:33": [
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "37:1": [
+    {
+      "surface": "trembles",
+      "tw_match": "tremble"
+    }
+  ],
+  "37:2": [],
+  "37:3": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "37:4": [
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "37:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "37:6": [
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "37:7": [
+    {
+      "surface": "seals",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "37:8": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "37:9": [
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    }
+  ],
+  "37:10": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "37:11": [
+    {
+      "surface": "scatters",
+      "tw_match": "scatter"
+    }
+  ],
+  "37:12": [
+    {
+      "surface": "counsels",
+      "tw_match": "counsels"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "37:13": [
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "37:14": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "37:15": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "37:16": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "knowledges",
+      "tw_match": "knowledge"
+    }
+  ],
+  "37:17": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "37:18": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "37:19": [],
+  "37:20": [],
+  "37:21": [
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "37:22": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "awesome",
+      "tw_match": "awesome"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "37:23": [
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "37:24": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "38:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "38:2": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "38:3": [
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "38:4": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "38:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "38:6": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "cornerstone",
+      "tw_match": "cornerstone"
+    }
+  ],
+  "38:7": [
+    {
+      "surface": "sons of God",
+      "tw_match": "sons of God"
+    }
+  ],
+  "38:8": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "38:9": [],
+  "38:10": [],
+  "38:11": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    }
+  ],
+  "38:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "38:13": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "38:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    }
+  ],
+  "38:15": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "38:16": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "38:17": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "38:18": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "38:19": [],
+  "38:20": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "38:21": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "38:22": [
+    {
+      "surface": "storehouses",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    }
+  ],
+  "38:23": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "38:24": [
+    {
+      "surface": "distributed",
+      "tw_match": "distributed"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "scatters",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "38:25": [],
+  "38:26": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "38:27": [
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "38:28": [
+    {
+      "surface": "begets",
+      "tw_match": "beget"
+    }
+  ],
+  "38:29": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    }
+  ],
+  "38:30": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "38:31": [],
+  "38:32": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Bear",
+      "tw_match": "bear"
+    }
+  ],
+  "38:33": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "38:34": [],
+  "38:35": [],
+  "38:36": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "38:37": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "38:38": [
+    {
+      "surface": "hardening",
+      "tw_match": "harden"
+    }
+  ],
+  "38:39": [
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "lioness",
+      "tw_match": "lioness"
+    }
+  ],
+  "38:40": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    }
+  ],
+  "38:41": [
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stagger",
+      "tw_match": "stagger"
+    }
+  ],
+  "39:1": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "fawning",
+      "tw_match": "fawn"
+    }
+  ],
+  "39:2": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    }
+  ],
+  "39:3": [
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "39:4": [],
+  "39:5": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "39:6": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "39:7": [],
+  "39:8": [
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    }
+  ],
+  "39:9": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "39:10": [
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "39:11": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "39:12": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "39:13": [],
+  "39:14": [
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "39:15": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    }
+  ],
+  "39:16": [
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "39:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "39:18": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    }
+  ],
+  "39:19": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    }
+  ],
+  "39:20": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    }
+  ],
+  "39:21": [
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    }
+  ],
+  "39:22": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "39:23": [
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "39:24": [
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "39:25": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "39:26": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "39:27": [
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    }
+  ],
+  "39:28": [
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    }
+  ],
+  "39:29": [
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    }
+  ],
+  "39:30": [
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "40:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "40:2": [
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "40:3": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "40:4": [
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    }
+  ],
+  "40:5": [],
+  "40:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "40:7": [
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "40:8": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "40:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "40:10": [
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "40:11": [
+    {
+      "surface": "Scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    }
+  ],
+  "40:12": [
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "40:13": [],
+  "40:14": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "40:15": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "40:16": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "40:17": [
+    {
+      "surface": "bends",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "40:18": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "40:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Maker",
+      "tw_match": "Maker"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "40:20": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "40:21": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    }
+  ],
+  "40:22": [],
+  "40:23": [
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "40:24": [
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "41:1": [
+    {
+      "surface": "Leviathan",
+      "tw_match": "Leviathan"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "41:2": [],
+  "41:3": [
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    }
+  ],
+  "41:4": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "41:5": [],
+  "41:6": [],
+  "41:7": [
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    }
+  ],
+  "41:8": [],
+  "41:9": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    }
+  ],
+  "41:10": [],
+  "41:11": [
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "41:12": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "41:13": [],
+  "41:14": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "41:15": [
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    }
+  ],
+  "41:16": [],
+  "41:17": [],
+  "41:18": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "41:19": [],
+  "41:20": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    }
+  ],
+  "41:21": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "41:22": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "41:23": [],
+  "41:24": [
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "41:25": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "41:26": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "41:27": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "41:28": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    }
+  ],
+  "41:29": [
+    {
+      "surface": "Clubs",
+      "tw_match": "clubs"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "41:30": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "41:31": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "41:32": [],
+  "41:33": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "41:34": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    }
+  ],
+  "42:1": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "42:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "42:3": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "42:4": [],
+  "42:5": [],
+  "42:6": [
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    }
+  ],
+  "42:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "42:8": [
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "42:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    }
+  ],
+  "42:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "42:11": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "42:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "42:13": [],
+  "42:14": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "42:15": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "42:16": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "42:17": [
+    {
+      "surface": "Job",
+      "tw_match": "Job"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_JOL.json
+++ b/sources/keyword_data/keywords_JOL.json
@@ -1,0 +1,1401 @@
+{
+  "1:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "drunkards",
+      "tw_match": "drunkard"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lioness",
+      "tw_match": "lioness"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "mourns",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "dries",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "pomegranate",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "Shaddai",
+      "tw_match": "shaddai"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "seeds",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "storehouses",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "garden of Eden",
+      "tw_match": "garden of Eden"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "steeds",
+      "tw_match": "steed"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "2:8": [],
+  "2:9": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "shakes",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "the western sea",
+      "tw_match": "the western sea"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "2:30": [
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "2:31": [
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    }
+  ],
+  "2:32": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "Philistia",
+      "tw_match": "Philistia"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "temples",
+      "tw_match": "temple"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:7": [],
+  "3:8": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "plowshares",
+      "tw_match": "plowshares"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    }
+  ],
+  "3:15": [],
+  "3:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_JON.json
+++ b/sources/keyword_data/keywords_JON.json
@@ -1,0 +1,885 @@
+{
+  "1:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "raging",
+      "tw_match": "rage"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "2:3": [],
+  "2:4": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "wrapped around",
+      "tw_match": "wrapped around"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "vanities",
+      "tw_match": "vanity"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "proclamation",
+      "tw_match": "proclamation"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "compassionate",
+      "tw_match": "compassionate"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_JOS.json
+++ b/sources/keyword_data/keywords_JOS.json
@@ -1,0 +1,11990 @@
+{
+  "1:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "Euphrates River",
+      "tw_match": "Euphrates River"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prosperous",
+      "tw_match": "prosperous"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    }
+  ],
+  "2:6": [],
+  "2:7": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "2:8": [],
+  "2:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "tied",
+      "tw_match": "tied"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Box of the Covenant of Yahweh",
+      "tw_match": "Box of the Covenant of Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "dispossessing",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box of the Covenant of Yahweh",
+      "tw_match": "Box of the Covenant of Yahweh"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Box of the Covenant of Yahweh",
+      "tw_match": "Box of the Covenant of Yahweh"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box of the Covenant of Yahweh",
+      "tw_match": "Box of the Covenant of Yahweh"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "circumcise",
+      "tw_match": "circumcise"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "circumcise",
+      "tw_match": "circumcise"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "sandal",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Box of the Covenant of Yahweh",
+      "tw_match": "Box of the Covenant of Yahweh"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "storehouse",
+      "tw_match": "storehouse"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "storehouse",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Cursed",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "Consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "confession",
+      "tw_match": "confession"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Shinar",
+      "tw_match": "Shinar"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "slaying",
+      "tw_match": "slay"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Box of the Covenant of Yahweh",
+      "tw_match": "Box of the Covenant of Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "cunning",
+      "tw_match": "cunning"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "slay",
+      "tw_match": "slay"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "avenged",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "commanders",
+      "tw_match": "commander"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "hanging",
+      "tw_match": "hang"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "10:31": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "10:34": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:35": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    }
+  ],
+  "10:36": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "10:37": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    }
+  ],
+  "10:38": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:39": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "10:40": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "breathing",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:41": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "10:42": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:43": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "breathing",
+      "tw_match": "breath"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "breathing",
+      "tw_match": "breath"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "Mount Hermon",
+      "tw_match": "Mount Hermon"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Hivites",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "harden",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Anakites",
+      "tw_match": "Anakites"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "Anakites",
+      "tw_match": "Anakites"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Mount Hermon",
+      "tw_match": "Mount Hermon"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "Sea of Kinnereth",
+      "tw_match": "Sea of Kinnereth"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Raphaites",
+      "tw_match": "Raphaites"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Mount Hermon",
+      "tw_match": "Mount Hermon"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Mount Hermon",
+      "tw_match": "Mount Hermon"
+    },
+    {
+      "surface": "Lebo Hamath",
+      "tw_match": "Lebo Hamath"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "Sidonians",
+      "tw_match": "Sidonians"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Mount Hermon",
+      "tw_match": "Mount Hermon"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Raphaites",
+      "tw_match": "Raphaites"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Geshur",
+      "tw_match": "Geshur"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "13:18": [],
+  "13:19": [],
+  "13:20": [
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "diviner",
+      "tw_match": "diviner"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    }
+  ],
+  "13:26": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "13:27": [
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Sea of Kinnereth",
+      "tw_match": "Sea of Kinnereth"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "13:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "13:30": [
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "13:31": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "13:32": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "13:33": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inherited",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Anakites",
+      "tw_match": "Anakites"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Kiriath Arba",
+      "tw_match": "Kiriath Arba"
+    },
+    {
+      "surface": "Anakites",
+      "tw_match": "Anakites"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Raphaites",
+      "tw_match": "Raphaites"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "Mount Seir",
+      "tw_match": "Mount Seir"
+    },
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Kiriath Arba",
+      "tw_match": "Kiriath Arba"
+    },
+    {
+      "surface": "Anak",
+      "tw_match": "Anak"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Anak",
+      "tw_match": "Anak"
+    }
+  ],
+  "15:15": [],
+  "15:16": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "captures",
+      "tw_match": "capture"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "15:22": [],
+  "15:23": [
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    }
+  ],
+  "15:24": [],
+  "15:25": [],
+  "15:26": [],
+  "15:27": [],
+  "15:28": [
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "15:29": [],
+  "15:30": [],
+  "15:31": [],
+  "15:32": [
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "15:33": [],
+  "15:34": [],
+  "15:35": [],
+  "15:36": [],
+  "15:37": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "15:38": [
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "15:39": [],
+  "15:40": [],
+  "15:41": [],
+  "15:42": [],
+  "15:43": [],
+  "15:44": [],
+  "15:45": [
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    }
+  ],
+  "15:46": [
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    }
+  ],
+  "15:47": [
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    }
+  ],
+  "15:48": [],
+  "15:49": [],
+  "15:50": [],
+  "15:51": [
+    {
+      "surface": "Goshen",
+      "tw_match": "Goshen"
+    }
+  ],
+  "15:52": [],
+  "15:53": [],
+  "15:54": [
+    {
+      "surface": "Kiriath Arba",
+      "tw_match": "Kiriath Arba"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "15:55": [
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    }
+  ],
+  "15:56": [
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "15:57": [
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    }
+  ],
+  "15:58": [],
+  "15:59": [],
+  "15:60": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Rabbah",
+      "tw_match": "Rabbah"
+    }
+  ],
+  "15:61": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    }
+  ],
+  "15:62": [
+    {
+      "surface": "En Gedi",
+      "tw_match": "En Gedi"
+    }
+  ],
+  "15:63": [
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "16:3": [],
+  "16:4": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "inherited",
+      "tw_match": "inherit"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "laborer",
+      "tw_match": "laborer"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "inherited",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "dispossessing",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Raphaites",
+      "tw_match": "Raphaites"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "Tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "Raphaites",
+      "tw_match": "Raphaites"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "18:23": [],
+  "18:24": [],
+  "18:25": [
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    }
+  ],
+  "18:27": [],
+  "18:28": [
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    }
+  ],
+  "19:3": [],
+  "19:4": [],
+  "19:5": [],
+  "19:6": [],
+  "19:7": [
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "inherited",
+      "tw_match": "inherit"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "19:12": [],
+  "19:13": [
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "19:14": [],
+  "19:15": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "Jezreel",
+      "tw_match": "Jezreel"
+    }
+  ],
+  "19:19": [],
+  "19:20": [],
+  "19:21": [],
+  "19:22": [
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "19:25": [],
+  "19:26": [
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    }
+  ],
+  "19:27": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "19:28": [
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    }
+  ],
+  "19:30": [],
+  "19:31": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "19:32": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "19:33": [
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "19:34": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "19:35": [
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    }
+  ],
+  "19:36": [
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    }
+  ],
+  "19:37": [
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    }
+  ],
+  "19:38": [
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    }
+  ],
+  "19:39": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "19:40": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "19:41": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "19:42": [],
+  "19:43": [
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    }
+  ],
+  "19:44": [],
+  "19:45": [
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "19:46": [
+    {
+      "surface": "Joppa",
+      "tw_match": "Joppa"
+    }
+  ],
+  "19:47": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "19:48": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "19:49": [
+    {
+      "surface": "inheriting",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "19:50": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "19:51": [
+    {
+      "surface": "inheritances",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Kiriath Arba",
+      "tw_match": "Kiriath Arba"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sojourned",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "Kiriath Arba",
+      "tw_match": "Kiriath Arba"
+    },
+    {
+      "surface": "Anak",
+      "tw_match": "Anak"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "21:14": [],
+  "21:15": [],
+  "21:16": [
+    {
+      "surface": "Beth Shemesh",
+      "tw_match": "Beth Shemesh"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "21:18": [],
+  "21:19": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "21:22": [],
+  "21:23": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    }
+  ],
+  "21:29": [],
+  "21:30": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "21:31": [],
+  "21:32": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Kedesh",
+      "tw_match": "Kedesh"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "21:33": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "21:34": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "21:35": [],
+  "21:36": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "21:37": [],
+  "21:38": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Ramoth",
+      "tw_match": "Ramoth"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "21:39": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    }
+  ],
+  "21:40": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "21:41": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:42": [],
+  "21:43": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    }
+  ],
+  "21:44": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "21:45": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "rebelling",
+      "tw_match": "rebel"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "Profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "22:31": [
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:32": [
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:33": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "22:34": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "aged",
+      "tw_match": "aged"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "transgressing",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Perizzite",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Hivite",
+      "tw_match": "Hivite"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "labored",
+      "tw_match": "labored"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "Profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:24": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:25": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "24:26": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "oak",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:27": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:28": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "24:29": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "24:30": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "24:31": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "24:32": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Hamor",
+      "tw_match": "Hamor"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "24:33": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Gibeah",
+      "tw_match": "Gibeah"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_JUD.json
+++ b/sources/keyword_data/keywords_JUD.json
@@ -1,0 +1,564 @@
+{
+  "1:1": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "in Jesus",
+      "tw_match": "in Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "exhorting",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "condemnation",
+      "tw_match": "condemnation"
+    },
+    {
+      "surface": "ungodly",
+      "tw_match": "ungodly"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "remind",
+      "tw_match": "remind"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "dreaming",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "slander",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    },
+    {
+      "surface": "archangel",
+      "tw_match": "archangel"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "arguing",
+      "tw_match": "arguing"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "slander",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "slander",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Cain",
+      "tw_match": "Cain"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "feasts",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "feasting",
+      "tw_match": "feasting"
+    },
+    {
+      "surface": "shepherding",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    },
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "ungodliness",
+      "tw_match": "ungodliness"
+    },
+    {
+      "surface": "ungodly",
+      "tw_match": "ungodly"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "lusts",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "boastful",
+      "tw_match": "boastful"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "mockers",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "lusts",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "ungodliness",
+      "tw_match": "ungodliness"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_LAM.json
+++ b/sources/keyword_data/keywords_LAM.json
@@ -1,0 +1,2257 @@
+{
+  "1:1": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "princess",
+      "tw_match": "princess"
+    },
+    {
+      "surface": "provinces",
+      "tw_match": "province"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "betrayed",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "deer",
+      "tw_match": "deer"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "restores",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "fortifications",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "fortifications",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "wasted",
+      "tw_match": "wasted"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "visions",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "3:2": [],
+  "3:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:4": [],
+  "3:5": [
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:7": [],
+  "3:8": [
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "perverted",
+      "tw_match": "pervert"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:13": [],
+  "3:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:15": [],
+  "3:16": [],
+  "3:17": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "3:28": [],
+  "3:29": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "3:30": [
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    }
+  ],
+  "3:31": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "3:32": [
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "3:33": [
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    }
+  ],
+  "3:34": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "3:35": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "3:36": [
+    {
+      "surface": "perverting",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "3:37": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "3:38": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "3:39": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    }
+  ],
+  "3:40": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:41": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "3:42": [
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "pardon",
+      "tw_match": "pardon"
+    }
+  ],
+  "3:43": [
+    {
+      "surface": "slayed",
+      "tw_match": "slay"
+    }
+  ],
+  "3:44": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "3:45": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "3:46": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "3:47": [
+    {
+      "surface": "Panic",
+      "tw_match": "panic"
+    },
+    {
+      "surface": "pitfall",
+      "tw_match": "pitfall"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "3:48": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "3:49": [],
+  "3:50": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "3:51": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "3:52": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:53": [
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "3:54": [],
+  "3:55": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "3:56": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "3:57": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "3:58": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "3:59": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "3:60": [
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    }
+  ],
+  "3:61": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:62": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:63": [],
+  "3:64": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:65": [
+    {
+      "surface": "condemnation",
+      "tw_match": "condemnation"
+    }
+  ],
+  "3:66": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "dispersing",
+      "tw_match": "disperse"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "wasted",
+      "tw_match": "wasted"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "compassionate",
+      "tw_match": "compassionate"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "sojourn",
+      "tw_match": "sojourn"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "watchtowers",
+      "tw_match": "watchtower"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "eagles",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "pits",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "5:5": [],
+  "5:6": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "5:10": [],
+  "5:11": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "hung",
+      "tw_match": "hung"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stagger",
+      "tw_match": "stagger"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "5:17": [],
+  "5:18": [
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_LEV.json
+++ b/sources/keyword_data/keywords_LEV.json
@@ -1,0 +1,14283 @@
+{
+  "1:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "acceptance",
+      "tw_match": "acceptance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "pigeon",
+      "tw_match": "pigeon"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "leaven",
+      "tw_match": "leaven"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "grains",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "grains",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar of incense",
+      "tw_match": "altar of incense"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace offering",
+      "tw_match": "peace offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "slaughters",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "doe",
+      "tw_match": "doe"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "4:33": [
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "slaughters",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "4:34": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "4:35": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "pigeon",
+      "tw_match": "pigeon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "regulation",
+      "tw_match": "regulations"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "pigeon",
+      "tw_match": "pigeon"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "trespass",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "trespass",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "citizen",
+      "tw_match": "citizen"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    },
+    {
+      "surface": "robbery",
+      "tw_match": "robbery"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "robbery",
+      "tw_match": "robbery"
+    },
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "consumes",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "leaven",
+      "tw_match": "leaven"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "6:28": [
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "7:3": [],
+  "7:4": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "leaven",
+      "tw_match": "leaven"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace offering",
+      "tw_match": "peace offering"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:31": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "7:32": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "7:33": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "7:34": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    }
+  ],
+  "7:35": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "7:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "7:37": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "ordination",
+      "tw_match": "ordination"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "7:38": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "breastplate",
+      "tw_match": "breastplate"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "ordination",
+      "tw_match": "ordination"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "ordination",
+      "tw_match": "ordination"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "ordination",
+      "tw_match": "ordination"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "ordination",
+      "tw_match": "ordination"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "ordination",
+      "tw_match": "ordination"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:36": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "9:11": [],
+  "9:12": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "regulation",
+      "tw_match": "regulations"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Mishael",
+      "tw_match": "Mishael"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    }
+  ],
+  "11:5": [],
+  "11:6": [],
+  "11:7": [
+    {
+      "surface": "pig",
+      "tw_match": "pig"
+    }
+  ],
+  "11:8": [],
+  "11:9": [],
+  "11:10": [
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "detest",
+      "tw_match": "detest"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "detest",
+      "tw_match": "detest"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    }
+  ],
+  "11:14": [],
+  "11:15": [],
+  "11:16": [],
+  "11:17": [],
+  "11:18": [],
+  "11:19": [],
+  "11:20": [
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "11:24": [],
+  "11:25": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:30": [],
+  "11:31": [],
+  "11:32": [
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "11:33": [],
+  "11:34": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    }
+  ],
+  "11:35": [],
+  "11:36": [
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "11:37": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "11:38": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "11:39": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "11:40": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "11:41": [
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "11:42": [
+    {
+      "surface": "multiplying",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "11:43": [
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "11:44": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:45": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "11:46": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:47": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "circumcised",
+      "tw_match": "circumcised"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "pigeon",
+      "tw_match": "pigeon"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "turtledoves",
+      "tw_match": "turtledove"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "13:18": [],
+  "13:19": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "13:24": [],
+  "13:25": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "13:26": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:27": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "13:29": [],
+  "13:30": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "13:31": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:32": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:33": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:34": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "13:35": [],
+  "13:36": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "13:37": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "13:38": [],
+  "13:39": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "13:40": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "13:41": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "13:42": [
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "13:43": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "13:44": [
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "13:45": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    }
+  ],
+  "13:46": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:47": [],
+  "13:48": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "13:49": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "13:50": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:51": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:52": [],
+  "13:53": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "13:54": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:55": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "13:56": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "13:57": [],
+  "13:58": [
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "13:59": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "slaughters",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "pigeon",
+      "tw_match": "pigeon"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:30": [
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "pigeon",
+      "tw_match": "pigeon"
+    }
+  ],
+  "14:31": [
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:32": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "14:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "14:34": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "14:35": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "14:36": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:37": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:38": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "14:39": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:40": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "14:41": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:42": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:43": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "14:44": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:45": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "14:46": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "14:47": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "14:48": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "14:49": [
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:50": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "14:51": [
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "14:52": [
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "14:53": [
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "14:54": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "14:55": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:56": [],
+  "14:57": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:3": [],
+  "15:4": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "15:9": [],
+  "15:10": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "15:12": [],
+  "15:13": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "pigeon",
+      "tw_match": "pigeon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "15:23": [],
+  "15:24": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "pigeon",
+      "tw_match": "pigeon"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "defiling",
+      "tw_match": "defile"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "Box",
+      "tw_match": "box"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scapegoat",
+      "tw_match": "scapegoat"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "scapegoat",
+      "tw_match": "scapegoat"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "Box of the Testimony",
+      "tw_match": "Box of the Testimony"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "scapegoat",
+      "tw_match": "scapegoat"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "16:29": [
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    }
+  ],
+  "16:30": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "16:31": [
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    }
+  ],
+  "16:32": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "anoints",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "16:33": [
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "16:34": [
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "slaughters",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "prostituting",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sojourns",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "18:7": [],
+  "18:8": [],
+  "18:9": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "18:10": [],
+  "18:11": [],
+  "18:12": [],
+  "18:13": [],
+  "18:14": [],
+  "18:15": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "18:16": [],
+  "18:17": [],
+  "18:18": [
+    {
+      "surface": "concubine",
+      "tw_match": "concubine"
+    }
+  ],
+  "18:19": [],
+  "18:20": [
+    {
+      "surface": "citizen",
+      "tw_match": "citizen"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "perversion",
+      "tw_match": "perversion"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "acceptance",
+      "tw_match": "acceptance"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "harvesting",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "gleaning",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "citizen",
+      "tw_match": "citizen"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "rob",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "citizen",
+      "tw_match": "citizen"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "slanderer",
+      "tw_match": "slanderers"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "Reproving",
+      "tw_match": "reprove"
+    },
+    {
+      "surface": "reprove",
+      "tw_match": "reprove"
+    },
+    {
+      "surface": "citizen",
+      "tw_match": "citizen"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "freed",
+      "tw_match": "freed"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:25": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:26": [
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "soothsaying",
+      "tw_match": "soothsaying"
+    }
+  ],
+  "19:27": [
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "19:28": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "19:30": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "19:31": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:32": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "19:33": [
+    {
+      "surface": "sojourns",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "19:34": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:35": [
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "19:36": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "19:37": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "customs",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "prostituting",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "Molech",
+      "tw_match": "Molech"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "adulterer",
+      "tw_match": "adulterer"
+    },
+    {
+      "surface": "adulteress",
+      "tw_match": "adulteress"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "perversion",
+      "tw_match": "perversion"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "20:14": [],
+  "20:15": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "20:21": [],
+  "20:22": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "21:2": [],
+  "21:3": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    }
+  ],
+  "21:5": [],
+  "21:6": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "prostituting",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "prostituting",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "profaning",
+      "tw_match": "profane"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "virginity",
+      "tw_match": "virginity"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "prostituting",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    }
+  ],
+  "21:19": [],
+  "21:20": [
+    {
+      "surface": "defect",
+      "tw_match": "defect"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "washes",
+      "tw_match": "wash"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "freewill",
+      "tw_match": "freewill"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "acceptance",
+      "tw_match": "acceptance"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "acceptance",
+      "tw_match": "acceptance"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "acceptance",
+      "tw_match": "acceptance"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "22:31": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "22:32": [
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "22:33": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "assemblies",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "assemblies",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "acceptance",
+      "tw_match": "acceptance"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "leaven",
+      "tw_match": "leaven"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "harvesting",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "gleaning",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "23:27": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "23:30": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "23:31": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "23:32": [
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "23:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "23:34": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:35": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "23:36": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "23:37": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "assemblies",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "23:38": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "freewill",
+      "tw_match": "freewill"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "23:39": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "23:40": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "23:41": [
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "23:42": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "23:43": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:44": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holies",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "Egyptian",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Stoning",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "blasphemes",
+      "tw_match": "blaspheme"
+    }
+  ],
+  "24:17": [],
+  "24:18": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "citizen",
+      "tw_match": "citizen"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "sojourns",
+      "tw_match": "sojourn"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "Day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "liberty",
+      "tw_match": "liberty"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "Year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "25:14": [],
+  "25:15": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "citizen",
+      "tw_match": "citizen"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "25:20": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "25:21": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "25:22": [
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "25:23": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "25:24": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "25:25": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    }
+  ],
+  "25:26": [
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "25:27": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "25:28": [
+    {
+      "surface": "Year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "25:29": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "completes",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "Days",
+      "tw_match": "day"
+    }
+  ],
+  "25:30": [
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "fulfills",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "25:31": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "25:32": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "25:33": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "25:34": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "25:35": [],
+  "25:36": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "25:37": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "25:38": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "25:39": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "25:40": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "25:41": [
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "25:42": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "25:43": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "25:44": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "25:45": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "25:46": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "25:47": [
+    {
+      "surface": "member",
+      "tw_match": "member"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "25:48": [
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    }
+  ],
+  "25:49": [
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "25:50": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "25:51": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "25:52": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "25:53": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "25:54": [
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "Year",
+      "tw_match": "year"
+    }
+  ],
+  "25:55": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "carved image",
+      "tw_match": "carved image"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "grape",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "26:14": [],
+  "26:15": [
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "detests",
+      "tw_match": "detest"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "26:18": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "26:20": [
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "26:21": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "26:22": [
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "26:23": [],
+  "26:24": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "26:25": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "avenging",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "26:26": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "26:27": [],
+  "26:28": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "26:29": [],
+  "26:30": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "detest",
+      "tw_match": "detest"
+    }
+  ],
+  "26:31": [
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "26:32": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "26:33": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    }
+  ],
+  "26:34": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "26:35": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "26:36": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "26:37": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "26:38": [
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "26:39": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "26:40": [
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    }
+  ],
+  "26:41": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "uncircumcised",
+      "tw_match": "uncircumcised"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "26:42": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "26:43": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "deserted",
+      "tw_match": "deserted"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "detested",
+      "tw_match": "detested"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "26:44": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "detest",
+      "tw_match": "detest"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "26:45": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "26:46": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "persons",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "27:4": [],
+  "27:5": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "vowing",
+      "tw_match": "vow"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "redeeming",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "consecrates",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "consecrating",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "consecrates",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "consecrates",
+      "tw_match": "consecrate"
+    }
+  ],
+  "27:18": [
+    {
+      "surface": "consecrates",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "27:19": [
+    {
+      "surface": "redeeming",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "consecrating",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "27:20": [
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "27:21": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "27:22": [
+    {
+      "surface": "consecrates",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "27:23": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:24": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "27:25": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "27:26": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "27:27": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "27:28": [
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "27:29": [
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "ransomed",
+      "tw_match": "ransomed"
+    }
+  ],
+  "27:30": [
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "27:31": [
+    {
+      "surface": "redeeming",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    }
+  ],
+  "27:32": [
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:33": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "27:34": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_LUK.json
+++ b/sources/keyword_data/keywords_LUK.json
@@ -1,0 +1,14783 @@
+{
+  "1:1": [
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "eyewitnesses",
+      "tw_match": "eyewitness"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Elizabeth",
+      "tw_match": "Elizabeth"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Elizabeth",
+      "tw_match": "Elizabeth"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "altar of incense",
+      "tw_match": "altar of incense"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "Elizabeth",
+      "tw_match": "Elizabeth"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "strong drink",
+      "tw_match": "strong drink"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Gabriel",
+      "tw_match": "Gabriel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "wondering",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Elizabeth",
+      "tw_match": "Elizabeth"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Gabriel",
+      "tw_match": "Gabriel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "favored",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "1:30": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:31": [
+    {
+      "surface": "conceive",
+      "tw_match": "conceive"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:32": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "1:33": [
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "kingship",
+      "tw_match": "kingship"
+    }
+  ],
+  "1:34": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "1:35": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:36": [
+    {
+      "surface": "Elizabeth",
+      "tw_match": "Elizabeth"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    }
+  ],
+  "1:37": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:38": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "1:39": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:40": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Elizabeth",
+      "tw_match": "Elizabeth"
+    }
+  ],
+  "1:41": [
+    {
+      "surface": "Elizabeth",
+      "tw_match": "Elizabeth"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "1:42": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "1:43": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:44": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "1:45": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:46": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:47": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    }
+  ],
+  "1:48": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "1:49": [
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "1:50": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    }
+  ],
+  "1:51": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    }
+  ],
+  "1:52": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "1:53": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:54": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "1:55": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "1:56": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "1:57": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Elizabeth",
+      "tw_match": "Elizabeth"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "1:58": [
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    }
+  ],
+  "1:59": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "circumcise",
+      "tw_match": "circumcise"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "1:60": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "1:61": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "1:62": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "1:63": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "1:64": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:65": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    }
+  ],
+  "1:66": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:67": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "1:68": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "1:69": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "1:70": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "1:71": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "1:72": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "1:73": [
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "1:74": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "1:75": [
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "1:76": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:77": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "1:78": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:79": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "1:80": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "governing",
+      "tw_match": "govern"
+    },
+    {
+      "surface": "Syria",
+      "tw_match": "Syria"
+    }
+  ],
+  "2:3": [],
+  "2:4": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "2:17": [],
+  "2:18": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "praising",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "circumcise",
+      "tw_match": "circumcise"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "pigeons",
+      "tw_match": "pigeon"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "2:30": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "2:31": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "2:32": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:33": [],
+  "2:34": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "2:35": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "2:36": [
+    {
+      "surface": "prophetess",
+      "tw_match": "prophetess"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "virginity",
+      "tw_match": "virginity"
+    }
+  ],
+  "2:37": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "fastings",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:38": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:39": [
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    }
+  ],
+  "2:40": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:41": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "2:42": [
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "2:43": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:44": [
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "2:45": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    }
+  ],
+  "2:46": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    }
+  ],
+  "2:47": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "2:48": [
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    }
+  ],
+  "2:49": [
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "2:50": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "2:51": [
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    },
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    }
+  ],
+  "2:52": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "governing",
+      "tw_match": "govern"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "tetrarch",
+      "tw_match": "tetrarch"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "Annas",
+      "tw_match": "Annas"
+    },
+    {
+      "surface": "Caiaphas",
+      "tw_match": "Caiaphas"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "3:5": [],
+  "3:6": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "vipers",
+      "tw_match": "viper"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "ax",
+      "tw_match": "ax"
+    },
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "3:10": [],
+  "3:11": [
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    }
+  ],
+  "3:13": [],
+  "3:14": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "wondering",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "baptize",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "winnowing",
+      "tw_match": "winnow"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "storehouse",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "unquenchable",
+      "tw_match": "unquenchable"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "exhorting",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "preached",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "tetrarch",
+      "tw_match": "tetrarch"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "Herodias",
+      "tw_match": "Herodias"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "Amos",
+      "tw_match": "Amos"
+    },
+    {
+      "surface": "Nahum",
+      "tw_match": "Nahum"
+    }
+  ],
+  "3:26": [],
+  "3:27": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    }
+  ],
+  "3:28": [],
+  "3:29": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "3:30": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    }
+  ],
+  "3:31": [
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "3:32": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    }
+  ],
+  "3:33": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "3:34": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    },
+    {
+      "surface": "Nahor",
+      "tw_match": "Nahor"
+    }
+  ],
+  "3:35": [],
+  "3:36": [
+    {
+      "surface": "Shem",
+      "tw_match": "Shem"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Lamech",
+      "tw_match": "Lamech"
+    }
+  ],
+  "3:37": [
+    {
+      "surface": "Enoch",
+      "tw_match": "Enoch"
+    }
+  ],
+  "3:38": [
+    {
+      "surface": "Seth",
+      "tw_match": "Seth"
+    },
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tempted",
+      "tw_match": "tempt"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "temptation",
+      "tw_match": "temptation"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    },
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "Spirit of the Lord",
+      "tw_match": "Spirit of the Lord"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "favorable",
+      "tw_match": "favorable"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "lepers",
+      "tw_match": "leper"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Elisha",
+      "tw_match": "Elisha"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "4:29": [],
+  "4:30": [],
+  "4:31": [
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "4:33": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    }
+  ],
+  "4:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:35": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "hurting",
+      "tw_match": "hurt"
+    }
+  ],
+  "4:36": [
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "4:37": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "4:38": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    }
+  ],
+  "4:39": [
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "4:40": [],
+  "4:41": [
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rebuking",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "4:42": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "4:43": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "4:44": [
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "lake of Gennesaret",
+      "tw_match": "lake of Gennesaret"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "fishermen",
+      "tw_match": "fishermen"
+    },
+    {
+      "surface": "washing",
+      "tw_match": "wash"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "catch",
+      "tw_match": "catch"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    }
+  ],
+  "5:6": [],
+  "5:7": [],
+  "5:8": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "catch",
+      "tw_match": "catch"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Zebedee",
+      "tw_match": "Zebedee"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "catching",
+      "tw_match": "catch"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "leprosy",
+      "tw_match": "leprosy"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "leprosy",
+      "tw_match": "leprosy"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "5:15": [],
+  "5:16": [
+    {
+      "surface": "deserted",
+      "tw_match": "deserted"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "blasphemies",
+      "tw_match": "blasphemy"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "tax collector",
+      "tw_match": "tax collector"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "5:28": [],
+  "5:29": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "5:31": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "5:32": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    }
+  ],
+  "5:33": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "5:34": [
+    {
+      "surface": "bridal",
+      "tw_match": "bridal"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    }
+  ],
+  "5:35": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    }
+  ],
+  "5:36": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "5:37": [
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "wineskins",
+      "tw_match": "wineskin"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "5:38": [
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "wineskins",
+      "tw_match": "wineskin"
+    }
+  ],
+  "5:39": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "grainfields",
+      "tw_match": "grainfields"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "not lawful",
+      "tw_match": "not lawful"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "not lawful",
+      "tw_match": "not lawful"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "Son of Man",
+      "tw_match": "Son of Man"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Bartholomew",
+      "tw_match": "Bartholomew"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "Matthew",
+      "tw_match": "Matthew"
+    },
+    {
+      "surface": "Thomas",
+      "tw_match": "Thomas"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "Judas son of James",
+      "tw_match": "Judas son of James"
+    },
+    {
+      "surface": "Judas Iscariot",
+      "tw_match": "Judas Iscariot"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "insult",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "6:28": [
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "mistreating",
+      "tw_match": "mistreat"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    }
+  ],
+  "6:30": [],
+  "6:31": [],
+  "6:32": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "6:33": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "6:34": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "6:35": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:36": [
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "6:37": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    },
+    {
+      "surface": "Release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    }
+  ],
+  "6:38": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "6:39": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "6:40": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "6:41": [],
+  "6:42": [
+    {
+      "surface": "hypocrite",
+      "tw_match": "hypocrite"
+    }
+  ],
+  "6:43": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "6:44": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "6:45": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:46": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "6:47": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "6:48": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "6:49": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "carried out",
+      "tw_match": "carried out"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    }
+  ],
+  "7:15": [],
+  "7:16": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "afflictions",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "lepers",
+      "tw_match": "leper"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "7:30": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "7:31": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "7:32": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    }
+  ],
+  "7:33": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    }
+  ],
+  "7:34": [
+    {
+      "surface": "Son of Man",
+      "tw_match": "Son of Man"
+    },
+    {
+      "surface": "drunkard",
+      "tw_match": "drunkard"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "7:35": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "7:36": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "7:37": [
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "7:38": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "kissing",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "7:39": [
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    }
+  ],
+  "7:40": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    }
+  ],
+  "7:41": [],
+  "7:42": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "7:43": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "7:44": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "7:45": [
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "kissing",
+      "tw_match": "kiss"
+    }
+  ],
+  "7:46": [
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "7:47": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "7:48": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "7:49": [
+    {
+      "surface": "forgives",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "7:50": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "manager",
+      "tw_match": "manager"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "sower",
+      "tw_match": "sower"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "mysteries",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "8:17": [],
+  "8:18": [],
+  "8:19": [],
+  "8:20": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "8:23": [],
+  "8:24": [
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "tombs",
+      "tw_match": "tomb"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "torment",
+      "tw_match": "torment"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "bonds",
+      "tw_match": "bonds"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    },
+    {
+      "surface": "abyss",
+      "tw_match": "abyss"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    },
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "minded",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "8:36": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "8:37": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "8:38": [
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    }
+  ],
+  "8:39": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "8:40": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    }
+  ],
+  "8:41": [
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "8:42": [
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    }
+  ],
+  "8:43": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "8:44": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "8:45": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    }
+  ],
+  "8:46": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "8:47": [
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "8:48": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "8:49": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    }
+  ],
+  "8:50": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "8:51": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    }
+  ],
+  "8:52": [
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "8:53": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "8:54": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    }
+  ],
+  "8:55": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "8:56": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "tetrarch",
+      "tw_match": "tetrarch"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "9:13": [],
+  "9:14": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:15": [],
+  "9:16": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:17": [],
+  "9:18": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:32": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "9:33": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "9:34": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "9:35": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "9:36": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "9:37": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:38": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    }
+  ],
+  "9:39": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    }
+  ],
+  "9:40": [
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:41": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "perverted",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "9:42": [
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    }
+  ],
+  "9:43": [
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:44": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "9:45": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "9:46": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:47": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "9:48": [
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    }
+  ],
+  "9:49": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "9:50": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "9:51": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:52": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Samaritan",
+      "tw_match": "Samaritan"
+    }
+  ],
+  "9:53": [
+    {
+      "surface": "welcome",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "9:54": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "9:55": [
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    }
+  ],
+  "9:56": [],
+  "9:57": [],
+  "9:58": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:59": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "9:60": [
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "9:61": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "9:62": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "plow",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "laborers",
+      "tw_match": "laborer"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "laborer",
+      "tw_match": "laborer"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Hades",
+      "tw_match": "Hades"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "rejecting",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "rejects",
+      "tw_match": "reject"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "snakes",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "10:28": [],
+  "10:29": [
+    {
+      "surface": "justify",
+      "tw_match": "justify"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "10:30": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    }
+  ],
+  "10:31": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "Samaritan",
+      "tw_match": "Samaritan"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "10:34": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "10:35": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:36": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    }
+  ],
+  "10:37": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "10:38": [
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    },
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    }
+  ],
+  "10:39": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "10:40": [
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "10:41": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Martha",
+      "tw_match": "Martha"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "10:42": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "temptation",
+      "tw_match": "temptation"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "Friend",
+      "tw_match": "friend"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    }
+  ],
+  "11:12": [],
+  "11:13": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "Beelzebul",
+      "tw_match": "Beelzebul"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "Beelzebul",
+      "tw_match": "Beelzebul"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "Beelzebul",
+      "tw_match": "Beelzebul"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "armor",
+      "tw_match": "armor"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "spoils",
+      "tw_match": "spoils"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "scatters",
+      "tw_match": "scatter"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "11:25": [],
+  "11:26": [
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Ninevites",
+      "tw_match": "Ninevite"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "Queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    }
+  ],
+  "11:33": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "11:34": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "11:35": [
+    {
+      "surface": "beware",
+      "tw_match": "beware"
+    }
+  ],
+  "11:36": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    }
+  ],
+  "11:37": [
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "11:38": [
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "11:39": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "11:40": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "11:41": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "11:42": [
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:43": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    }
+  ],
+  "11:44": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "11:45": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "insult",
+      "tw_match": "insult"
+    }
+  ],
+  "11:46": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "11:47": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "tombs",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "11:48": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "11:49": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "persecute",
+      "tw_match": "persecute"
+    }
+  ],
+  "11:50": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "11:51": [
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "11:52": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "11:53": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "11:54": [
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "hypocrisy",
+      "tw_match": "hypocrisy"
+    }
+  ],
+  "12:2": [],
+  "12:3": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "confesses",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "authorities",
+      "tw_match": "authority"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "mediator",
+      "tw_match": "mediator"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "12:23": [],
+  "12:24": [
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:25": [],
+  "12:26": [],
+  "12:27": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "12:30": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "12:31": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "12:32": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "12:33": [
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "12:34": [],
+  "12:35": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    }
+  ],
+  "12:36": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "12:37": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "12:38": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "12:39": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "12:40": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "12:41": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    }
+  ],
+  "12:42": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "manager",
+      "tw_match": "manager"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "12:43": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "12:44": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "12:45": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    }
+  ],
+  "12:46": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    }
+  ],
+  "12:47": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "12:48": [],
+  "12:49": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "12:50": [
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "12:51": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "12:52": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "12:53": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "12:54": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "12:55": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "12:56": [
+    {
+      "surface": "Hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "interpret",
+      "tw_match": "interpret"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "12:57": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "12:58": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "magistrate",
+      "tw_match": "magistrate"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "12:59": [],
+  "13:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "reporting",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Galileans",
+      "tw_match": "Galilean"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "Galileans",
+      "tw_match": "Galilean"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "manure",
+      "tw_match": "manure"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "bond",
+      "tw_match": "bond"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "leavened",
+      "tw_match": "leaven"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "13:26": [],
+  "13:27": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "13:29": [
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "13:30": [],
+  "13:31": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "13:32": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:33": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "13:34": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "stoning",
+      "tw_match": "stoning"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "13:35": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "14:2": [],
+  "14:3": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "14:4": [],
+  "14:5": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "14:6": [],
+  "14:7": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "choosing",
+      "tw_match": "choose"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "Friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "exalting",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "humbling",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "banquet",
+      "tw_match": "banquet"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "14:16": [],
+  "14:17": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "14:18": [],
+  "14:19": [],
+  "14:20": [
+    {
+      "surface": "married",
+      "tw_match": "married"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "14:24": [],
+  "14:25": [],
+  "14:26": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    }
+  ],
+  "14:30": [],
+  "14:31": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "14:32": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "14:33": [
+    {
+      "surface": "possesses",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    }
+  ],
+  "14:34": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "14:35": [
+    {
+      "surface": "manure",
+      "tw_match": "manure"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "repenting",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "sweep",
+      "tw_match": "sweep"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "repenting",
+      "tw_match": "repent"
+    }
+  ],
+  "15:11": [],
+  "15:12": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "distributed",
+      "tw_match": "distributed"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "wasted",
+      "tw_match": "wasted"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "citizens",
+      "tw_match": "citizen"
+    },
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "15:28": [],
+  "15:29": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "slaving",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    }
+  ],
+  "15:31": [],
+  "15:32": [
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "manager",
+      "tw_match": "manager"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "wasting",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "manager",
+      "tw_match": "manager"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "welcome",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "manager",
+      "tw_match": "manager"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "welcome",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "ridiculing",
+      "tw_match": "ridicule"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "justifying",
+      "tw_match": "justify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "marrying",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "feasting",
+      "tw_match": "feasting"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "16:21": [],
+  "16:22": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "Hades",
+      "tw_match": "Hades"
+    },
+    {
+      "surface": "torment",
+      "tw_match": "torment"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Lazarus",
+      "tw_match": "Lazarus"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "torment",
+      "tw_match": "torment"
+    }
+  ],
+  "16:29": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "16:30": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    }
+  ],
+  "16:31": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "repents",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "plowing",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "girding",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "17:12": [],
+  "17:13": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "Samaritan",
+      "tw_match": "Samaritan"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "17:23": [],
+  "17:24": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "17:25": [
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "17:26": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "17:27": [
+    {
+      "surface": "marrying",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "marriage",
+      "tw_match": "marriage"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "17:28": [
+    {
+      "surface": "Likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "planting",
+      "tw_match": "plant"
+    }
+  ],
+  "17:29": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "sulfur",
+      "tw_match": "sulfur"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "17:30": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "17:31": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "17:32": [
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    }
+  ],
+  "17:33": [
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "17:34": [],
+  "17:35": [],
+  "17:36": [],
+  "17:37": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:3": [],
+  "18:4": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "tax collector",
+      "tw_match": "tax collector"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "adulterers",
+      "tw_match": "adulterer"
+    },
+    {
+      "surface": "tax collector",
+      "tw_match": "tax collector"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "week",
+      "tw_match": "week"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "tax collector",
+      "tw_match": "tax collector"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "exalting",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "humbling",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "rebuking",
+      "tw_match": "rebuke"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "18:21": [],
+  "18:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "18:23": [],
+  "18:24": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "18:31": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "18:32": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "mistreated",
+      "tw_match": "mistreat"
+    }
+  ],
+  "18:33": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "18:34": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "18:35": [
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    }
+  ],
+  "18:36": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "18:37": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    }
+  ],
+  "18:38": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "18:39": [
+    {
+      "surface": "rebuking",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "18:40": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "18:41": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "18:42": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "18:43": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Zacchaeus",
+      "tw_match": "Zacchaeus"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "tax collector",
+      "tw_match": "tax collector"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Zacchaeus",
+      "tw_match": "Zacchaeus"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "welcomed",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "Zacchaeus",
+      "tw_match": "Zacchaeus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "citizens",
+      "tw_match": "citizen"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "Well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "19:19": [],
+  "19:20": [
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "reaping",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "19:24": [],
+  "19:25": [
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    }
+  ],
+  "19:26": [],
+  "19:27": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "19:28": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Olives",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "19:30": [
+    {
+      "surface": "tied up",
+      "tw_match": "tied up"
+    }
+  ],
+  "19:31": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "19:32": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "19:33": [],
+  "19:34": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "19:35": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "19:36": [],
+  "19:37": [
+    {
+      "surface": "Mount of Olives",
+      "tw_match": "Mount of Olives"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mighty works",
+      "tw_match": "mighty works"
+    }
+  ],
+  "19:38": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "19:39": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "19:40": [
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "19:41": [],
+  "19:42": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "19:43": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "19:44": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "19:45": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    }
+  ],
+  "19:46": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    }
+  ],
+  "19:47": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "19:48": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "hanging",
+      "tw_match": "hang"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "20:12": [],
+  "20:13": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "heir",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "watched",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    }
+  ],
+  "20:23": [],
+  "20:24": [
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:26": [],
+  "20:27": [
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "20:29": [],
+  "20:30": [],
+  "20:31": [
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "20:32": [],
+  "20:33": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "20:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "marriage",
+      "tw_match": "marriage"
+    }
+  ],
+  "20:35": [
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "marriage",
+      "tw_match": "marriage"
+    }
+  ],
+  "20:36": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "sons of God",
+      "tw_match": "sons of God"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "20:37": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "20:38": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:39": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "20:40": [],
+  "20:41": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "20:42": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Psalms",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "20:43": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    }
+  ],
+  "20:44": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "20:45": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "20:46": [
+    {
+      "surface": "Beware",
+      "tw_match": "beware"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "banquets",
+      "tw_match": "banquet"
+    }
+  ],
+  "20:47": [
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "condemnation",
+      "tw_match": "condemnation"
+    }
+  ],
+  "21:1": [],
+  "21:2": [],
+  "21:3": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    }
+  ],
+  "21:4": [],
+  "21:5": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "rebellions",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "Nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "famines",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "persecute",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "21:14": [],
+  "21:15": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "21:17": [],
+  "21:18": [
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "21:29": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    }
+  ],
+  "21:30": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "21:31": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "21:32": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "21:33": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "21:34": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "21:35": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "21:36": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "21:37": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "21:38": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "Day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "22:9": [],
+  "22:10": [
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "22:12": [],
+  "22:13": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "22:17": [],
+  "22:18": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "22:21": [],
+  "22:22": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "quarrel",
+      "tw_match": "quarrel"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "trials",
+      "tw_match": "trial"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:31": [
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "sift",
+      "tw_match": "sift"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "22:32": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "22:33": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "22:34": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "22:35": [
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "22:36": [
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "22:37": [
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    }
+  ],
+  "22:38": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    }
+  ],
+  "22:39": [
+    {
+      "surface": "custom",
+      "tw_match": "customs"
+    },
+    {
+      "surface": "Mount of Olives",
+      "tw_match": "Mount of Olives"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "22:40": [
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "temptation",
+      "tw_match": "temptation"
+    }
+  ],
+  "22:41": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    }
+  ],
+  "22:42": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "22:43": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "22:44": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "22:45": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "22:46": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "temptation",
+      "tw_match": "temptation"
+    }
+  ],
+  "22:47": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    }
+  ],
+  "22:48": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "betraying",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    }
+  ],
+  "22:49": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "22:50": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "22:51": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "22:52": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "robber",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "clubs",
+      "tw_match": "clubs"
+    }
+  ],
+  "22:53": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "22:54": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "22:55": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "22:56": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "22:57": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "22:58": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "22:59": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Galilean",
+      "tw_match": "Galilean"
+    }
+  ],
+  "22:60": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "22:61": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "word of the Lord",
+      "tw_match": "word of the Lord"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "22:62": [],
+  "22:63": [
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    }
+  ],
+  "22:64": [
+    {
+      "surface": "Prophesy",
+      "tw_match": "prophesy"
+    }
+  ],
+  "22:65": [
+    {
+      "surface": "blaspheming",
+      "tw_match": "blaspheme"
+    }
+  ],
+  "22:66": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    }
+  ],
+  "22:67": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "22:68": [],
+  "22:69": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:70": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:71": [
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "perverting",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "Galilean",
+      "tw_match": "Galilean"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "hoping",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "23:9": [],
+  "23:10": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    }
+  ],
+  "23:14": [],
+  "23:15": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "Barabbas",
+      "tw_match": "Barabbas"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "Crucify",
+      "tw_match": "crucify"
+    },
+    {
+      "surface": "crucify",
+      "tw_match": "crucify"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "23:26": [
+    {
+      "surface": "seizing",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "23:27": [
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "wombs",
+      "tw_match": "womb"
+    }
+  ],
+  "23:30": [],
+  "23:31": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    }
+  ],
+  "23:32": [],
+  "23:33": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "23:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "23:35": [
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "ridiculing",
+      "tw_match": "ridicule"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Chosen One",
+      "tw_match": "Chosen One"
+    }
+  ],
+  "23:36": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "23:37": [
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "23:38": [
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "23:39": [
+    {
+      "surface": "hung",
+      "tw_match": "hung"
+    },
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    }
+  ],
+  "23:40": [
+    {
+      "surface": "rebuking",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "23:41": [
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "23:42": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "23:43": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    }
+  ],
+  "23:44": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:45": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "23:46": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "23:47": [
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "glorifying",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "23:48": [],
+  "23:49": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "23:50": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "council",
+      "tw_match": "council"
+    },
+    {
+      "surface": "member",
+      "tw_match": "member"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "23:51": [
+    {
+      "surface": "council",
+      "tw_match": "council"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "23:52": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "23:53": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "23:54": [
+    {
+      "surface": "Day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "23:55": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "23:56": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "week",
+      "tw_match": "week"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "24:4": [],
+  "24:5": [
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "24:8": [],
+  "24:9": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "Mary Magdalene",
+      "tw_match": "Mary Magdalene"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "wondering",
+      "tw_match": "wonder"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "24:14": [],
+  "24:15": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "24:16": [],
+  "24:17": [],
+  "24:18": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "hoping",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "24:24": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "24:25": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "24:26": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "24:27": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    }
+  ],
+  "24:28": [
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    }
+  ],
+  "24:29": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "24:30": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "24:31": [],
+  "24:32": [
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    }
+  ],
+  "24:33": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "24:34": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "24:35": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "24:36": [
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "24:37": [
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "24:38": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "24:39": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "24:40": [],
+  "24:41": [
+    {
+      "surface": "wondering",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "24:42": [],
+  "24:43": [],
+  "24:44": [
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Psalms",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "24:45": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    }
+  ],
+  "24:46": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "24:47": [
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "24:48": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "24:49": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "24:50": [
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "24:51": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "24:52": [
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "24:53": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_MAL.json
+++ b/sources/keyword_data/keywords_MAL.json
@@ -1,0 +1,1144 @@
+{
+  "1:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Malachi",
+      "tw_match": "Malachi"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "honors",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "profaning",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "blemished",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "rebuking",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    },
+    {
+      "surface": "festivals",
+      "tw_match": "festival"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "create",
+      "tw_match": "create"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "purifying",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "sorcerers",
+      "tw_match": "sorcerer"
+    },
+    {
+      "surface": "adulterers",
+      "tw_match": "adulterer"
+    },
+    {
+      "surface": "swearing",
+      "tw_match": "swearing"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "rob",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "robbing",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "robbing",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "corrupt",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_MAT.json
+++ b/sources/keyword_data/keywords_MAT.json
@@ -1,0 +1,15017 @@
+{
+  "1:1": [
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    },
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Rehoboam",
+      "tw_match": "Rehoboam"
+    },
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "Jehoshaphat",
+      "tw_match": "Jehoshaphat"
+    },
+    {
+      "surface": "Joram",
+      "tw_match": "Joram"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Amos",
+      "tw_match": "Amos"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "Babylonian",
+      "tw_match": "Babylonian"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Babylonian",
+      "tw_match": "Babylonian"
+    },
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Babylonian",
+      "tw_match": "Babylonian"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "virgin",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "inquired",
+      "tw_match": "inquire"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "reigning",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "waist",
+      "tw_match": "waist"
+    },
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Jordan River",
+      "tw_match": "Jordan River"
+    },
+    {
+      "surface": "confessing",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "vipers",
+      "tw_match": "viper"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "ax",
+      "tw_match": "ax"
+    },
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "baptize",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "winnowing",
+      "tw_match": "winnow"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "storehouse",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "unquenchable",
+      "tw_match": "unquenchable"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "tempted",
+      "tw_match": "tempt"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "tempting",
+      "tw_match": "tempt"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "holy city",
+      "tw_match": "holy city"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    },
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "4:16": [],
+  "4:17": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "Repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "Sea of Galilee",
+      "tw_match": "Sea of Galilee"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "fishermen",
+      "tw_match": "fishermen"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "fishers",
+      "tw_match": "fishers"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "Zebedee",
+      "tw_match": "Zebedee"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "Syria",
+      "tw_match": "Syria"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "5:2": [],
+  "5:3": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "meek",
+      "tw_match": "meek"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "peacemakers",
+      "tw_match": "peacemakers"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "sons of God",
+      "tw_match": "sons of God"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "insult",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "persecute",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "be subject to",
+      "tw_match": "be subject to"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "be subject to",
+      "tw_match": "be subject to"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "council",
+      "tw_match": "council"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "reconciled",
+      "tw_match": "reconciled"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "lust",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "5:31": [],
+  "5:32": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "marries",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    }
+  ],
+  "5:33": [
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "oaths",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "5:34": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:35": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    }
+  ],
+  "5:36": [
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    }
+  ],
+  "5:37": [
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    }
+  ],
+  "5:38": [],
+  "5:39": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "5:40": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "tunic",
+      "tw_match": "tunic"
+    }
+  ],
+  "5:41": [],
+  "5:42": [],
+  "5:43": [
+    {
+      "surface": "Love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "5:44": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    }
+  ],
+  "5:45": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "unjust",
+      "tw_match": "unjust"
+    }
+  ],
+  "5:46": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    }
+  ],
+  "5:47": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "5:48": [
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "heavenly Father",
+      "tw_match": "heavenly Father"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "take heed",
+      "tw_match": "take heed"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "alms",
+      "tw_match": "alms"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "temptation",
+      "tw_match": "temptation"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "heavenly Father",
+      "tw_match": "heavenly Father"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    }
+  ],
+  "6:21": [],
+  "6:22": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "devoted",
+      "tw_match": "devoted"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "heavenly Father",
+      "tw_match": "heavenly Father"
+    }
+  ],
+  "6:27": [],
+  "6:28": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "6:29": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "6:31": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:32": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "heavenly Father",
+      "tw_match": "heavenly Father"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "6:33": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "6:34": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "7:3": [],
+  "7:4": [],
+  "7:5": [
+    {
+      "surface": "hypocrite",
+      "tw_match": "hypocrite"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "Beware",
+      "tw_match": "beware"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "thistles",
+      "tw_match": "thistle"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "lawlessness",
+      "tw_match": "lawlessness"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "floods",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "floods",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    }
+  ],
+  "8:1": [],
+  "8:2": [
+    {
+      "surface": "leper",
+      "tw_match": "leper"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "leprosy",
+      "tw_match": "leprosy"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    }
+  ],
+  "8:7": [],
+  "8:8": [
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "tombs",
+      "tw_match": "tomb"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "Son of God",
+      "tw_match": "Son of God"
+    },
+    {
+      "surface": "torment",
+      "tw_match": "torment"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "courage",
+      "tw_match": "courage"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "blasphemes",
+      "tw_match": "blaspheme"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Matthew",
+      "tw_match": "Matthew"
+    },
+    {
+      "surface": "tax collector",
+      "tw_match": "tax collector"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "9:12": [],
+  "9:13": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "bridal",
+      "tw_match": "bridal"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "wineskins",
+      "tw_match": "wineskin"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "official",
+      "tw_match": "official"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "courage",
+      "tw_match": "courage"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    },
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "disturbed",
+      "tw_match": "disturb"
+    }
+  ],
+  "9:24": [],
+  "9:25": [],
+  "9:26": [
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "9:32": [
+    {
+      "surface": "demon-possessed",
+      "tw_match": "demon-possessed"
+    }
+  ],
+  "9:33": [
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:34": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "9:35": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "9:36": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "9:37": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "laborers",
+      "tw_match": "laborer"
+    }
+  ],
+  "9:38": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "laborers",
+      "tw_match": "laborer"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "Zebedee",
+      "tw_match": "Zebedee"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Bartholomew",
+      "tw_match": "Bartholomew"
+    },
+    {
+      "surface": "Thomas",
+      "tw_match": "Thomas"
+    },
+    {
+      "surface": "Matthew",
+      "tw_match": "Matthew"
+    },
+    {
+      "surface": "tax collector",
+      "tw_match": "tax collector"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "Judas Iscariot",
+      "tw_match": "Judas Iscariot"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "Samaritans",
+      "tw_match": "Samaritan"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "lepers",
+      "tw_match": "leper"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "belts",
+      "tw_match": "belt"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "laborer",
+      "tw_match": "laborer"
+    }
+  ],
+  "10:11": [],
+  "10:12": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "day of judgment",
+      "tw_match": "day of judgment"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "serpents",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "beware",
+      "tw_match": "beware"
+    },
+    {
+      "surface": "councils",
+      "tw_match": "council"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "persecute",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Beelzebul",
+      "tw_match": "Beelzebul"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "10:30": [],
+  "10:31": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "10:34": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "10:35": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "10:36": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    }
+  ],
+  "10:37": [
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    }
+  ],
+  "10:38": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "10:39": [],
+  "10:40": [
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    }
+  ],
+  "10:41": [
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "10:42": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "11:3": [],
+  "11:4": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "lepers",
+      "tw_match": "leper"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "suffers",
+      "tw_match": "suffer"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "Prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "11:15": [],
+  "11:16": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "flute",
+      "tw_match": "flute"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "Son of Man",
+      "tw_match": "Son of Man"
+    },
+    {
+      "surface": "drunkard",
+      "tw_match": "drunkard"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "day of judgment",
+      "tw_match": "day of judgment"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Hades",
+      "tw_match": "Hades"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "day of judgment",
+      "tw_match": "day of judgment"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "laboring",
+      "tw_match": "laboring"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "grainfields",
+      "tw_match": "grainfields"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "not lawful",
+      "tw_match": "not lawful"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "not lawful",
+      "tw_match": "not lawful"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "quench",
+      "tw_match": "quench"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "demon-possessed",
+      "tw_match": "demon-possessed"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "Beelzebul",
+      "tw_match": "Beelzebul"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "12:27": [
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "Beelzebul",
+      "tw_match": "Beelzebul"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "12:30": [
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "scatters",
+      "tw_match": "scatter"
+    }
+  ],
+  "12:31": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "blasphemy",
+      "tw_match": "blasphemy"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "12:32": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    }
+  ],
+  "12:33": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "12:34": [
+    {
+      "surface": "vipers",
+      "tw_match": "viper"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "12:35": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "12:36": [
+    {
+      "surface": "day of judgment",
+      "tw_match": "day of judgment"
+    }
+  ],
+  "12:37": [
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    }
+  ],
+  "12:38": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "12:39": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "adulterous",
+      "tw_match": "adulterous"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "12:40": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "12:41": [
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    }
+  ],
+  "12:42": [
+    {
+      "surface": "Queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "12:43": [
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "12:44": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "12:45": [
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "12:46": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "12:47": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "12:48": [],
+  "12:49": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "12:50": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "sower",
+      "tw_match": "sower"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "13:6": [],
+  "13:7": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "13:9": [],
+  "13:10": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "mysteries",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "13:12": [],
+  "13:13": [
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "sower",
+      "tw_match": "sower"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "unfruitful",
+      "tw_match": "unfruitful"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "13:26": [
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    }
+  ],
+  "13:27": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "13:29": [
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "13:30": [
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "13:31": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    }
+  ],
+  "13:32": [
+    {
+      "surface": "seeds",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "13:33": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "leavened",
+      "tw_match": "leaven"
+    }
+  ],
+  "13:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    }
+  ],
+  "13:35": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "13:36": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    }
+  ],
+  "13:37": [
+    {
+      "surface": "sowing",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "13:38": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    }
+  ],
+  "13:39": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "13:40": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    }
+  ],
+  "13:41": [
+    {
+      "surface": "Son of Man",
+      "tw_match": "Son of Man"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "lawlessness",
+      "tw_match": "lawlessness"
+    }
+  ],
+  "13:42": [
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "13:43": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "13:44": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "13:45": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "13:46": [],
+  "13:47": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "13:48": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "13:49": [
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "13:50": [
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "13:51": [],
+  "13:52": [
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "discipled",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "13:53": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    }
+  ],
+  "13:54": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    }
+  ],
+  "13:55": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "13:56": [],
+  "13:57": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "13:58": [
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "unbelief",
+      "tw_match": "unbelief"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "tetrarch",
+      "tw_match": "tetrarch"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Herodias",
+      "tw_match": "Herodias"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "not lawful",
+      "tw_match": "not lawful"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "Herodias",
+      "tw_match": "Herodias"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "oaths",
+      "tw_match": "oath"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "14:11": [],
+  "14:12": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "14:17": [],
+  "14:18": [],
+  "14:19": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "14:20": [],
+  "14:21": [],
+  "14:22": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "courage",
+      "tw_match": "courage"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "14:30": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "14:31": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "14:32": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "14:33": [
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:34": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "14:35": [],
+  "14:36": [
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "transgress",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "tradition",
+      "tw_match": "tradition"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "transgress",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tradition",
+      "tw_match": "tradition"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "tradition",
+      "tw_match": "tradition"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "Hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "honors",
+      "tw_match": "honor"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "doctrines",
+      "tw_match": "doctrine"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "defiles",
+      "tw_match": "defile"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "heavenly Father",
+      "tw_match": "heavenly Father"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "murders",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "adulteries",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "immoralities",
+      "tw_match": "immorality"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "blasphemies",
+      "tw_match": "blasphemy"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "defiling",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "demon-possessed",
+      "tw_match": "demon-possessed"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Sea of Galilee",
+      "tw_match": "Sea of Galilee"
+    }
+  ],
+  "15:30": [],
+  "15:31": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "15:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "15:35": [],
+  "15:36": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "15:37": [],
+  "15:38": [],
+  "15:39": [],
+  "16:1": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "interpret",
+      "tw_match": "interpret"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "adulterous",
+      "tw_match": "adulterous"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    }
+  ],
+  "16:7": [],
+  "16:8": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Caesarea Philippi",
+      "tw_match": "Caesarea Philippi"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "16:15": [],
+  "16:16": [
+    {
+      "surface": "Simon Peter",
+      "tw_match": "Simon Peter"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Jonah",
+      "tw_match": "Jonah"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Hades",
+      "tw_match": "Hades"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "Merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "17:2": [],
+  "17:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "kneeling",
+      "tw_match": "kneel"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "perverted",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Son of Man",
+      "tw_match": "Son of Man"
+    }
+  ],
+  "17:23": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "17:24": [
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    }
+  ],
+  "17:25": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "taxes",
+      "tw_match": "tax"
+    }
+  ],
+  "17:26": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "17:27": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "18:2": [],
+  "18:3": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "hung",
+      "tw_match": "hung"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "reprove",
+      "tw_match": "reprove"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Gentile",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "tax collector",
+      "tw_match": "tax collector"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "18:24": [],
+  "18:25": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "bowing",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "18:31": [
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "18:32": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    }
+  ],
+  "18:33": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "18:34": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "18:35": [
+    {
+      "surface": "heavenly Father",
+      "tw_match": "heavenly Father"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "19:2": [],
+  "19:3": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    }
+  ],
+  "19:4": [],
+  "19:5": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "hardness",
+      "tw_match": "hardness"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "marries",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "married",
+      "tw_match": "married"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "eunuchs",
+      "tw_match": "eunuch"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "19:15": [],
+  "19:16": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "19:24": [
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "19:25": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "19:26": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:27": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "19:28": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "19:30": [],
+  "20:1": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "manager",
+      "tw_match": "manager"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "Friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "wronging",
+      "tw_match": "wrong"
+    }
+  ],
+  "20:14": [],
+  "20:15": [
+    {
+      "surface": "not lawful",
+      "tw_match": "not lawful"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "20:16": [],
+  "20:17": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "crucify",
+      "tw_match": "crucify"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "Zebedee",
+      "tw_match": "Zebedee"
+    },
+    {
+      "surface": "bowing",
+      "tw_match": "bow"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "20:24": [],
+  "20:25": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    }
+  ],
+  "20:29": [
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "20:30": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "20:31": [
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "20:32": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "20:33": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "20:34": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Mount of Olives",
+      "tw_match": "Mount of Olives"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "tied up",
+      "tw_match": "tied up"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "21:8": [],
+  "21:9": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    }
+  ],
+  "21:18": [],
+  "21:19": [
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "21:29": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "21:30": [
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "21:31": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "21:32": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "21:33": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "watchtower",
+      "tw_match": "watchtower"
+    }
+  ],
+  "21:34": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "21:35": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    }
+  ],
+  "21:36": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "21:37": [],
+  "21:38": [
+    {
+      "surface": "heir",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "21:39": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "21:40": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "21:41": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "21:42": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "21:43": [
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    }
+  ],
+  "21:44": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "21:45": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "21:46": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "22:5": [],
+  "22:6": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "mistreated",
+      "tw_match": "mistreat"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "Friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "entrap",
+      "tw_match": "entrap"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "image",
+      "tw_match": "image"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:22": [],
+  "22:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "Likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "22:27": [],
+  "22:28": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "marriage",
+      "tw_match": "marriage"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "22:31": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:32": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "22:33": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "22:34": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "22:35": [
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    }
+  ],
+  "22:36": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "22:37": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "22:38": [],
+  "22:39": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "22:40": [
+    {
+      "surface": "hung",
+      "tw_match": "hung"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "22:41": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "22:42": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "22:43": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "22:44": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "22:45": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "22:46": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "23:5": [],
+  "23:6": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "banquets",
+      "tw_match": "banquet"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavenly Father",
+      "tw_match": "heavenly Father"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "Foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "Foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "sanctifying",
+      "tw_match": "sanctify"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "self-control",
+      "tw_match": "self-control"
+    }
+  ],
+  "23:26": [
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "23:27": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "tombs",
+      "tw_match": "tomb"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "hypocrisy",
+      "tw_match": "hypocrisy"
+    },
+    {
+      "surface": "lawlessness",
+      "tw_match": "lawlessness"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "tombs",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "23:30": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "23:31": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "23:32": [],
+  "23:33": [
+    {
+      "surface": "Serpents",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "vipers",
+      "tw_match": "viper"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "23:34": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "crucify",
+      "tw_match": "crucify"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    }
+  ],
+  "23:35": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "23:36": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "23:37": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "stoning",
+      "tw_match": "stoning"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    }
+  ],
+  "23:38": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "23:39": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "Mount of Olives",
+      "tw_match": "Mount of Olives"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "famines",
+      "tw_match": "famine"
+    }
+  ],
+  "24:8": [],
+  "24:9": [
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "lawlessness",
+      "tw_match": "lawlessness"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "preached",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "24:18": [],
+  "24:19": [
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "24:24": [
+    {
+      "surface": "Christs",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    }
+  ],
+  "24:25": [],
+  "24:26": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "24:27": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "24:28": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "24:29": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "24:30": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "24:31": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "24:32": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "24:33": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "24:34": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "24:35": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "24:36": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "24:37": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "24:38": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "marrying",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "marriage",
+      "tw_match": "marriage"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "24:39": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "24:40": [],
+  "24:41": [],
+  "24:42": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "24:43": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "24:44": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "24:45": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "24:46": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "24:47": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "24:48": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "24:49": [
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    }
+  ],
+  "24:50": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "24:51": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "Likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "25:20": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    }
+  ],
+  "25:21": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "25:22": [
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    }
+  ],
+  "25:23": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "25:24": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "reaping",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    }
+  ],
+  "25:25": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "25:26": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    }
+  ],
+  "25:27": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "25:28": [],
+  "25:29": [],
+  "25:30": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "25:31": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "25:32": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "25:33": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "25:34": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "25:35": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "25:36": [],
+  "25:37": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "25:38": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "25:39": [],
+  "25:40": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    }
+  ],
+  "25:41": [
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "25:42": [],
+  "25:43": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "25:44": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "25:45": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    }
+  ],
+  "25:46": [
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Caiaphas",
+      "tw_match": "Caiaphas"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "leper",
+      "tw_match": "leper"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    }
+  ],
+  "26:9": [],
+  "26:10": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "26:11": [],
+  "26:12": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "burial",
+      "tw_match": "burial"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "preached",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Judas Iscariot",
+      "tw_match": "Judas Iscariot"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "26:18": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "26:20": [],
+  "26:21": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    }
+  ],
+  "26:22": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "26:23": [],
+  "26:24": [
+    {
+      "surface": "Son of Man",
+      "tw_match": "Son of Man"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "26:25": [
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    }
+  ],
+  "26:26": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "26:27": [],
+  "26:28": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "26:29": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "26:30": [
+    {
+      "surface": "Mount of Olives",
+      "tw_match": "Mount of Olives"
+    }
+  ],
+  "26:31": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "26:32": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "26:33": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "26:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "26:35": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "26:36": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Gethsemane",
+      "tw_match": "Gethsemane"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "26:37": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Zebedee",
+      "tw_match": "Zebedee"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "26:38": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "26:39": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "26:40": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "26:41": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "temptation",
+      "tw_match": "temptation"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "26:42": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "26:43": [],
+  "26:44": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "26:45": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "26:46": [],
+  "26:47": [
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "clubs",
+      "tw_match": "clubs"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "26:48": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "Seize",
+      "tw_match": "seize"
+    }
+  ],
+  "26:49": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "26:50": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "26:51": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "26:52": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "26:53": [
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "26:54": [
+    {
+      "surface": "scriptures",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "26:55": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "robber",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "clubs",
+      "tw_match": "clubs"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "26:56": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "26:57": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Caiaphas",
+      "tw_match": "Caiaphas"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "26:58": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "26:59": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "false testimony",
+      "tw_match": "false testimony"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "26:60": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "26:61": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "26:62": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    }
+  ],
+  "26:63": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "26:64": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "26:65": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "blasphemy",
+      "tw_match": "blasphemy"
+    }
+  ],
+  "26:66": [
+    {
+      "surface": "deserving",
+      "tw_match": "deserve"
+    }
+  ],
+  "26:67": [],
+  "26:68": [
+    {
+      "surface": "Prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "26:69": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "26:70": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "26:71": [
+    {
+      "surface": "gateway",
+      "tw_match": "gateway"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    }
+  ],
+  "26:72": [
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "26:73": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    }
+  ],
+  "26:74": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "26:75": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    },
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "hanged",
+      "tw_match": "hang"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "not lawful",
+      "tw_match": "not lawful"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "burial",
+      "tw_match": "burial"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Barabbas",
+      "tw_match": "Barabbas"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "Barabbas",
+      "tw_match": "Barabbas"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "27:18": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    }
+  ],
+  "27:19": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    }
+  ],
+  "27:20": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Barabbas",
+      "tw_match": "Barabbas"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "27:21": [
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "Barabbas",
+      "tw_match": "Barabbas"
+    }
+  ],
+  "27:22": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "27:23": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "27:24": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "27:25": [],
+  "27:26": [
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "Barabbas",
+      "tw_match": "Barabbas"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "27:27": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "27:28": [],
+  "27:29": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "27:30": [
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    }
+  ],
+  "27:31": [
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "crucify",
+      "tw_match": "crucify"
+    }
+  ],
+  "27:32": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "27:33": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Golgotha",
+      "tw_match": "Golgotha"
+    }
+  ],
+  "27:34": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "27:35": [
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "27:36": [
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    }
+  ],
+  "27:37": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "27:38": [
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "27:39": [
+    {
+      "surface": "blaspheming",
+      "tw_match": "blaspheme"
+    }
+  ],
+  "27:40": [
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "27:41": [
+    {
+      "surface": "Likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "27:42": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "27:43": [
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "27:44": [
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "reviling",
+      "tw_match": "revile"
+    }
+  ],
+  "27:45": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "27:46": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "27:47": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "27:48": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    }
+  ],
+  "27:49": [
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    }
+  ],
+  "27:50": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "27:51": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "27:52": [
+    {
+      "surface": "tombs",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "27:53": [
+    {
+      "surface": "tombs",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "holy city",
+      "tw_match": "holy city"
+    }
+  ],
+  "27:54": [
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Son of God",
+      "tw_match": "Son of God"
+    }
+  ],
+  "27:55": [
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    }
+  ],
+  "27:56": [
+    {
+      "surface": "Mary Magdalene",
+      "tw_match": "Mary Magdalene"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Zebedee",
+      "tw_match": "Zebedee"
+    }
+  ],
+  "27:57": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "discipled",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "27:58": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "27:59": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "27:60": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "27:61": [
+    {
+      "surface": "Mary Magdalene",
+      "tw_match": "Mary Magdalene"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "27:62": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    }
+  ],
+  "27:63": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "27:64": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "deception",
+      "tw_match": "deception"
+    }
+  ],
+  "27:65": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "27:66": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "week",
+      "tw_match": "week"
+    },
+    {
+      "surface": "Mary Magdalene",
+      "tw_match": "Mary Magdalene"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    }
+  ],
+  "28:10": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "disciple",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "baptizing",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "28:20": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_MIC.json
+++ b/sources/keyword_data/keywords_MIC.json
@@ -1,0 +1,2252 @@
+{
+  "1:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Micah",
+      "tw_match": "Micah"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jotham",
+      "tw_match": "Jotham"
+    },
+    {
+      "surface": "Ahaz",
+      "tw_match": "Ahaz"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "planting",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "mourns",
+      "tw_match": "mourn"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Gath",
+      "tw_match": "Gath"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "eagles",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "lamentation",
+      "tw_match": "lamentation"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "reproaches",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "strong drink",
+      "tw_match": "strong drink"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Peace",
+      "tw_match": "peace"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "seers",
+      "tw_match": "seer"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "diviners",
+      "tw_match": "diviner"
+    },
+    {
+      "surface": "disgraced",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "detest",
+      "tw_match": "detest"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "plowed",
+      "tw_match": "plowed"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "last days",
+      "tw_match": "last days"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "plowshares",
+      "tw_match": "plowshares"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "Nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "watchtower",
+      "tw_match": "watchtower"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "counselor",
+      "tw_match": "counselor"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "thresh",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "unjust",
+      "tw_match": "unjust"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Ephrathah",
+      "tw_match": "Ephrathah"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Assyrians",
+      "tw_match": "Assyrian"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Assyrians",
+      "tw_match": "Assyrian"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "witchcraft",
+      "tw_match": "witchcraft"
+    },
+    {
+      "surface": "diviners",
+      "tw_match": "diviner"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "Asherah",
+      "tw_match": "Asherah"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Testify",
+      "tw_match": "testify"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "bondage",
+      "tw_match": "bondage"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclamation",
+      "tw_match": "proclamation"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "acknowledges",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "dishonest",
+      "tw_match": "dishonest"
+    },
+    {
+      "surface": "abominable",
+      "tw_match": "abominable"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "olives",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "regulations",
+      "tw_match": "regulations"
+    },
+    {
+      "surface": "Omri",
+      "tw_match": "Omri"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Ahab",
+      "tw_match": "Ahab"
+    },
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "gleaned",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "grape",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "bribes",
+      "tw_match": "bribe"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "thorn",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "dishonors",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "pleads",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "Shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_MRK.json
+++ b/sources/keyword_data/keywords_MRK.json
@@ -1,0 +1,8494 @@
+{
+  "1:1": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "baptizing",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Jordan River",
+      "tw_match": "Jordan River"
+    },
+    {
+      "surface": "confessing",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "waist",
+      "tw_match": "waist"
+    },
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "baptize",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tempted",
+      "tw_match": "tempt"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "Repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Sea of Galilee",
+      "tw_match": "Sea of Galilee"
+    },
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "fishermen",
+      "tw_match": "fishermen"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "fishers",
+      "tw_match": "fishers"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "Zebedee",
+      "tw_match": "Zebedee"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Zebedee",
+      "tw_match": "Zebedee"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazareth",
+      "tw_match": "Nazareth"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "1:30": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "1:31": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    }
+  ],
+  "1:32": [
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "1:33": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "1:34": [
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "1:35": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    }
+  ],
+  "1:36": [],
+  "1:37": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "1:38": [
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    }
+  ],
+  "1:39": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "1:40": [
+    {
+      "surface": "leper",
+      "tw_match": "leper"
+    },
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    },
+    {
+      "surface": "kneeling",
+      "tw_match": "kneel"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "1:41": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "1:42": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "leprosy",
+      "tw_match": "leprosy"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "1:43": [
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "1:44": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "1:45": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "2:3": [],
+  "2:4": [],
+  "2:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "blasphemes",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "tax collector",
+      "tw_match": "tax collector"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "bridal",
+      "tw_match": "bridal"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "wineskins",
+      "tw_match": "wineskin"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "grainfields",
+      "tw_match": "grainfields"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "not lawful",
+      "tw_match": "not lawful"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Abiathar",
+      "tw_match": "Abiathar"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "not lawful",
+      "tw_match": "not lawful"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "3:3": [],
+  "3:4": [
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "Sabbaths",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "hardness",
+      "tw_match": "hardness"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Idumea",
+      "tw_match": "Idumea"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "afflictions",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "rebuking",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "3:13": [],
+  "3:14": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "Zebedee",
+      "tw_match": "Zebedee"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "Bartholomew",
+      "tw_match": "Bartholomew"
+    },
+    {
+      "surface": "Matthew",
+      "tw_match": "Matthew"
+    },
+    {
+      "surface": "Thomas",
+      "tw_match": "Thomas"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "Judas Iscariot",
+      "tw_match": "Judas Iscariot"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Beelzebul",
+      "tw_match": "Beelzebul"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "blasphemies",
+      "tw_match": "blasphemy"
+    },
+    {
+      "surface": "blaspheme",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "3:29": [
+    {
+      "surface": "blasphemes",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "3:30": [
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    }
+  ],
+  "3:31": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "3:32": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "3:33": [],
+  "3:34": [],
+  "3:35": [
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "sower",
+      "tw_match": "sower"
+    },
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "4:6": [],
+  "4:7": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    }
+  ],
+  "4:9": [],
+  "4:10": [
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "sower",
+      "tw_match": "sower"
+    },
+    {
+      "surface": "sows",
+      "tw_match": "sow"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "unfruitful",
+      "tw_match": "unfruitful"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "4:23": [],
+  "4:24": [
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    }
+  ],
+  "4:25": [],
+  "4:26": [
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "seeds",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "4:33": [
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "4:34": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "4:35": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "4:36": [],
+  "4:37": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "4:38": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    }
+  ],
+  "4:39": [
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "4:40": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "4:41": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    },
+    {
+      "surface": "tombs",
+      "tw_match": "tomb"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "tombs",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tombs",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "swear by",
+      "tw_match": "swear by"
+    },
+    {
+      "surface": "torment",
+      "tw_match": "torment"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    }
+  ],
+  "5:9": [],
+  "5:10": [
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "begged",
+      "tw_match": "begged"
+    },
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "demon-possessed",
+      "tw_match": "demon-possessed"
+    },
+    {
+      "surface": "minded",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "demon-possessed",
+      "tw_match": "demon-possessed"
+    },
+    {
+      "surface": "pigs",
+      "tw_match": "pig"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "demon-possessed",
+      "tw_match": "demon-possessed"
+    },
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "begs",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "5:24": [],
+  "5:25": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "5:31": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "5:32": [],
+  "5:33": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "5:34": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "5:35": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    }
+  ],
+  "5:36": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "5:37": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "5:38": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "5:39": [
+    {
+      "surface": "disturbed",
+      "tw_match": "disturb"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "5:40": [],
+  "5:41": [],
+  "5:42": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:43": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "miracle",
+      "tw_match": "miracle"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "unbelief",
+      "tw_match": "unbelief"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "anointing",
+      "tw_match": "anointing"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Herodias",
+      "tw_match": "Herodias"
+    },
+    {
+      "surface": "Philip",
+      "tw_match": "Philip"
+    },
+    {
+      "surface": "married",
+      "tw_match": "married"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "not lawful",
+      "tw_match": "not lawful"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "Herodias",
+      "tw_match": "Herodias"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "safe",
+      "tw_match": "safe"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "Herodias",
+      "tw_match": "Herodias"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "oaths",
+      "tw_match": "oath"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "6:28": [],
+  "6:29": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    }
+  ],
+  "6:31": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "6:32": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "6:33": [
+    {
+      "surface": "leaving",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    }
+  ],
+  "6:34": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "6:35": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "6:36": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:37": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:38": [],
+  "6:39": [],
+  "6:40": [],
+  "6:41": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:42": [],
+  "6:43": [],
+  "6:44": [],
+  "6:45": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "6:46": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "6:47": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:48": [
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "6:49": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "6:50": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "courage",
+      "tw_match": "courage"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "6:51": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "6:52": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    }
+  ],
+  "6:53": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "6:54": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "6:55": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "6:56": [
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "tradition",
+      "tw_match": "tradition"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "baptize",
+      "tw_match": "baptize"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "baptisms",
+      "tw_match": "baptism"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "tradition",
+      "tw_match": "tradition"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "hypocrites",
+      "tw_match": "hypocrite"
+    },
+    {
+      "surface": "honors",
+      "tw_match": "honor"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "doctrines",
+      "tw_match": "doctrine"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tradition",
+      "tw_match": "tradition"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "tradition",
+      "tw_match": "tradition"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "7:12": [],
+  "7:13": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "tradition",
+      "tw_match": "tradition"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "defiling",
+      "tw_match": "defile"
+    }
+  ],
+  "7:16": [],
+  "7:17": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    }
+  ],
+  "7:19": [],
+  "7:20": [
+    {
+      "surface": "defiles",
+      "tw_match": "defile"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "murders",
+      "tw_match": "murder"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "coveting",
+      "tw_match": "covet"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "blasphemy",
+      "tw_match": "blasphemy"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "evils",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "Syrophoenician",
+      "tw_match": "Syrophoenician"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    }
+  ],
+  "7:30": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "demon",
+      "tw_match": "demon"
+    }
+  ],
+  "7:31": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "Sea of Galilee",
+      "tw_match": "Sea of Galilee"
+    }
+  ],
+  "7:32": [
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    }
+  ],
+  "7:33": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "7:34": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "7:35": [
+    {
+      "surface": "bond",
+      "tw_match": "bond"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "7:36": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    }
+  ],
+  "7:37": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "8:3": [],
+  "8:4": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    }
+  ],
+  "8:5": [],
+  "8:6": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "8:8": [],
+  "8:9": [],
+  "8:10": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    }
+  ],
+  "8:13": [],
+  "8:14": [],
+  "8:15": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "yeast",
+      "tw_match": "yeast"
+    },
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "Herod",
+      "tw_match": "Herod"
+    }
+  ],
+  "8:16": [],
+  "8:17": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    }
+  ],
+  "8:18": [],
+  "8:19": [],
+  "8:20": [],
+  "8:21": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    }
+  ],
+  "8:23": [],
+  "8:24": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    }
+  ],
+  "8:26": [],
+  "8:27": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Caesarea Philippi",
+      "tw_match": "Caesarea Philippi"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "8:36": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "8:37": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "8:38": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "adulterous",
+      "tw_match": "adulterous"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    }
+  ],
+  "9:10": [],
+  "9:11": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "restores",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "arguing",
+      "tw_match": "arguing"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "arguing",
+      "tw_match": "arguing"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "unbelief",
+      "tw_match": "unbelief"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Son of Man",
+      "tw_match": "Son of Man"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "9:32": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "9:33": [
+    {
+      "surface": "Capernaum",
+      "tw_match": "Capernaum"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "9:34": [
+    {
+      "surface": "arguing",
+      "tw_match": "arguing"
+    }
+  ],
+  "9:35": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "9:36": [],
+  "9:37": [
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "9:38": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "9:39": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "9:40": [],
+  "9:41": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "9:42": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "9:43": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "unquenchable",
+      "tw_match": "unquenchable"
+    }
+  ],
+  "9:44": [
+    {
+      "surface": "quenched",
+      "tw_match": "quenched"
+    }
+  ],
+  "9:45": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "9:46": [
+    {
+      "surface": "quenched",
+      "tw_match": "quenched"
+    }
+  ],
+  "9:47": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "9:48": [
+    {
+      "surface": "quenched",
+      "tw_match": "quenched"
+    }
+  ],
+  "9:49": [],
+  "9:50": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "hardness",
+      "tw_match": "hardness"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "10:8": [],
+  "10:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "marries",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "marries",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "camel",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "10:30": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "10:31": [],
+  "10:32": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "10:34": [
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "10:35": [
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Zebedee",
+      "tw_match": "Zebedee"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    }
+  ],
+  "10:36": [],
+  "10:37": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "10:38": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    }
+  ],
+  "10:39": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    }
+  ],
+  "10:40": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "10:41": [
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "10:42": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "10:43": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "10:44": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "10:45": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    }
+  ],
+  "10:46": [
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "beggar",
+      "tw_match": "beggar"
+    }
+  ],
+  "10:47": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "10:48": [
+    {
+      "surface": "rebuking",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "10:49": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "courage",
+      "tw_match": "courage"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "10:50": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "10:51": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    }
+  ],
+  "10:52": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    },
+    {
+      "surface": "Mount of Olives",
+      "tw_match": "Mount of Olives"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "tied up",
+      "tw_match": "tied up"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "tied up",
+      "tw_match": "tied up"
+    }
+  ],
+  "11:5": [],
+  "11:6": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "11:8": [],
+  "11:9": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "11:19": [],
+  "11:20": [
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "reminded",
+      "tw_match": "remind"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "believes",
+      "tw_match": "believe"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "11:33": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "watchtower",
+      "tw_match": "watchtower"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "killing",
+      "tw_match": "kill"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "heir",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "Pharisees",
+      "tw_match": "Pharisee"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lawful",
+      "tw_match": "lawful"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "hypocrisy",
+      "tw_match": "hypocrisy"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "Sadducees",
+      "tw_match": "Sadducee"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "marry",
+      "tw_match": "marry"
+    },
+    {
+      "surface": "marriage",
+      "tw_match": "marriage"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "12:27": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:30": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "12:31": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "12:32": [
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    }
+  ],
+  "12:33": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "12:34": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "12:35": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "12:36": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "12:37": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "12:38": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    }
+  ],
+  "12:39": [
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "banquets",
+      "tw_match": "banquet"
+    }
+  ],
+  "12:40": [
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "condemnation",
+      "tw_match": "condemnation"
+    }
+  ],
+  "12:41": [
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "12:42": [],
+  "12:43": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    }
+  ],
+  "12:44": [],
+  "13:1": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Mount of Olives",
+      "tw_match": "Mount of Olives"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "Andrew",
+      "tw_match": "Andrew"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "Tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "13:6": [],
+  "13:7": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "famines",
+      "tw_match": "famine"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "councils",
+      "tw_match": "council"
+    },
+    {
+      "surface": "synagogues",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "13:16": [],
+  "13:17": [
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "Christs",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "13:26": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "13:27": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "13:29": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "13:30": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "13:31": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "13:32": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "13:33": [
+    {
+      "surface": "Watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "13:34": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "13:35": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "13:36": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "13:37": [],
+  "14:1": [
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "Bethany",
+      "tw_match": "Bethany"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "leper",
+      "tw_match": "leper"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "waste",
+      "tw_match": "waste"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "burial",
+      "tw_match": "burial"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "preached",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "Judas Iscariot",
+      "tw_match": "Judas Iscariot"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Unleavened",
+      "tw_match": "unleavened"
+    },
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "sacrificing",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Teacher",
+      "tw_match": "Teacher"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    }
+  ],
+  "14:15": [],
+  "14:16": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "14:17": [],
+  "14:18": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    }
+  ],
+  "14:19": [],
+  "14:20": [],
+  "14:21": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "14:23": [],
+  "14:24": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "Mount of Olives",
+      "tw_match": "Mount of Olives"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "14:30": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "14:31": [],
+  "14:32": [
+    {
+      "surface": "Gethsemane",
+      "tw_match": "Gethsemane"
+    },
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "14:33": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "14:34": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "14:35": [
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "14:36": [
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "14:37": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "14:38": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "temptation",
+      "tw_match": "temptation"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "14:39": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    }
+  ],
+  "14:40": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "14:41": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "14:42": [],
+  "14:43": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "clubs",
+      "tw_match": "clubs"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "14:44": [
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "Seize",
+      "tw_match": "seize"
+    }
+  ],
+  "14:45": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Rabbi",
+      "tw_match": "Rabbi"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "14:46": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    }
+  ],
+  "14:47": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "14:48": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "robber",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "clubs",
+      "tw_match": "clubs"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    }
+  ],
+  "14:49": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "14:50": [],
+  "14:51": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    }
+  ],
+  "14:52": [],
+  "14:53": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "14:54": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "14:55": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "14:56": [
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "14:57": [
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    }
+  ],
+  "14:58": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "14:59": [
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "14:60": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    }
+  ],
+  "14:61": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    }
+  ],
+  "14:62": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "14:63": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "14:64": [
+    {
+      "surface": "blasphemy",
+      "tw_match": "blasphemy"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    },
+    {
+      "surface": "deserving",
+      "tw_match": "deserve"
+    }
+  ],
+  "14:65": [
+    {
+      "surface": "Prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    }
+  ],
+  "14:66": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "14:67": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "14:68": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "14:69": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "14:70": [
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Galilean",
+      "tw_match": "Galilean"
+    }
+  ],
+  "14:71": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "14:72": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "releasing",
+      "tw_match": "release"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Barabbas",
+      "tw_match": "Barabbas"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "rebels",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "Barabbas",
+      "tw_match": "Barabbas"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "Crucify",
+      "tw_match": "crucify"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Crucify",
+      "tw_match": "crucify"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "Barabbas",
+      "tw_match": "Barabbas"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "bending",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "bowing",
+      "tw_match": "bow"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "crucify",
+      "tw_match": "crucify"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "Golgotha",
+      "tw_match": "Golgotha"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "King of the Jews",
+      "tw_match": "King of the Jews"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "crucify",
+      "tw_match": "crucify"
+    },
+    {
+      "surface": "robbers",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "blaspheming",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "Likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "chief priests",
+      "tw_match": "chief priests"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "scribes",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "reviling",
+      "tw_match": "revile"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "15:34": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "15:35": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "15:36": [
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "Leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    }
+  ],
+  "15:37": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "15:38": [
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "15:39": [
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "Son of God",
+      "tw_match": "Son of God"
+    }
+  ],
+  "15:40": [
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "Mary Magdalene",
+      "tw_match": "Mary Magdalene"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    }
+  ],
+  "15:41": [
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "15:42": [
+    {
+      "surface": "Day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "15:43": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "member",
+      "tw_match": "member"
+    },
+    {
+      "surface": "council",
+      "tw_match": "council"
+    },
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "15:44": [
+    {
+      "surface": "Pilate",
+      "tw_match": "Pilate"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    }
+  ],
+  "15:45": [
+    {
+      "surface": "centurion",
+      "tw_match": "centurion"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "15:46": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "15:47": [
+    {
+      "surface": "Mary Magdalene",
+      "tw_match": "Mary Magdalene"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "Mary Magdalene",
+      "tw_match": "Mary Magdalene"
+    },
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "James",
+      "tw_match": "James"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "week",
+      "tw_match": "week"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "alarmed",
+      "tw_match": "alarmed"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "alarmed",
+      "tw_match": "alarmed"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Nazarene",
+      "tw_match": "Nazarene"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "disciples",
+      "tw_match": "disciple"
+    },
+    {
+      "surface": "Peter",
+      "tw_match": "Peter"
+    },
+    {
+      "surface": "Galilee",
+      "tw_match": "Galilee"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "week",
+      "tw_match": "week"
+    },
+    {
+      "surface": "Mary Magdalene",
+      "tw_match": "Mary Magdalene"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "16:12": [],
+  "16:13": [
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "unbelief",
+      "tw_match": "unbelief"
+    },
+    {
+      "surface": "hardness",
+      "tw_match": "hardness"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "snakes",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "preached",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "confirming",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_NAM.json
+++ b/sources/keyword_data/keywords_NAM.json
@@ -1,0 +1,863 @@
+{
+  "1:1": [
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Nahum",
+      "tw_match": "Nahum"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "avenging",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "rebukes",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "dries",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "thorn",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "advisor",
+      "tw_match": "advisor"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "announcing",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "cypresses",
+      "tw_match": "cypress"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lioness",
+      "tw_match": "lioness"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lionesses",
+      "tw_match": "lioness"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "bounding",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "horseman",
+      "tw_match": "horseman"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "witchcraft",
+      "tw_match": "witchcraft"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "3:6": [],
+  "3:7": [
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "the Nile",
+      "tw_match": "the Nile"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "mold",
+      "tw_match": "mold"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "Multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_NEH.json
+++ b/sources/keyword_data/keywords_NEH.json
@@ -1,0 +1,6112 @@
+{
+  "1:1": [
+    {
+      "surface": "Nehemiah",
+      "tw_match": "Nehemiah"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "praying",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "confessing",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "corruption",
+      "tw_match": "corruption"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "cupbearer",
+      "tw_match": "cupbearer"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "unpleasant",
+      "tw_match": "unpleasant"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "unpleasant",
+      "tw_match": "unpleasant"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "unpleasant",
+      "tw_match": "unpleasant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "crossed",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "Arabian",
+      "tw_match": "Arabian"
+    },
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "rebelling",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "consecrated",
+      "tw_match": "consecrated"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Gibeonite",
+      "tw_match": "Gibeonite"
+    },
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    },
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "descending",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "Nehemiah",
+      "tw_match": "Nehemiah"
+    },
+    {
+      "surface": "graves",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "3:18": [],
+  "3:19": [
+    {
+      "surface": "Mizpah",
+      "tw_match": "Mizpah"
+    },
+    {
+      "surface": "armory",
+      "tw_match": "armory"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "court",
+      "tw_match": "court"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "3:29": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "3:30": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    }
+  ],
+  "3:31": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "3:32": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "wipe out",
+      "tw_match": "wipe out"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Arabians",
+      "tw_match": "Arabian"
+    },
+    {
+      "surface": "Ammonites",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "bearers",
+      "tw_match": "bearers"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "counsels",
+      "tw_match": "counsels"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "breastplates",
+      "tw_match": "breastplate"
+    },
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "girded",
+      "tw_match": "girded"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "outcry",
+      "tw_match": "outcry"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "bondage",
+      "tw_match": "bondage"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "outcry",
+      "tw_match": "outcry"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "governors",
+      "tw_match": "governors"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "bondage",
+      "tw_match": "bondage"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Arabian",
+      "tw_match": "Arabian"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "6:8": [],
+  "6:9": [
+    {
+      "surface": "frightening",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prophetess",
+      "tw_match": "prophetess"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "frightening",
+      "tw_match": "frighten"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "multiplying",
+      "tw_match": "multiply"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "frighten",
+      "tw_match": "frighten"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "official",
+      "tw_match": "official"
+    },
+    {
+      "surface": "citadel",
+      "tw_match": "citadel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Nebuchadnezzar",
+      "tw_match": "Nebuchadnezzar"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "exiled",
+      "tw_match": "exiled"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "Nehemiah",
+      "tw_match": "Nehemiah"
+    },
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Mordecai",
+      "tw_match": "Mordecai"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:8": [],
+  "7:9": [],
+  "7:10": [],
+  "7:11": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Joab",
+      "tw_match": "Joab"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    }
+  ],
+  "7:13": [],
+  "7:14": [],
+  "7:15": [],
+  "7:16": [],
+  "7:17": [],
+  "7:18": [],
+  "7:19": [],
+  "7:20": [],
+  "7:21": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "7:22": [],
+  "7:23": [],
+  "7:24": [],
+  "7:25": [
+    {
+      "surface": "Gibeon",
+      "tw_match": "Gibeon"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "7:27": [],
+  "7:28": [],
+  "7:29": [],
+  "7:30": [
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    }
+  ],
+  "7:31": [],
+  "7:32": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "Ai",
+      "tw_match": "Ai"
+    }
+  ],
+  "7:33": [],
+  "7:34": [
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    }
+  ],
+  "7:35": [],
+  "7:36": [
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "7:37": [],
+  "7:38": [],
+  "7:39": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "7:40": [],
+  "7:41": [],
+  "7:42": [],
+  "7:43": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "7:44": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    }
+  ],
+  "7:45": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    }
+  ],
+  "7:46": [],
+  "7:47": [],
+  "7:48": [],
+  "7:49": [],
+  "7:50": [],
+  "7:51": [],
+  "7:52": [],
+  "7:53": [],
+  "7:54": [],
+  "7:55": [],
+  "7:56": [],
+  "7:57": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "7:58": [],
+  "7:59": [],
+  "7:60": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "7:61": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:62": [],
+  "7:63": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Gileadite",
+      "tw_match": "Gileadite"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "7:64": [
+    {
+      "surface": "desecrated",
+      "tw_match": "desecrated"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    }
+  ],
+  "7:65": [
+    {
+      "surface": "Tirshatha",
+      "tw_match": "Tirshatha"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "7:66": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "7:67": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "7:68": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "mules",
+      "tw_match": "mule"
+    }
+  ],
+  "7:69": [
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "7:70": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Tirshatha",
+      "tw_match": "Tirshatha"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "7:71": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "7:72": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "tunics",
+      "tw_match": "tunic"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "7:73": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Uriah",
+      "tw_match": "Uriah"
+    },
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Mishael",
+      "tw_match": "Mishael"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    },
+    {
+      "surface": "prostrated",
+      "tw_match": "prostrate"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "law of God",
+      "tw_match": "law of God"
+    },
+    {
+      "surface": "interpretation",
+      "tw_match": "interpretation"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "Nehemiah",
+      "tw_match": "Nehemiah"
+    },
+    {
+      "surface": "Tirshatha",
+      "tw_match": "Tirshatha"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "courtyards",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "law of God",
+      "tw_match": "law of God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "last day",
+      "tw_match": "last day"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "confessed",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "confessing",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "prostrating",
+      "tw_match": "prostrate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "host of the heavens",
+      "tw_match": "host of the heavens"
+    },
+    {
+      "surface": "prostrates",
+      "tw_match": "prostrate"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abram",
+      "tw_match": "Abram"
+    },
+    {
+      "surface": "Ur",
+      "tw_match": "Ur"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Hittites",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Perizzites",
+      "tw_match": "Perizzite"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Girgashites",
+      "tw_match": "Girgashites"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "reeds",
+      "tw_match": "reed"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "9:16": [],
+  "9:17": [
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "compassionate",
+      "tw_match": "compassionate"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "blasphemies",
+      "tw_match": "blasphemy"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "cisterns",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "blasphemies",
+      "tw_match": "blasphemy"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "saviors",
+      "tw_match": "savior"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:32": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "9:33": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "9:34": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "9:35": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "9:36": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "9:37": [
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "9:38": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "Nehemiah",
+      "tw_match": "Nehemiah"
+    },
+    {
+      "surface": "Tirshatha",
+      "tw_match": "Tirshatha"
+    },
+    {
+      "surface": "Zedekiah",
+      "tw_match": "Zedekiah"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "10:3": [],
+  "10:4": [],
+  "10:5": [
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Daniel",
+      "tw_match": "Daniel"
+    },
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "10:10": [],
+  "10:11": [],
+  "10:12": [],
+  "10:13": [],
+  "10:14": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    }
+  ],
+  "10:15": [],
+  "10:16": [
+    {
+      "surface": "Adonijah",
+      "tw_match": "Adonijah"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    }
+  ],
+  "10:18": [],
+  "10:19": [],
+  "10:20": [],
+  "10:21": [
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    }
+  ],
+  "10:22": [],
+  "10:23": [
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    }
+  ],
+  "10:24": [],
+  "10:25": [],
+  "10:26": [],
+  "10:27": [],
+  "10:28": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "law of God",
+      "tw_match": "law of God"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "law of God",
+      "tw_match": "law of God"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "10:30": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "10:31": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:34": [
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "10:35": [
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:36": [
+    {
+      "surface": "firstborns",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "10:37": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "tithes",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "10:38": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "tithes",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:39": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "holy city",
+      "tw_match": "holy city"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "province",
+      "tw_match": "province"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Baruch",
+      "tw_match": "Baruch"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "11:8": [],
+  "11:9": [
+    {
+      "surface": "Joel",
+      "tw_match": "Joel"
+    },
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "11:13": [],
+  "11:14": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "holy city",
+      "tw_match": "holy city"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "guarded",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "11:21": [],
+  "11:22": [
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Kiriath Arba",
+      "tw_match": "Kiriath Arba"
+    }
+  ],
+  "11:26": [],
+  "11:27": [
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "11:28": [],
+  "11:29": [
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "Beersheba",
+      "tw_match": "Beersheba"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    }
+  ],
+  "11:32": [],
+  "11:33": [
+    {
+      "surface": "Ramah",
+      "tw_match": "Ramah"
+    }
+  ],
+  "11:34": [],
+  "11:35": [],
+  "11:36": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    }
+  ],
+  "12:2": [],
+  "12:3": [],
+  "12:4": [
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    }
+  ],
+  "12:5": [],
+  "12:6": [],
+  "12:7": [
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    }
+  ],
+  "12:10": [],
+  "12:11": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "12:15": [],
+  "12:16": [
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "Abijah",
+      "tw_match": "Abijah"
+    }
+  ],
+  "12:18": [],
+  "12:19": [],
+  "12:20": [],
+  "12:21": [
+    {
+      "surface": "Hilkiah",
+      "tw_match": "Hilkiah"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "storehouses",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Nehemiah",
+      "tw_match": "Nehemiah"
+    },
+    {
+      "surface": "governor",
+      "tw_match": "governor"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    }
+  ],
+  "12:27": [
+    {
+      "surface": "dedication",
+      "tw_match": "dedication"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "lyres",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    }
+  ],
+  "12:28": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:29": [
+    {
+      "surface": "Gilgal",
+      "tw_match": "Gilgal"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:30": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "12:31": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "12:32": [
+    {
+      "surface": "officials",
+      "tw_match": "officials"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "12:33": [
+    {
+      "surface": "Azariah",
+      "tw_match": "Azariah"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    }
+  ],
+  "12:34": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Jeremiah",
+      "tw_match": "Jeremiah"
+    }
+  ],
+  "12:35": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Jonathan",
+      "tw_match": "Jonathan"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    }
+  ],
+  "12:36": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "man of God",
+      "tw_match": "man of God"
+    },
+    {
+      "surface": "Ezra",
+      "tw_match": "Ezra"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    }
+  ],
+  "12:37": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "city of David",
+      "tw_match": "city of David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "12:38": [
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "12:39": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "12:40": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    }
+  ],
+  "12:41": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Eliakim",
+      "tw_match": "Eliakim"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "Hananiah",
+      "tw_match": "Hananiah"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    }
+  ],
+  "12:42": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Elam",
+      "tw_match": "Elam"
+    },
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    }
+  ],
+  "12:43": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:44": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "storehouses",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "tithes",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    }
+  ],
+  "12:45": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "12:46": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:47": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "Nehemiah",
+      "tw_match": "Nehemiah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "consecrating",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    },
+    {
+      "surface": "tithes",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "gatekeepers",
+      "tw_match": "gatekeeper"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Artaxerxes",
+      "tw_match": "Artaxerxes"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "prefects",
+      "tw_match": "prefect"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "tithe",
+      "tw_match": "tithe"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Zadok",
+      "tw_match": "Zadok"
+    },
+    {
+      "surface": "scribe",
+      "tw_match": "scribe"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wipe out",
+      "tw_match": "wipe out"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "winepresses",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "Tyrians",
+      "tw_match": "Tyrians"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "profaning",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "profaning",
+      "tw_match": "profane"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "goods",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "consecrate",
+      "tw_match": "consecrate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Ammonite",
+      "tw_match": "Ammonite"
+    },
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:26": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:27": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "13:29": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "defiling",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "13:30": [
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "13:31": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_NUM.json
+++ b/sources/keyword_data/keywords_NUM.json
@@ -1,0 +1,21322 @@
+{
+  "1:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    }
+  ],
+  "1:30": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:31": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "1:32": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:33": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "1:34": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:35": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "1:36": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:37": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "1:38": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:39": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "1:40": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:41": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "1:42": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:43": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "1:44": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "1:45": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:46": [],
+  "1:47": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "1:48": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "1:49": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:50": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "1:51": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "1:52": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:53": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    }
+  ],
+  "1:54": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "2:4": [],
+  "2:5": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "2:6": [],
+  "2:7": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "2:8": [],
+  "2:9": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "2:11": [],
+  "2:12": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "2:13": [],
+  "2:14": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Reuel",
+      "tw_match": "Reuel"
+    }
+  ],
+  "2:15": [],
+  "2:16": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "2:19": [],
+  "2:20": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "2:21": [],
+  "2:22": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "2:23": [],
+  "2:24": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "2:26": [],
+  "2:27": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "2:28": [],
+  "2:29": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "2:30": [],
+  "2:31": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "2:32": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "2:33": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "2:34": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Shimei",
+      "tw_match": "Shimei"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "3:29": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "3:30": [
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "3:31": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "3:32": [
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "3:33": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "3:34": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "3:35": [
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "3:36": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "3:37": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    }
+  ],
+  "3:38": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:39": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "3:40": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "3:41": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "3:42": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:43": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "3:44": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "3:45": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "3:46": [
+    {
+      "surface": "ransoms",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:47": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "3:48": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    }
+  ],
+  "3:49": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "ransomed",
+      "tw_match": "ransomed"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "3:50": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "3:51": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "4:6": [],
+  "4:7": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "4:8": [],
+  "4:9": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "source",
+      "tw_match": "source"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "source",
+      "tw_match": "source"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:24": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:26": [
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "4:27": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    }
+  ],
+  "4:28": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "4:29": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:30": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:31": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "4:32": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    }
+  ],
+  "4:33": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "4:34": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:35": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:36": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "4:37": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "serves",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:38": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:39": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:40": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:41": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "serves",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:42": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:43": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:44": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "4:45": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:46": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "4:47": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "4:48": [],
+  "4:49": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "swear",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    }
+  ],
+  "5:24": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "5:25": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "5:26": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "5:27": [
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "5:28": [
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "5:29": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "5:30": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "5:31": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "vowing",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "seeds",
+      "tw_match": "seed"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "fulfilling",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "defiles",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "turtledoves",
+      "tw_match": "turtledove"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fulfilling",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "defect",
+      "tw_match": "defect"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "6:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    }
+  ],
+  "6:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "dedication",
+      "tw_match": "dedication"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "dedication",
+      "tw_match": "dedication"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:24": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "7:25": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:26": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:28": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:29": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:30": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "7:31": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:32": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:33": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:34": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:35": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:36": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    }
+  ],
+  "7:37": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:38": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:39": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:40": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:41": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:42": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "7:43": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:44": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:45": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:46": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:47": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:48": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "7:49": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:50": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:51": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:52": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:53": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:54": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "7:55": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:56": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:57": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:58": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:59": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:60": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "7:61": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:62": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:63": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:64": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:65": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:66": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "7:67": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:68": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:69": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:70": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:71": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:72": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "7:73": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:74": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:75": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:76": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:77": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:78": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "7:79": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    }
+  ],
+  "7:80": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "7:81": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "7:82": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:83": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "7:84": [
+    {
+      "surface": "dedication",
+      "tw_match": "dedication"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "7:85": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "7:86": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "7:87": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "7:88": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "dedication",
+      "tw_match": "dedication"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "7:89": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "atonement lid",
+      "tw_match": "atonement lid"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinances",
+      "tw_match": "ordinance"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "sojourns",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "9:16": [],
+  "9:17": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:5": [],
+  "10:6": [],
+  "10:7": [
+    {
+      "surface": "assembling",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "taken up",
+      "tw_match": "taken up"
+    },
+    {
+      "surface": "Testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Paran",
+      "tw_match": "Paran"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "10:17": [],
+  "10:18": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Reuel",
+      "tw_match": "Reuel"
+    },
+    {
+      "surface": "Midianite",
+      "tw_match": "Midianite"
+    },
+    {
+      "surface": "law of Moses",
+      "tw_match": "law of Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "10:30": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    }
+  ],
+  "10:31": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "10:34": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "10:35": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "10:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "conceive",
+      "tw_match": "conceive"
+    },
+    {
+      "surface": "Carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "carries",
+      "tw_match": "carry"
+    }
+  ],
+  "11:13": [],
+  "11:14": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "slay",
+      "tw_match": "slay"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "prophesying",
+      "tw_match": "prophesy"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "11:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:34": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "11:35": [],
+  "12:1": [
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "column",
+      "tw_match": "column"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    },
+    {
+      "surface": "skin disease",
+      "tw_match": "skin disease"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Paran",
+      "tw_match": "Paran"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Paran",
+      "tw_match": "Paran"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Hoshea",
+      "tw_match": "Hoshea"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "fortifications",
+      "tw_match": "fortifications"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Hebron",
+      "tw_match": "Hebron"
+    },
+    {
+      "surface": "Anak",
+      "tw_match": "Anak"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "13:26": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Paran",
+      "tw_match": "Paran"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "13:27": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "13:28": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Anak",
+      "tw_match": "Anak"
+    }
+  ],
+  "13:29": [
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Hittite",
+      "tw_match": "Hittite"
+    },
+    {
+      "surface": "Jebusite",
+      "tw_match": "Jebusite"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "13:30": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "13:31": [],
+  "13:32": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "13:33": [
+    {
+      "surface": "Nephilim",
+      "tw_match": "Nephilim"
+    },
+    {
+      "surface": "Anak",
+      "tw_match": "Anak"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "column",
+      "tw_match": "column"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "unpunished",
+      "tw_match": "unpunished"
+    },
+    {
+      "surface": "appointing",
+      "tw_match": "appoint"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "Amalekite",
+      "tw_match": "Amalekite"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "14:30": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "14:31": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "14:32": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "14:33": [
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "fornications",
+      "tw_match": "fornication"
+    }
+  ],
+  "14:34": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "14:35": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "14:36": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "14:37": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:38": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "14:39": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    }
+  ],
+  "14:40": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "14:41": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:42": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "14:43": [
+    {
+      "surface": "Amalekite",
+      "tw_match": "Amalekite"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:44": [
+    {
+      "surface": "box",
+      "tw_match": "box"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "14:45": [
+    {
+      "surface": "Amalekite",
+      "tw_match": "Amalekite"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "herd",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "15:12": [],
+  "15:13": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "sojourns",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sojourning",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "blaspheming",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "15:34": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "15:35": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "stoning",
+      "tw_match": "stoning"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "15:36": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "stoned",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "15:37": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "15:38": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "15:39": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prostituting",
+      "tw_match": "prostitute"
+    }
+  ],
+  "15:40": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:41": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "chooses",
+      "tw_match": "choose"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chooses",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:29": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "creates",
+      "tw_match": "create"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "16:31": [],
+  "16:32": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    }
+  ],
+  "16:33": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "16:34": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "16:35": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    }
+  ],
+  "16:36": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "16:37": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "16:38": [
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "16:39": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "16:40": [
+    {
+      "surface": "reminder",
+      "tw_match": "reminder"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "16:41": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:42": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:43": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "16:44": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "16:45": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    }
+  ],
+  "16:46": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "16:47": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "16:48": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "16:49": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    }
+  ],
+  "16:50": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "staffs",
+      "tw_match": "staff"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "staffs",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "staffs",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "staffs",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "dedicated",
+      "tw_match": "dedicate"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "cow",
+      "tw_match": "cow"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "contributions",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    }
+  ],
+  "18:31": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "18:32": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "defect",
+      "tw_match": "defect"
+    },
+    {
+      "surface": "yoke",
+      "tw_match": "yoke"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "heifer",
+      "tw_match": "heifer"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sojourns",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "19:15": [],
+  "19:16": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    },
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "quarreled",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "pomegranate",
+      "tw_match": "pomegranate"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "quarreled",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "20:29": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "dedicate",
+      "tw_match": "dedicate"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "dedicated",
+      "tw_match": "dedicate"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "detests",
+      "tw_match": "detest"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "snakes",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "prayed",
+      "tw_match": "pray"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wadis",
+      "tw_match": "wadi"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "wadis",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "noblemen",
+      "tw_match": "noblemen"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "staffs",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "21:19": [],
+  "21:20": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "proverbs",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    }
+  ],
+  "21:29": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    }
+  ],
+  "21:30": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "devastation",
+      "tw_match": "devastation"
+    }
+  ],
+  "21:31": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    }
+  ],
+  "21:32": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    }
+  ],
+  "21:33": [
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "21:34": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    }
+  ],
+  "21:35": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Amorite",
+      "tw_match": "Amorite"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "slay",
+      "tw_match": "slay"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "22:31": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "22:32": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    }
+  ],
+  "22:33": [
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "22:34": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "22:35": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    }
+  ],
+  "22:36": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "22:37": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "22:38": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:39": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "22:40": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    }
+  ],
+  "22:41": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "high place",
+      "tw_match": "high place"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "Aram",
+      "tw_match": "Aram"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "23:10": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "23:11": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:18": [],
+  "23:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "23:21": [
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "23:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lioness",
+      "tw_match": "lioness"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "23:26": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "23:27": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    }
+  ],
+  "23:30": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wadis",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "lioness",
+      "tw_match": "lioness"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "advise",
+      "tw_match": "advise"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Seth",
+      "tw_match": "Seth"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Seir",
+      "tw_match": "Seir"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "24:21": [],
+  "24:22": [
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "24:24": [
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "24:25": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worshipped",
+      "tw_match": "worship"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "hang",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Slay",
+      "tw_match": "slay"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Midianite",
+      "tw_match": "Midianite"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "priesthood",
+      "tw_match": "priesthood"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Midianite",
+      "tw_match": "Midianite"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "Midianites",
+      "tw_match": "Midianite"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "26:8": [],
+  "26:9": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:14": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "26:15": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:16": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:17": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:18": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "26:20": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:21": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:22": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "26:23": [
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:24": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:25": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    }
+  ],
+  "26:26": [
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:27": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "26:28": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "26:29": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Gileadite",
+      "tw_match": "Gileadite"
+    }
+  ],
+  "26:30": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:31": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    }
+  ],
+  "26:32": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:33": [
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    }
+  ],
+  "26:34": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "26:35": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:36": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:37": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    }
+  ],
+  "26:38": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:39": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:40": [
+    {
+      "surface": "Naaman",
+      "tw_match": "Naaman"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:41": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "26:42": [
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:43": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "26:44": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:45": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:46": [
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "26:47": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    }
+  ],
+  "26:48": [
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:49": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:50": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "26:51": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "26:52": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "26:53": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "26:54": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "26:55": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "26:56": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "26:57": [
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "26:58": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Levite",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Korahite",
+      "tw_match": "Korahite"
+    }
+  ],
+  "26:59": [
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Miriam",
+      "tw_match": "Miriam"
+    }
+  ],
+  "26:60": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    }
+  ],
+  "26:61": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:62": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "26:63": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "26:64": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "26:65": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "quarrel",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Meribah Kadesh",
+      "tw_match": "Meribah Kadesh"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "27:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "27:19": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "27:20": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "27:21": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "27:22": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "27:23": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "28:10": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Sabbath",
+      "tw_match": "Sabbath"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "unleavened bread",
+      "tw_match": "unleavened bread"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "28:20": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "28:21": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "28:22": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "28:23": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    }
+  ],
+  "28:24": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "28:25": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "28:26": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "weeks",
+      "tw_match": "week"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "28:27": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "28:28": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "28:29": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "28:30": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "28:31": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:7": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "29:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "29:13": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "29:14": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "tenths",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    }
+  ],
+  "29:15": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "29:16": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "29:17": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "29:18": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    }
+  ],
+  "29:19": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "29:20": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "29:21": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    }
+  ],
+  "29:22": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "29:23": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "29:24": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    }
+  ],
+  "29:25": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "29:26": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "29:27": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    }
+  ],
+  "29:28": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "29:29": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "29:30": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    }
+  ],
+  "29:31": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "29:32": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "29:33": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    }
+  ],
+  "29:34": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "29:35": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "29:36": [
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "unblemished",
+      "tw_match": "unblemished"
+    }
+  ],
+  "29:37": [
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "ordinance",
+      "tw_match": "ordinance"
+    }
+  ],
+  "29:38": [
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "sin offering",
+      "tw_match": "sin offering"
+    },
+    {
+      "surface": "burnt offering",
+      "tw_match": "burnt offering"
+    },
+    {
+      "surface": "grain offering",
+      "tw_match": "grain offering"
+    },
+    {
+      "surface": "drink offering",
+      "tw_match": "drink offering"
+    }
+  ],
+  "29:39": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "29:40": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:1": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "30:2": [
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "binds",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "30:6": [
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "30:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "30:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "30:9": [
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "binds",
+      "tw_match": "bind"
+    }
+  ],
+  "30:10": [
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "30:11": [
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "30:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "30:13": [
+    {
+      "surface": "vow",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    }
+  ],
+  "30:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "binding",
+      "tw_match": "bind"
+    }
+  ],
+  "30:15": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "30:16": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Midianites",
+      "tw_match": "Midianite"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:4": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "31:5": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "31:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    }
+  ],
+  "31:7": [
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "31:8": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "31:10": [],
+  "31:11": [
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "31:12": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "31:13": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "31:14": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    }
+  ],
+  "31:15": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "31:16": [
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "31:17": [
+    {
+      "surface": "slay",
+      "tw_match": "slay"
+    }
+  ],
+  "31:18": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "31:19": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "Purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    }
+  ],
+  "31:20": [
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "31:21": [
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "31:22": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "31:23": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "purification",
+      "tw_match": "purification"
+    }
+  ],
+  "31:24": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "31:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "31:26": [
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "31:27": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "31:28": [
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "31:29": [
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "31:30": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:31": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:32": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "31:33": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "31:34": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "31:35": [],
+  "31:36": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "31:37": [
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "31:38": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:39": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:40": [
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:41": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "31:42": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "31:43": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "31:44": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "31:45": [
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    }
+  ],
+  "31:46": [],
+  "31:47": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "31:48": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "31:49": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "31:50": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "31:51": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "31:52": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    }
+  ],
+  "31:53": [
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    }
+  ],
+  "31:54": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "tent of meeting",
+      "tw_match": "tent of meeting"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "32:1": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "32:2": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "32:3": [
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    }
+  ],
+  "32:4": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "32:5": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "32:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    }
+  ],
+  "32:7": [
+    {
+      "surface": "discourage",
+      "tw_match": "discourage"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "crossing",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "32:8": [
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "32:9": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "discouraged",
+      "tw_match": "discouraged"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "32:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "32:11": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "32:12": [
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "32:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "32:14": [
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "32:15": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "32:16": [
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "32:17": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "32:18": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "32:19": [
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "32:20": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "32:21": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "32:22": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "32:23": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "32:24": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "32:25": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "32:26": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "32:27": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "32:28": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "32:29": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "32:30": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "32:31": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "32:32": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "32:33": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "32:34": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "32:35": [],
+  "32:36": [
+    {
+      "surface": "Haran",
+      "tw_match": "Haran"
+    },
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "32:37": [
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    }
+  ],
+  "32:38": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "32:39": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    }
+  ],
+  "32:40": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "32:41": [
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "32:42": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "33:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "33:2": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "33:3": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Passover",
+      "tw_match": "Passover"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "33:4": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "burying",
+      "tw_match": "bury"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "33:5": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    }
+  ],
+  "33:6": [
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "33:7": [
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "33:8": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "33:9": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "33:10": [
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    }
+  ],
+  "33:11": [
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sin",
+      "tw_match": "sin"
+    }
+  ],
+  "33:12": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sin",
+      "tw_match": "sin"
+    }
+  ],
+  "33:13": [],
+  "33:14": [],
+  "33:15": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "33:16": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "33:17": [],
+  "33:18": [],
+  "33:19": [
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "33:20": [
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "33:21": [],
+  "33:22": [],
+  "33:23": [],
+  "33:24": [],
+  "33:25": [],
+  "33:26": [],
+  "33:27": [
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    }
+  ],
+  "33:28": [
+    {
+      "surface": "Terah",
+      "tw_match": "Terah"
+    }
+  ],
+  "33:29": [],
+  "33:30": [],
+  "33:31": [],
+  "33:32": [],
+  "33:33": [],
+  "33:34": [],
+  "33:35": [],
+  "33:36": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "33:37": [
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "33:38": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "33:39": [
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "33:40": [
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "33:41": [],
+  "33:42": [],
+  "33:43": [],
+  "33:44": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "33:45": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "33:46": [
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "33:47": [],
+  "33:48": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "33:49": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Abel",
+      "tw_match": "Abel"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "33:50": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "33:51": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "33:52": [
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "figures",
+      "tw_match": "figure"
+    }
+  ],
+  "33:53": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    }
+  ],
+  "33:54": [
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "33:55": [
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "33:56": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "34:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "34:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "34:3": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "34:4": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "34:5": [
+    {
+      "surface": "wadi",
+      "tw_match": "wadi"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "34:6": [
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    }
+  ],
+  "34:7": [
+    {
+      "surface": "the Great Sea",
+      "tw_match": "the Great Sea"
+    }
+  ],
+  "34:8": [
+    {
+      "surface": "Lebo Hamath",
+      "tw_match": "Lebo Hamath"
+    }
+  ],
+  "34:9": [],
+  "34:10": [],
+  "34:11": [
+    {
+      "surface": "Sea of Kinnereth",
+      "tw_match": "Sea of Kinnereth"
+    }
+  ],
+  "34:12": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "34:13": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "34:14": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "34:15": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "34:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "34:17": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Eleazar",
+      "tw_match": "Eleazar"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "34:18": [
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "34:19": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Caleb",
+      "tw_match": "Caleb"
+    }
+  ],
+  "34:20": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    }
+  ],
+  "34:21": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "34:22": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Dan",
+      "tw_match": "Dan"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "34:23": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Ephod",
+      "tw_match": "ephod"
+    }
+  ],
+  "34:24": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "34:25": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "34:26": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "34:27": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "34:28": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    }
+  ],
+  "34:29": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "35:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ],
+  "35:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "35:3": [
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "35:4": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "35:5": [],
+  "35:6": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    }
+  ],
+  "35:7": [
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    }
+  ],
+  "35:8": [
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Levites",
+      "tw_match": "Levite"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "inherited",
+      "tw_match": "inherit"
+    }
+  ],
+  "35:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "35:10": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "35:11": [
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "35:12": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "35:13": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "35:14": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "35:15": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "35:16": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "murders",
+      "tw_match": "murder"
+    }
+  ],
+  "35:17": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "murders",
+      "tw_match": "murder"
+    }
+  ],
+  "35:18": [
+    {
+      "surface": "murders",
+      "tw_match": "murder"
+    }
+  ],
+  "35:19": [
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "murders",
+      "tw_match": "murder"
+    }
+  ],
+  "35:20": [],
+  "35:21": [
+    {
+      "surface": "murders",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    }
+  ],
+  "35:22": [],
+  "35:23": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "35:24": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "35:25": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "35:26": [
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "35:27": [
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    }
+  ],
+  "35:28": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "35:29": [
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "35:30": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    }
+  ],
+  "35:31": [
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "kills",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "35:32": [
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    }
+  ],
+  "35:33": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "atonement",
+      "tw_match": "atonement"
+    }
+  ],
+  "35:34": [
+    {
+      "surface": "defile",
+      "tw_match": "defile"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "36:1": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "36:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "36:3": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "36:4": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "36:5": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "36:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "36:7": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    }
+  ],
+  "36:8": [
+    {
+      "surface": "possesses",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "36:9": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "36:10": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "36:11": [
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    },
+    {
+      "surface": "Noah",
+      "tw_match": "Noah"
+    }
+  ],
+  "36:12": [
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "36:13": [
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    },
+    {
+      "surface": "Jericho",
+      "tw_match": "Jericho"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_OBA.json
+++ b/sources/keyword_data/keywords_OBA.json
@@ -1,0 +1,432 @@
+{
+  "1:1": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "Obadiah",
+      "tw_match": "Obadiah"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "lofty",
+      "tw_match": "lofty"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "grape",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "gleanings",
+      "tw_match": "gleanings"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "deceiving",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "wise men",
+      "tw_match": "wise men"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Samaria",
+      "tw_match": "Samaria"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "exile",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Canaanites",
+      "tw_match": "Canaanite"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "saviors",
+      "tw_match": "savior"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_PHM.json
+++ b/sources/keyword_data/keywords_PHM.json
@@ -1,0 +1,304 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "fellow worker",
+      "tw_match": "fellow worker"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "soldier",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "elder",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    }
+  ],
+  "1:10": [],
+  "1:11": [],
+  "1:12": [],
+  "1:13": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "wronged",
+      "tw_match": "wronged"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "self",
+      "tw_match": "self"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "1:21": [],
+  "1:22": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "Luke",
+      "tw_match": "Luke"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_PHP.json
+++ b/sources/keyword_data/keywords_PHP.json
@@ -1,0 +1,1598 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Philippi",
+      "tw_match": "Philippi"
+    },
+    {
+      "surface": "overseers",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "deacons",
+      "tw_match": "deacon"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "confirmation",
+      "tw_match": "confirmation"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "deliverance",
+      "tw_match": "deliverance"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "1:24": [],
+  "1:25": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "frightened",
+      "tw_match": "frighten"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "1:30": [],
+  "2:1": [
+    {
+      "surface": "encouragement",
+      "tw_match": "encouragement"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "compassions",
+      "tw_match": "compassion"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "2:4": [],
+  "2:5": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "arguing",
+      "tw_match": "arguing"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "children of God",
+      "tw_match": "children of God"
+    },
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    },
+    {
+      "surface": "perverted",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "minded",
+      "tw_match": "mind"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "fellow worker",
+      "tw_match": "fellow worker"
+    },
+    {
+      "surface": "soldier",
+      "tw_match": "soldier"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "welcome",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "2:30": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Beware",
+      "tw_match": "beware"
+    },
+    {
+      "surface": "beware",
+      "tw_match": "beware"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "3:4": [],
+  "3:5": [
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "Hebrews",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Pharisee",
+      "tw_match": "Pharisee"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    }
+  ],
+  "3:13": [],
+  "3:14": [
+    {
+      "surface": "prize",
+      "tw_match": "prize"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:16": [],
+  "3:17": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "citizenship",
+      "tw_match": "citizenship"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "subject",
+      "tw_match": "subject"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "labored",
+      "tw_match": "labored"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Book of Life",
+      "tw_match": "Book of Life"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "praiseworthy",
+      "tw_match": "praiseworthy"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "4:11": [],
+  "4:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "4:13": [],
+  "4:14": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "Philippians",
+      "tw_match": "Philippians"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "Thessalonica",
+      "tw_match": "Thessalonica"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "saint",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "Caesar",
+      "tw_match": "Caesar"
+    }
+  ],
+  "4:23": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_PRO.json
+++ b/sources/keyword_data/keywords_PRO.json
@@ -1,0 +1,11320 @@
+{
+  "1:1": [
+    {
+      "surface": "proverbs",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "prudence",
+      "tw_match": "prudence"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "1:15": [],
+  "1:16": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "unjust",
+      "tw_match": "unjust"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "Wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "mockers",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "mockery",
+      "tw_match": "mockery"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "1:30": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "1:31": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "1:32": [
+    {
+      "surface": "slay",
+      "tw_match": "slay"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "1:33": [
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "perversions",
+      "tw_match": "perversion"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    }
+  ],
+  "2:15": [],
+  "2:16": [],
+  "2:17": [
+    {
+      "surface": "forsakes",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "2:19": [],
+  "2:20": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:8": [],
+  "3:9": [
+    {
+      "surface": "Honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "storehouses",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "3:15": [],
+  "3:16": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "3:18": [],
+  "3:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "prudence",
+      "tw_match": "prudence"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "devastation",
+      "tw_match": "devastation"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "3:29": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "3:30": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "3:31": [
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "3:32": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "3:33": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "blesses",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "3:34": [
+    {
+      "surface": "mockers",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "mocks",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "3:35": [
+    {
+      "surface": "Wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "4:3": [],
+  "4:4": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "multiply",
+      "tw_match": "multiply"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "4:15": [],
+  "4:16": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "4:20": [],
+  "4:21": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "4:22": [],
+  "4:23": [
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "sources",
+      "tw_match": "source"
+    }
+  ],
+  "4:24": [],
+  "4:25": [],
+  "4:26": [],
+  "4:27": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "5:7": [],
+  "5:8": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "5:11": [],
+  "5:12": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "instructors",
+      "tw_match": "instructors"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "cistern",
+      "tw_match": "cistern"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "5:17": [],
+  "5:18": [
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "doe",
+      "tw_match": "doe"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "stagger",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "stagger",
+      "tw_match": "stagger"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:22": [
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "capture",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "5:23": [
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "staggers",
+      "tw_match": "stagger"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "ensnared",
+      "tw_match": "ensnare"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    }
+  ],
+  "6:4": [],
+  "6:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "6:13": [],
+  "6:14": [
+    {
+      "surface": "Perverse",
+      "tw_match": "perverse"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "self",
+      "tw_match": "self"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "breathing",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "Guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "Bind",
+      "tw_match": "bind"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "rebukes",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    }
+  ],
+  "6:24": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "6:25": [],
+  "6:26": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "6:27": [
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    }
+  ],
+  "6:28": [],
+  "6:29": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "6:30": [
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    }
+  ],
+  "6:31": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "6:32": [
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "6:33": [
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "6:34": [
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    }
+  ],
+  "6:35": [
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "7:3": [],
+  "7:4": [
+    {
+      "surface": "Wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Understanding",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "Kinsman",
+      "tw_match": "kinsman"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "discerned",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "guarded",
+      "tw_match": "guard"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "kisses",
+      "tw_match": "kiss"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "7:24": [],
+  "7:25": [],
+  "7:26": [
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    }
+  ],
+  "7:27": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "descending",
+      "tw_match": "descend"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "Understanding",
+      "tw_match": "understand"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "Understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "prudence",
+      "tw_match": "prudence"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "Wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "Prudence",
+      "tw_match": "prudence"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "Counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "possessed",
+      "tw_match": "possessed"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "8:25": [],
+  "8:26": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    }
+  ],
+  "8:32": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "8:33": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "doorposts",
+      "tw_match": "doorpost"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:36": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    }
+  ],
+  "9:4": [],
+  "9:5": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "Forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "instructor",
+      "tw_match": "instructors"
+    },
+    {
+      "surface": "mocker",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "mocker",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "9:16": [],
+  "9:17": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "proverbs",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "delivers",
+      "tw_match": "deliver"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "Blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "Wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "forsakes",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    }
+  ],
+  "10:22": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:23": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "10:24": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "10:25": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "10:26": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    }
+  ],
+  "10:27": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "10:28": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "10:29": [
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "10:30": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "10:31": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    }
+  ],
+  "10:32": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "perishes",
+      "tw_match": "perish"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "godless",
+      "tw_match": "godless"
+    },
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "exults",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "understandings",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "gossip",
+      "tw_match": "gossip"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "pledges",
+      "tw_match": "pledges"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sowing",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "pig",
+      "tw_match": "pig"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "troubling",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "lover",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "honoring",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "Bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prudent",
+      "tw_match": "prudent"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "tells",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "12:22": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "12:23": [
+    {
+      "surface": "prudent",
+      "tw_match": "prudent"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "12:24": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "laborer",
+      "tw_match": "laborer"
+    }
+  ],
+  "12:25": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "12:26": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "searches",
+      "tw_match": "search"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "12:27": [],
+  "12:28": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "13:4": [],
+  "13:5": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "Righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    }
+  ],
+  "13:7": [],
+  "13:8": [
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "counseled",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "Hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "rewarded",
+      "tw_match": "reward"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "snares",
+      "tw_match": "snare"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "Good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "prudent",
+      "tw_match": "prudent"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    }
+  ],
+  "13:19": [
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "13:20": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "13:21": [
+    {
+      "surface": "Evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "13:22": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "13:23": [
+    {
+      "surface": "unplowed",
+      "tw_match": "unplowed"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "13:24": [
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    }
+  ],
+  "13:25": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    },
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "mocker",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "prudent",
+      "tw_match": "prudent"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "guilt offering",
+      "tw_match": "guilt offering"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "14:12": [],
+  "14:13": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "believes",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "prudent",
+      "tw_match": "prudent"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "prudent",
+      "tw_match": "prudent"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "14:24": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "14:25": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "14:26": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "14:27": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "snares",
+      "tw_match": "snare"
+    }
+  ],
+  "14:28": [
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "14:29": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "14:30": [
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    }
+  ],
+  "14:31": [
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "honors",
+      "tw_match": "honor"
+    }
+  ],
+  "14:32": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "14:33": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "14:34": [
+    {
+      "surface": "Righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "14:35": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "15:1": [],
+  "15:2": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "prudent",
+      "tw_match": "prudent"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "forsakes",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "mocker",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "rebukes",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "quarrel",
+      "tw_match": "quarrel"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "Folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "Joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "Evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "unjust",
+      "tw_match": "unjust"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "bribes",
+      "tw_match": "bribe"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "evils",
+      "tw_match": "evil"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "rejects",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "atoned",
+      "tw_match": "atoned"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "Divination",
+      "tw_match": "divination"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "atone",
+      "tw_match": "atone"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "honeycomb",
+      "tw_match": "honeycomb"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "16:25": [],
+  "16:26": [
+    {
+      "surface": "laborer",
+      "tw_match": "laborer"
+    },
+    {
+      "surface": "labors",
+      "tw_match": "labors"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "16:28": [
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    }
+  ],
+  "16:29": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "16:30": [
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "16:31": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "16:32": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "capturing",
+      "tw_match": "capture"
+    }
+  ],
+  "16:33": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "quarreling",
+      "tw_match": "quarrel"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tests",
+      "tw_match": "test"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "mocker",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "17:11": [
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "messenger",
+      "tw_match": "messenger"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "quarrel",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "releasing",
+      "tw_match": "release"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "pledging",
+      "tw_match": "pledging"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "17:19": [
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    }
+  ],
+  "17:20": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "17:21": [
+    {
+      "surface": "begets",
+      "tw_match": "beget"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "17:22": [
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "dries",
+      "tw_match": "dry"
+    }
+  ],
+  "17:23": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "17:24": [
+    {
+      "surface": "Wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "17:25": [
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "17:26": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    }
+  ],
+  "17:27": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "17:28": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    }
+  ],
+  "18:16": [],
+  "18:17": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    },
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:15": [],
+  "19:16": [
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "19:19": [],
+  "19:20": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "19:22": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "19:23": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "19:24": [],
+  "19:25": [
+    {
+      "surface": "mocker",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "prudent",
+      "tw_match": "prudent"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "19:26": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "19:27": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "19:28": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "mocks",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "19:29": [
+    {
+      "surface": "Judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "mockers",
+      "tw_match": "mocker"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "mocker",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "staggers",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "wrongs",
+      "tw_match": "wrong"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "Honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "plow",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "begs",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "Counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "proclaims",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "winnows",
+      "tw_match": "winnow"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "Stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "20:16": [
+    {
+      "surface": "pledged",
+      "tw_match": "pledged"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "20:17": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "20:18": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "20:19": [
+    {
+      "surface": "gossip",
+      "tw_match": "gossip"
+    }
+  ],
+  "20:20": [
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    }
+  ],
+  "20:21": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "20:22": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "20:23": [
+    {
+      "surface": "Stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "20:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "20:25": [
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    }
+  ],
+  "20:26": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "winnows",
+      "tw_match": "winnow"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "20:27": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    }
+  ],
+  "20:28": [
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "20:29": [
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "20:30": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "Perverse",
+      "tw_match": "perverse"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "mocker",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "outcry",
+      "tw_match": "outcry"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "lover",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "presumptuous",
+      "tw_match": "presumptuous"
+    },
+    {
+      "surface": "haughty",
+      "tw_match": "haughty"
+    },
+    {
+      "surface": "Mocker",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "21:25": [],
+  "21:26": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "21:28": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "21:29": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "21:30": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "21:31": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "prudent",
+      "tw_match": "prudent"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "Thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "traps",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "sower",
+      "tw_match": "sower"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "mocker",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "Folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "counsels",
+      "tw_match": "counsels"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "rob",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "22:24": [],
+  "22:25": [
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "22:27": [],
+  "22:28": [],
+  "22:29": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "23:2": [],
+  "23:3": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "23:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "23:8": [
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    }
+  ],
+  "23:9": [
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    }
+  ],
+  "23:10": [],
+  "23:11": [
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    }
+  ],
+  "23:12": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "23:13": [
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "23:14": [
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "23:15": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "23:16": [
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "23:17": [
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "23:18": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "23:19": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "23:20": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "23:21": [],
+  "23:22": [
+    {
+      "surface": "begot",
+      "tw_match": "begot"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "23:23": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "23:24": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "begets",
+      "tw_match": "beget"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "23:25": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "23:26": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "23:27": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "23:28": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "robber",
+      "tw_match": "robber"
+    }
+  ],
+  "23:29": [
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    }
+  ],
+  "23:30": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    }
+  ],
+  "23:31": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "23:32": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "viper",
+      "tw_match": "viper"
+    }
+  ],
+  "23:33": [
+    {
+      "surface": "perverse",
+      "tw_match": "perverse"
+    }
+  ],
+  "23:34": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "23:35": [
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "Wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "mocker",
+      "tw_match": "mocker"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "24:11": [
+    {
+      "surface": "staggering",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "24:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "24:13": [
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "24:14": [
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "24:15": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "24:16": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    }
+  ],
+  "24:17": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "stumbles",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "24:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "24:19": [
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "24:20": [
+    {
+      "surface": "evil one",
+      "tw_match": "evil one"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "24:21": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "24:22": [
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "24:23": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "24:24": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "24:25": [
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "24:26": [
+    {
+      "surface": "kisses",
+      "tw_match": "kiss"
+    }
+  ],
+  "24:27": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    }
+  ],
+  "24:28": [
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    }
+  ],
+  "24:29": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    }
+  ],
+  "24:30": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "24:31": [
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "24:32": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    }
+  ],
+  "24:33": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "24:34": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "proverbs",
+      "tw_match": "proverb"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "Heavens",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "humiliate",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "humiliates",
+      "tw_match": "humiliate"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "boasts",
+      "tw_match": "boast"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "commander",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "25:20": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "25:21": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "25:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:23": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "25:24": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    }
+  ],
+  "25:25": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "25:26": [
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "trampling",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "spoiled",
+      "tw_match": "spoil"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "25:27": [
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "25:28": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "26:6": [],
+  "26:7": [
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "thorn",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "drunkard",
+      "tw_match": "drunkard"
+    },
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "archer",
+      "tw_match": "archer"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "26:13": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "26:14": [],
+  "26:15": [],
+  "26:16": [
+    {
+      "surface": "discernment",
+      "tw_match": "discernment"
+    }
+  ],
+  "26:17": [],
+  "26:18": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    }
+  ],
+  "26:19": [
+    {
+      "surface": "deceives",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "26:20": [
+    {
+      "surface": "quarrel",
+      "tw_match": "quarrel"
+    }
+  ],
+  "26:21": [
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    }
+  ],
+  "26:22": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "26:23": [
+    {
+      "surface": "Silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "26:24": [],
+  "26:25": [
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    }
+  ],
+  "26:26": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "26:27": [
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "26:28": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "Faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "kisses",
+      "tw_match": "kiss"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "tramples",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "Oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "calamity",
+      "tw_match": "calamity"
+    },
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "reproaching",
+      "tw_match": "reproach"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "prudent",
+      "tw_match": "prudent"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "pledged",
+      "tw_match": "pledged"
+    },
+    {
+      "surface": "pledge",
+      "tw_match": "pledge"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "blesses",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "27:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "quarrels",
+      "tw_match": "quarrel"
+    },
+    {
+      "surface": "alike",
+      "tw_match": "alike"
+    }
+  ],
+  "27:16": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "27:17": [
+    {
+      "surface": "Iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "27:18": [
+    {
+      "surface": "guarding",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    }
+  ],
+  "27:19": [],
+  "27:20": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "27:21": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    }
+  ],
+  "27:22": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "grains",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    }
+  ],
+  "27:23": [
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    }
+  ],
+  "27:24": [
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "27:25": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "27:26": [
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "27:27": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "understands",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "washes",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "forsaking",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "understands",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "humiliates",
+      "tw_match": "humiliate"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    }
+  ],
+  "28:10": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "28:11": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "discerning",
+      "tw_match": "discern"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    }
+  ],
+  "28:12": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    }
+  ],
+  "28:13": [
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "confessing",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "forsaking",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "28:14": [
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "hardening",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "28:15": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "28:16": [
+    {
+      "surface": "leader",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "unjust",
+      "tw_match": "unjust"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "28:17": [
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "28:18": [
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "28:19": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "28:20": [
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "28:21": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "transgress",
+      "tw_match": "transgress"
+    }
+  ],
+  "28:22": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "28:23": [
+    {
+      "surface": "rebuking",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "28:24": [
+    {
+      "surface": "robbing",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "28:25": [
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "28:26": [
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "28:27": [
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    }
+  ],
+  "28:28": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "rebukes",
+      "tw_match": "rebuke"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "destroys",
+      "tw_match": "destroy"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "contributions",
+      "tw_match": "contribution"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "29:7": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "legal",
+      "tw_match": "legal"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "mockery",
+      "tw_match": "mockery"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "rages",
+      "tw_match": "rage"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "29:12": [
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "29:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "29:15": [
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "29:16": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "29:17": [
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "29:18": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "29:19": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "understands",
+      "tw_match": "understand"
+    }
+  ],
+  "29:20": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "29:21": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "29:22": [
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    }
+  ],
+  "29:23": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "29:24": [
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "29:25": [
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:26": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "29:27": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "30:1": [],
+  "30:2": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "descended",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "30:6": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "30:7": [],
+  "30:8": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "30:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "dispossessed",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "30:10": [
+    {
+      "surface": "slander",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    }
+  ],
+  "30:11": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "30:12": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "30:13": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "30:14": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "devouring",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "30:15": [],
+  "30:16": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "30:17": [
+    {
+      "surface": "mocks",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    }
+  ],
+  "30:18": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "30:19": [
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "30:20": [
+    {
+      "surface": "commits",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "30:21": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "30:22": [
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "30:23": [
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "dispossesses",
+      "tw_match": "dispossess"
+    }
+  ],
+  "30:24": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "30:25": [],
+  "30:26": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "30:27": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    }
+  ],
+  "30:28": [
+    {
+      "surface": "catch",
+      "tw_match": "catch"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "30:29": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "30:30": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "30:31": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "goat",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "30:32": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "30:33": [
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "31:4": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "31:5": [
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    },
+    {
+      "surface": "pervert",
+      "tw_match": "pervert"
+    },
+    {
+      "surface": "legal",
+      "tw_match": "legal"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "31:6": [
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "31:7": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "31:8": [
+    {
+      "surface": "legal",
+      "tw_match": "legal"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "legal",
+      "tw_match": "legal"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "31:10": [],
+  "31:11": [
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "spoil",
+      "tw_match": "spoil"
+    }
+  ],
+  "31:12": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "31:13": [
+    {
+      "surface": "searches",
+      "tw_match": "search"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    }
+  ],
+  "31:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "31:15": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    }
+  ],
+  "31:16": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "31:17": [
+    {
+      "surface": "girds",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    }
+  ],
+  "31:18": [
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    }
+  ],
+  "31:19": [
+    {
+      "surface": "palms",
+      "tw_match": "palm"
+    }
+  ],
+  "31:20": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "31:21": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    }
+  ],
+  "31:22": [
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    }
+  ],
+  "31:23": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "31:24": [
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "Canaanite",
+      "tw_match": "Canaanite"
+    }
+  ],
+  "31:25": [
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "31:26": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "31:27": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "31:28": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    }
+  ],
+  "31:29": [],
+  "31:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    }
+  ],
+  "31:31": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_PSA.json
+++ b/sources/keyword_data/keywords_PSA.json
@@ -1,0 +1,34881 @@
+{
+  "1:1": [
+    {
+      "surface": "advice",
+      "tw_match": "advice"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "meditates",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "bonds",
+      "tw_match": "bonds"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "mocks",
+      "tw_match": "mock"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "begotten",
+      "tw_match": "begotten"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "admonished",
+      "tw_match": "admonish"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Kiss",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "new wine",
+      "tw_match": "new wine"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Understand",
+      "tw_match": "understand"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "sojourn",
+      "tw_match": "sojourn"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "rebel",
+      "tw_match": "rebel"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "disturbed",
+      "tw_match": "disturb"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "6:6": [],
+  "6:7": [
+    {
+      "surface": "wasted",
+      "tw_match": "wasted"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "shamed",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "disturbed",
+      "tw_match": "disturb"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "savior",
+      "tw_match": "savior"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "conceives",
+      "tw_match": "conceive"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "heavenly",
+      "tw_match": "heavenly"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "crowned",
+      "tw_match": "crowned"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "ensnared",
+      "tw_match": "ensnare"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "boasts",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "blesses",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "robber",
+      "tw_match": "robber"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "murders",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    }
+  ],
+  "10:10": [],
+  "10:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "a bow",
+      "tw_match": "a bow"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tests",
+      "tw_match": "test"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "snares",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "abominable",
+      "tw_match": "abominable"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "corrupt",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "restores",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sojourn",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "slander",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "insult",
+      "tw_match": "insult"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "honors",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "bribe",
+      "tw_match": "bribe"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "multiplied",
+      "tw_match": "multiplied"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "lot",
+      "tw_match": "lots"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "counsels",
+      "tw_match": "counsels"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "instructs",
+      "tw_match": "instruct"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "transgress",
+      "tw_match": "transgress"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    }
+  ],
+  "17:5": [],
+  "17:6": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "17:10": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    }
+  ],
+  "17:11": [],
+  "17:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "18:4": [],
+  "18:5": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "snares",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "trapped",
+      "tw_match": "trapped"
+    }
+  ],
+  "18:6": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "18:7": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:8": [],
+  "18:9": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "cherub",
+      "tw_match": "cherub"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "Hailstones",
+      "tw_match": "hailstone"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "hailstones",
+      "tw_match": "hailstone"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "dispersed",
+      "tw_match": "disperse"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "18:16": [],
+  "18:17": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rewarded",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "18:25": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "18:26": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "18:27": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    }
+  ],
+  "18:28": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:29": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:30": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "18:31": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:32": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "18:33": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "deer",
+      "tw_match": "deer"
+    }
+  ],
+  "18:34": [
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "a bow",
+      "tw_match": "a bow"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "18:35": [
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "18:36": [],
+  "18:37": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "18:38": [],
+  "18:39": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    }
+  ],
+  "18:40": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "annihilated",
+      "tw_match": "annihilate"
+    }
+  ],
+  "18:41": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "18:42": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "18:43": [
+    {
+      "surface": "disputes",
+      "tw_match": "disputes"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "18:44": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "18:45": [
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    }
+  ],
+  "18:46": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "18:47": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "18:48": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "18:49": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    }
+  ],
+  "18:50": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "covenant loyalty",
+      "tw_match": "covenant loyalty"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "Day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "19:3": [],
+  "19:4": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "crosses",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "law of Yahweh",
+      "tw_match": "law of Yahweh"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "restoring",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "instructions",
+      "tw_match": "instructions"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "honeycomb",
+      "tw_match": "honeycomb"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "warned",
+      "tw_match": "warned"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "discern",
+      "tw_match": "discern"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:4": [
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    }
+  ],
+  "22:5": [
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "22:13": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "22:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "22:16": [],
+  "22:17": [],
+  "22:18": [
+    {
+      "surface": "lots",
+      "tw_match": "lots"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "wild dogs",
+      "tw_match": "wild dogs"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "22:22": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "22:23": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "awe",
+      "tw_match": "awe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "22:24": [
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "22:25": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "22:26": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "22:27": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "22:28": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "22:29": [
+    {
+      "surface": "prosperous",
+      "tw_match": "prosperous"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "descending",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "22:30": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "22:31": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "23:1": [
+    {
+      "surface": "Psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "23:2": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "23:3": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "23:4": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "23:5": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "23:6": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "24:1": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "24:2": [
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "24:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "24:4": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    }
+  ],
+  "24:5": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "24:6": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "24:7": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "24:8": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "24:9": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "24:10": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "25:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "25:3": [
+    {
+      "surface": "hopes",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "disgraced",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "25:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "25:6": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "25:7": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "rebelliousness",
+      "tw_match": "rebelliousness"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "25:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "25:9": [
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "25:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "25:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pardon",
+      "tw_match": "pardon"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "25:12": [
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "instruct",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    }
+  ],
+  "25:13": [
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "25:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "25:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "25:16": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "25:17": [
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "25:18": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "25:19": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "25:20": [
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "25:21": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "25:22": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    }
+  ],
+  "26:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    }
+  ],
+  "26:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    }
+  ],
+  "26:3": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "26:4": [
+    {
+      "surface": "dishonest",
+      "tw_match": "dishonest"
+    }
+  ],
+  "26:5": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "26:6": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "26:7": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "26:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "26:9": [
+    {
+      "surface": "sweep",
+      "tw_match": "sweep"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "26:10": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "bribes",
+      "tw_match": "bribe"
+    }
+  ],
+  "26:11": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "26:12": [
+    {
+      "surface": "assemblies",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    }
+  ],
+  "27:2": [
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "stumbled",
+      "tw_match": "stumble"
+    }
+  ],
+  "27:3": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "27:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "27:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "27:6": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "27:8": [
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:9": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "27:10": [
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "27:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "27:12": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "27:13": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "27:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "courageous",
+      "tw_match": "courageous"
+    }
+  ],
+  "28:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "28:2": [
+    {
+      "surface": "pleading",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "28:3": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "28:4": [
+    {
+      "surface": "deserve",
+      "tw_match": "deserve"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "28:5": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "28:6": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pleading",
+      "tw_match": "plead"
+    }
+  ],
+  "28:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "rejoices",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "28:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saving",
+      "tw_match": "save"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "28:9": [
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "29:1": [
+    {
+      "surface": "Psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sons of God",
+      "tw_match": "sons of God"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "29:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "deserves",
+      "tw_match": "deserve"
+    },
+    {
+      "surface": "Bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "29:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "29:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "29:6": [
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    }
+  ],
+  "29:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "29:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shakes",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Kadesh",
+      "tw_match": "Kadesh"
+    }
+  ],
+  "29:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "oaks",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Glory",
+      "tw_match": "glory"
+    }
+  ],
+  "29:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "29:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blesses",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "30:1": [
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "30:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "30:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "30:4": [
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "30:5": [
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "30:6": [],
+  "30:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "30:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "30:9": [
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    }
+  ],
+  "30:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "30:11": [
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "30:12": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "31:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "31:2": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "31:3": [
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    }
+  ],
+  "31:4": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "31:5": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    }
+  ],
+  "31:6": [
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "31:7": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "31:8": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "31:9": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "31:10": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "wasting",
+      "tw_match": "waste"
+    }
+  ],
+  "31:11": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "31:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "31:13": [
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    }
+  ],
+  "31:14": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "31:15": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "31:16": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "31:17": [
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "31:18": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    }
+  ],
+  "31:19": [
+    {
+      "surface": "revere",
+      "tw_match": "revere"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "31:20": [
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    }
+  ],
+  "31:21": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "besieged",
+      "tw_match": "besieged"
+    }
+  ],
+  "31:22": [
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    }
+  ],
+  "31:23": [
+    {
+      "surface": "Love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    }
+  ],
+  "31:24": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "32:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "32:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "32:3": [
+    {
+      "surface": "wasted",
+      "tw_match": "wasted"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "32:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "32:5": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "acknowledged",
+      "tw_match": "acknowledge"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "32:6": [
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    }
+  ],
+  "32:7": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "deliverance",
+      "tw_match": "deliverance"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "32:8": [
+    {
+      "surface": "instruct",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    }
+  ],
+  "32:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "mule",
+      "tw_match": "mule"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "32:10": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "32:11": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "33:1": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "33:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    }
+  ],
+  "33:3": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "33:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "33:5": [
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "33:6": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "33:7": [
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "storehouses",
+      "tw_match": "storehouse"
+    }
+  ],
+  "33:8": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "awe",
+      "tw_match": "awe"
+    }
+  ],
+  "33:9": [],
+  "33:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "33:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "33:12": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "33:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "33:14": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "33:15": [],
+  "33:16": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    }
+  ],
+  "33:17": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "33:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "33:19": [
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "33:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "33:21": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "33:22": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "34:1": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "34:2": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "34:3": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "34:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    }
+  ],
+  "34:5": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "34:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    }
+  ],
+  "34:7": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "34:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "34:9": [
+    {
+      "surface": "Fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "34:10": [
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "34:11": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "34:12": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "34:13": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "34:14": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "34:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "34:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "34:17": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    }
+  ],
+  "34:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saves",
+      "tw_match": "save"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "34:19": [
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "delivers",
+      "tw_match": "deliver"
+    }
+  ],
+  "34:20": [
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    }
+  ],
+  "34:21": [
+    {
+      "surface": "Evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    }
+  ],
+  "34:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    }
+  ],
+  "35:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "35:2": [
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "35:3": [
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "ax",
+      "tw_match": "ax"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "35:4": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "shamed",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "dishonored",
+      "tw_match": "dishonored"
+    }
+  ],
+  "35:5": [
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "35:6": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "35:7": [
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "35:8": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    },
+    {
+      "surface": "catch",
+      "tw_match": "catch"
+    }
+  ],
+  "35:9": [
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "35:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rob",
+      "tw_match": "rob"
+    }
+  ],
+  "35:11": [
+    {
+      "surface": "Unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "35:12": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "35:13": [
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    }
+  ],
+  "35:14": [
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "35:15": [
+    {
+      "surface": "stumbled",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    }
+  ],
+  "35:16": [
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "35:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "35:18": [
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "35:19": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "35:20": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "35:21": [],
+  "35:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "35:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "35:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "35:25": [
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "35:26": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    }
+  ],
+  "35:27": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "35:28": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "36:1": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "36:2": [
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "36:3": [
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "36:4": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    }
+  ],
+  "36:5": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "36:6": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "36:7": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "36:8": [
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    }
+  ],
+  "36:9": [
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    }
+  ],
+  "36:10": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "36:11": [
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "36:12": [],
+  "37:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "37:2": [
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    }
+  ],
+  "37:3": [
+    {
+      "surface": "Trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "37:4": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "37:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "37:6": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "37:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "37:8": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "37:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "37:10": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "37:11": [
+    {
+      "surface": "meek",
+      "tw_match": "meek"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    }
+  ],
+  "37:12": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    }
+  ],
+  "37:13": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "37:14": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "37:15": [
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    }
+  ],
+  "37:16": [
+    {
+      "surface": "Better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "37:17": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "37:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "37:19": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    }
+  ],
+  "37:20": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "37:21": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "37:22": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "37:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "37:24": [
+    {
+      "surface": "stumbles",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "37:25": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "begging",
+      "tw_match": "begging"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "37:26": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "37:27": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "safe",
+      "tw_match": "safe"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "37:28": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "37:29": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "37:30": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "37:31": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "37:32": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "37:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "37:34": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "37:35": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "37:36": [],
+  "37:37": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "37:38": [
+    {
+      "surface": "Sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "37:39": [
+    {
+      "surface": "Salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "37:40": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "saves",
+      "tw_match": "save"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "38:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "38:2": [],
+  "38:3": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "38:4": [
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "38:5": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "38:6": [
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "38:7": [],
+  "38:8": [
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    }
+  ],
+  "38:9": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "38:10": [],
+  "38:11": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    }
+  ],
+  "38:12": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "snares",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "38:13": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "38:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "38:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "38:16": [],
+  "38:17": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    }
+  ],
+  "38:18": [
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "38:19": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "38:20": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "38:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "38:22": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "39:1": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "39:2": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "39:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "39:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "39:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "39:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    }
+  ],
+  "39:7": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "39:8": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    }
+  ],
+  "39:9": [],
+  "39:10": [],
+  "39:11": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "39:12": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "refugee",
+      "tw_match": "refugee"
+    }
+  ],
+  "39:13": [],
+  "40:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "40:2": [
+    {
+      "surface": "horrible",
+      "tw_match": "horrible"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "40:3": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "40:4": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "40:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    }
+  ],
+  "40:6": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "40:7": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "40:8": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    }
+  ],
+  "40:9": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "40:10": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "declared",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    }
+  ],
+  "40:11": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    }
+  ],
+  "40:12": [
+    {
+      "surface": "Troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "40:13": [
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "40:14": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "hurting",
+      "tw_match": "hurt"
+    }
+  ],
+  "40:15": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "40:16": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    }
+  ],
+  "40:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "41:1": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "41:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "41:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    }
+  ],
+  "41:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "41:5": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "41:6": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "tells",
+      "tw_match": "tell"
+    }
+  ],
+  "41:7": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    }
+  ],
+  "41:8": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "41:9": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "41:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "41:11": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "41:12": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "41:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "42:1": [
+    {
+      "surface": "deer",
+      "tw_match": "deer"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "42:2": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "42:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "42:4": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "celebrating",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "festival",
+      "tw_match": "festival"
+    }
+  ],
+  "42:5": [
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "42:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "42:7": [
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "42:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "42:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "42:10": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "42:11": [
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "43:1": [
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "Deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "43:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fortification",
+      "tw_match": "fortifications"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "43:3": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "43:4": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    }
+  ],
+  "43:5": [
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "44:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "44:2": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "44:3": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "possess",
+      "tw_match": "possess"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    }
+  ],
+  "44:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "44:5": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    }
+  ],
+  "44:6": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "44:7": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "44:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "boasted",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "44:9": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    }
+  ],
+  "44:10": [
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "44:11": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "44:12": [],
+  "44:13": [
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    }
+  ],
+  "44:14": [
+    {
+      "surface": "insult",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    }
+  ],
+  "44:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "44:16": [
+    {
+      "surface": "reproaching",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "insulting",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "44:17": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "44:18": [],
+  "44:19": [],
+  "44:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "44:21": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "44:22": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "slaughtering",
+      "tw_match": "slaughter"
+    }
+  ],
+  "44:23": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "44:24": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "44:25": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "44:26": [
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "45:1": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "subject",
+      "tw_match": "subject"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "45:2": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "45:3": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "45:4": [
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "meekness",
+      "tw_match": "meekness"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "45:5": [
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "45:6": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "45:7": [
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    }
+  ],
+  "45:8": [
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "45:9": [
+    {
+      "surface": "Kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "45:10": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "45:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "revere",
+      "tw_match": "revere"
+    }
+  ],
+  "45:12": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "45:13": [
+    {
+      "surface": "royal",
+      "tw_match": "royal"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "45:14": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    }
+  ],
+  "45:15": [
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    }
+  ],
+  "45:16": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "45:17": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "46:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "46:2": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "46:3": [
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "46:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "46:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "46:6": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "raged",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "46:7": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "46:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "46:9": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "spear",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    }
+  ],
+  "46:10": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "46:11": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "47:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "47:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "47:3": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "47:4": [
+    {
+      "surface": "chooses",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "47:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    }
+  ],
+  "47:6": [
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    }
+  ],
+  "47:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "47:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "47:9": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "48:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "48:2": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    }
+  ],
+  "48:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "48:4": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "assembled",
+      "tw_match": "assemble"
+    }
+  ],
+  "48:5": [],
+  "48:6": [
+    {
+      "surface": "Trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "48:7": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    }
+  ],
+  "48:8": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "48:9": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "48:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "48:11": [
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    }
+  ],
+  "48:12": [
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    }
+  ],
+  "48:13": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "palaces",
+      "tw_match": "palace"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "48:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "49:1": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "49:2": [],
+  "49:3": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "meditation",
+      "tw_match": "meditation"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "49:4": [
+    {
+      "surface": "parable",
+      "tw_match": "parable"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    }
+  ],
+  "49:5": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "49:6": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "49:7": [
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    }
+  ],
+  "49:8": [
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "49:9": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "49:10": [
+    {
+      "surface": "Wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "alike",
+      "tw_match": "alike"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "49:11": [
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "49:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "49:13": [
+    {
+      "surface": "folly",
+      "tw_match": "folly"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "49:14": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "49:15": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "49:16": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "49:17": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "49:18": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "49:19": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "49:20": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "50:1": [
+    {
+      "surface": "Psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "50:2": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "50:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    }
+  ],
+  "50:4": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "50:5": [
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "50:6": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "50:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "50:8": [
+    {
+      "surface": "reprove",
+      "tw_match": "reprove"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "50:9": [
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "50:10": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "50:11": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "50:12": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "50:13": [
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    }
+  ],
+  "50:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "50:15": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    }
+  ],
+  "50:16": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "50:17": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    }
+  ],
+  "50:18": [
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    }
+  ],
+  "50:19": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "50:20": [
+    {
+      "surface": "slander",
+      "tw_match": "slander"
+    }
+  ],
+  "50:21": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "reprove",
+      "tw_match": "reprove"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "50:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "50:23": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "51:1": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "blot out",
+      "tw_match": "blot out"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    }
+  ],
+  "51:2": [
+    {
+      "surface": "Wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "51:3": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "51:4": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "51:5": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "51:6": [
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "51:7": [
+    {
+      "surface": "Purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    }
+  ],
+  "51:8": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "51:9": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "blot out",
+      "tw_match": "blot out"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "51:10": [
+    {
+      "surface": "Create",
+      "tw_match": "create"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "51:11": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "51:12": [
+    {
+      "surface": "Restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "51:13": [
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    }
+  ],
+  "51:14": [
+    {
+      "surface": "Forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "51:15": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "51:16": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "51:17": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "51:18": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "51:19": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "52:1": [
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "52:2": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    }
+  ],
+  "52:3": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "52:4": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "52:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "52:6": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "52:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "52:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "52:9": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "53:1": [
+    {
+      "surface": "fool",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "corrupt",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "abominable",
+      "tw_match": "abominable"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "53:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "53:3": [
+    {
+      "surface": "corrupt",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "53:4": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "53:5": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "53:6": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "54:1": [
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "54:2": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "54:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "54:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "54:5": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "54:6": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "freewill offering",
+      "tw_match": "freewill offering"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "54:7": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "55:1": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    }
+  ],
+  "55:2": [
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    }
+  ],
+  "55:3": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "persecute",
+      "tw_match": "persecute"
+    }
+  ],
+  "55:4": [
+    {
+      "surface": "trembles",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    }
+  ],
+  "55:5": [
+    {
+      "surface": "trembling",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "horror",
+      "tw_match": "horror"
+    }
+  ],
+  "55:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    }
+  ],
+  "55:7": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "55:8": [
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "55:9": [
+    {
+      "surface": "Devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    }
+  ],
+  "55:10": [
+    {
+      "surface": "Day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "55:11": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "55:12": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    }
+  ],
+  "55:13": [
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "55:14": [
+    {
+      "surface": "fellowship",
+      "tw_match": "fellowship"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "55:15": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "55:16": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "55:17": [],
+  "55:18": [],
+  "55:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "humiliate",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "55:20": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "55:21": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    }
+  ],
+  "55:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "55:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    }
+  ],
+  "56:1": [
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "56:2": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "56:3": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    }
+  ],
+  "56:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "56:5": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "56:6": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "56:7": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "56:8": [],
+  "56:9": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "56:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "56:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "56:12": [
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "56:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "57:1": [
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "57:2": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "57:3": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "57:4": [
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "spears",
+      "tw_match": "spear"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    }
+  ],
+  "57:5": [
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "57:6": [
+    {
+      "surface": "distressed",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "57:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    }
+  ],
+  "57:8": [
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "lute",
+      "tw_match": "lute"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    }
+  ],
+  "57:9": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "57:10": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "57:11": [
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "58:1": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "58:2": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "58:3": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "58:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snake",
+      "tw_match": "snake"
+    }
+  ],
+  "58:5": [],
+  "58:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "58:7": [],
+  "58:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "58:9": [
+    {
+      "surface": "thorn",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "alike",
+      "tw_match": "alike"
+    }
+  ],
+  "58:10": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "58:11": [
+    {
+      "surface": "Truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "59:1": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "59:2": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "safe",
+      "tw_match": "safe"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "59:3": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "59:4": [],
+  "59:5": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "59:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "59:7": [
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    }
+  ],
+  "59:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "59:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "59:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "59:11": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "59:12": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "59:13": [
+    {
+      "surface": "Consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "59:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "59:15": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "59:16": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "59:17": [
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "60:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    }
+  ],
+  "60:2": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "shaking",
+      "tw_match": "shake"
+    }
+  ],
+  "60:3": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "staggering",
+      "tw_match": "stagger"
+    }
+  ],
+  "60:4": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "60:5": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "60:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    }
+  ],
+  "60:7": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    }
+  ],
+  "60:8": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Philistia",
+      "tw_match": "Philistia"
+    }
+  ],
+  "60:9": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "60:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "60:11": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "60:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "61:1": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "61:2": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "61:3": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "61:4": [
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "61:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "61:6": [
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "61:7": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "61:8": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "62:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "62:2": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "62:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "62:4": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "62:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "62:6": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    }
+  ],
+  "62:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "62:8": [
+    {
+      "surface": "Trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "62:9": [
+    {
+      "surface": "vanity",
+      "tw_match": "vanity"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "62:10": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "robbery",
+      "tw_match": "robbery"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "62:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "62:12": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "63:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "63:2": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "63:3": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "63:4": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "63:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "63:6": [
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "hours",
+      "tw_match": "hour"
+    }
+  ],
+  "63:7": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "63:8": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "63:9": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "63:10": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "63:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "64:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "64:2": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "64:3": [
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    }
+  ],
+  "64:4": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "64:5": [
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "traps",
+      "tw_match": "trap"
+    }
+  ],
+  "64:6": [
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    }
+  ],
+  "64:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "64:8": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    }
+  ],
+  "64:9": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "64:10": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    }
+  ],
+  "65:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "carried out",
+      "tw_match": "carried out"
+    }
+  ],
+  "65:2": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "65:3": [
+    {
+      "surface": "Iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    }
+  ],
+  "65:4": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "65:5": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "65:6": [
+    {
+      "surface": "belted",
+      "tw_match": "belt"
+    }
+  ],
+  "65:7": [],
+  "65:8": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "evidence",
+      "tw_match": "evidence"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "65:9": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "65:10": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "65:11": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    }
+  ],
+  "65:12": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "65:13": [
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "66:1": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "66:2": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    }
+  ],
+  "66:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "submit",
+      "tw_match": "submit"
+    }
+  ],
+  "66:4": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "66:5": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "66:6": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "66:7": [
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "66:8": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "66:9": [
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    }
+  ],
+  "66:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "66:11": [],
+  "66:12": [],
+  "66:13": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    }
+  ],
+  "66:14": [
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "66:15": [
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "66:16": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "66:17": [
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "66:18": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "66:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "66:20": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "67:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "67:2": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "67:3": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "67:4": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    },
+    {
+      "surface": "govern",
+      "tw_match": "govern"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "67:5": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "67:6": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "67:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "68:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "68:2": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "68:3": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "68:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Jordan River",
+      "tw_match": "Jordan River"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "68:5": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "68:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "68:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "68:8": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "68:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "68:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "68:11": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    }
+  ],
+  "68:12": [
+    {
+      "surface": "Kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "68:13": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "sheepfolds",
+      "tw_match": "sheepfold"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "68:14": [
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "snowed",
+      "tw_match": "snow"
+    }
+  ],
+  "68:15": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "68:16": [
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "68:17": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Sinai",
+      "tw_match": "Sinai"
+    }
+  ],
+  "68:18": [
+    {
+      "surface": "captives",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "68:19": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "68:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "saves",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "68:21": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "68:22": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "68:23": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    }
+  ],
+  "68:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "68:25": [],
+  "68:26": [
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "assemblies",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "68:27": [
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    }
+  ],
+  "68:28": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "decreed",
+      "tw_match": "decreed"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "68:29": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "68:30": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "reeds",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "bulls",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "Humiliate",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "68:31": [
+    {
+      "surface": "Princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "68:32": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "68:33": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "68:34": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "68:35": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    }
+  ],
+  "69:1": [
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "69:2": [
+    {
+      "surface": "floods",
+      "tw_match": "flood"
+    }
+  ],
+  "69:3": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "69:4": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "69:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "69:6": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "69:7": [
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "69:8": [
+    {
+      "surface": "alien",
+      "tw_match": "alien"
+    }
+  ],
+  "69:9": [
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "rebukes",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "69:10": [
+    {
+      "surface": "insulted",
+      "tw_match": "insult"
+    }
+  ],
+  "69:11": [
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    },
+    {
+      "surface": "proverb",
+      "tw_match": "proverb"
+    }
+  ],
+  "69:12": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "drunkards",
+      "tw_match": "drunkard"
+    }
+  ],
+  "69:13": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "69:14": [],
+  "69:15": [
+    {
+      "surface": "floods",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "69:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    }
+  ],
+  "69:17": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "69:18": [
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "ransom",
+      "tw_match": "ransom"
+    }
+  ],
+  "69:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    }
+  ],
+  "69:20": [
+    {
+      "surface": "Rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "69:21": [],
+  "69:22": [
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    }
+  ],
+  "69:23": [
+    {
+      "surface": "loins",
+      "tw_match": "loins"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    }
+  ],
+  "69:24": [
+    {
+      "surface": "overtake",
+      "tw_match": "overtake"
+    }
+  ],
+  "69:25": [
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "69:26": [
+    {
+      "surface": "persecuted",
+      "tw_match": "persecute"
+    }
+  ],
+  "69:27": [
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "69:28": [
+    {
+      "surface": "Book of Life",
+      "tw_match": "Book of Life"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "69:29": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "69:30": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    }
+  ],
+  "69:31": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "69:32": [
+    {
+      "surface": "meek",
+      "tw_match": "meek"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "69:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "69:34": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "69:35": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "69:36": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "70:1": [
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "70:2": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    }
+  ],
+  "70:3": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "70:4": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    }
+  ],
+  "70:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "71:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "71:2": [
+    {
+      "surface": "safe",
+      "tw_match": "safe"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "71:3": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    }
+  ],
+  "71:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    }
+  ],
+  "71:5": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    }
+  ],
+  "71:6": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "71:7": [
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "71:8": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "71:9": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    }
+  ],
+  "71:10": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "71:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "71:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "71:13": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    }
+  ],
+  "71:14": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "71:15": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "71:16": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "71:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "71:18": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "71:19": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "71:20": [
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "71:21": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "71:22": [
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "71:23": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    }
+  ],
+  "71:24": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    }
+  ],
+  "72:1": [
+    {
+      "surface": "Psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    }
+  ],
+  "72:2": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "72:3": [
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "72:4": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "72:5": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "72:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "72:7": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "72:8": [
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "72:9": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "72:10": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Tarshish",
+      "tw_match": "Tarshish"
+    },
+    {
+      "surface": "tribute",
+      "tw_match": "tribute"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    }
+  ],
+  "72:11": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "72:12": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    }
+  ],
+  "72:13": [
+    {
+      "surface": "saves",
+      "tw_match": "save"
+    }
+  ],
+  "72:14": [
+    {
+      "surface": "redeems",
+      "tw_match": "redeem"
+    }
+  ],
+  "72:15": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "Sheba",
+      "tw_match": "Sheba"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "72:16": [
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "72:17": [
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "72:18": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "72:19": [
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "72:20": [
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    }
+  ],
+  "73:1": [
+    {
+      "surface": "Psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    }
+  ],
+  "73:2": [],
+  "73:3": [
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "73:4": [],
+  "73:5": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "73:6": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    }
+  ],
+  "73:7": [],
+  "73:8": [
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "73:9": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "73:10": [],
+  "73:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "73:12": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "73:13": [
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "73:14": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    }
+  ],
+  "73:15": [
+    {
+      "surface": "betrayed",
+      "tw_match": "betray"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "73:16": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "73:17": [
+    {
+      "surface": "sanctuaries",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "discerned",
+      "tw_match": "discern"
+    }
+  ],
+  "73:18": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "73:19": [
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    },
+    {
+      "surface": "moment",
+      "tw_match": "moment"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    }
+  ],
+  "73:20": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    }
+  ],
+  "73:21": [],
+  "73:22": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    }
+  ],
+  "73:23": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "73:24": [
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "73:25": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "73:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "73:27": [
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    }
+  ],
+  "73:28": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "74:1": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "74:2": [
+    {
+      "surface": "congregation",
+      "tw_match": "congregation"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    }
+  ],
+  "74:3": [
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "74:4": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    }
+  ],
+  "74:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "axes",
+      "tw_match": "ax"
+    }
+  ],
+  "74:6": [],
+  "74:7": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "profaned",
+      "tw_match": "profaned"
+    }
+  ],
+  "74:8": [
+    {
+      "surface": "meeting",
+      "tw_match": "meeting"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "74:9": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    }
+  ],
+  "74:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "adversary",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "74:11": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "74:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "74:13": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "74:14": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "74:15": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "74:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "74:17": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "74:18": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    }
+  ],
+  "74:19": [
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "74:20": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "74:21": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "74:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    },
+    {
+      "surface": "insult",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "74:23": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    }
+  ],
+  "75:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "75:2": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "75:3": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "75:4": [
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "75:5": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    }
+  ],
+  "75:6": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "75:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "75:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "75:9": [
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "75:10": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "76:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "76:2": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "76:3": [
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "76:4": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "descend",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "76:5": [
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "76:6": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    }
+  ],
+  "76:7": [
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "76:8": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "76:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "76:10": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "gird",
+      "tw_match": "gird"
+    }
+  ],
+  "76:11": [
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    }
+  ],
+  "76:12": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "77:1": [
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "77:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "77:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "77:4": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    }
+  ],
+  "77:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "77:6": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    }
+  ],
+  "77:7": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "77:8": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "77:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "77:10": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "77:11": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "77:12": [],
+  "77:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "77:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "77:15": [
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "77:16": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    }
+  ],
+  "77:17": [
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "77:18": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "trembled",
+      "tw_match": "tremble"
+    }
+  ],
+  "77:19": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "77:20": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "78:1": [
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "78:2": [
+    {
+      "surface": "parables",
+      "tw_match": "parable"
+    }
+  ],
+  "78:3": [],
+  "78:4": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "praiseworthy",
+      "tw_match": "praiseworthy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "78:5": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "78:6": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "78:7": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "78:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "78:9": [
+    {
+      "surface": "Ephraimites",
+      "tw_match": "Ephraimite"
+    },
+    {
+      "surface": "bows",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "78:10": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "78:11": [],
+  "78:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "78:13": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "78:14": [],
+  "78:15": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "78:16": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "78:17": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "rebelling",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "78:18": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "78:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "78:20": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "78:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "78:22": [
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "78:23": [
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "78:24": [
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "78:25": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "78:26": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "78:27": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "78:28": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "78:29": [],
+  "78:30": [],
+  "78:31": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "78:32": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "78:33": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    }
+  ],
+  "78:34": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "78:35": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "78:36": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    }
+  ],
+  "78:37": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "78:38": [
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "stir up",
+      "tw_match": "stir up"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "78:39": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "78:40": [
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    }
+  ],
+  "78:41": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "78:42": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "78:43": [
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "78:44": [
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "78:45": [
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "78:46": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    }
+  ],
+  "78:47": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    }
+  ],
+  "78:48": [
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "livestock",
+      "tw_match": "livestock"
+    }
+  ],
+  "78:49": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "78:50": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "78:51": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    }
+  ],
+  "78:52": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "78:53": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "78:54": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "78:55": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "assigned",
+      "tw_match": "assigned"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    }
+  ],
+  "78:56": [
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "78:57": [
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    }
+  ],
+  "78:58": [
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "78:59": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "78:60": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "Shiloh",
+      "tw_match": "Shiloh"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "78:61": [
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "78:62": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "78:63": [
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    }
+  ],
+  "78:64": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "78:65": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "78:66": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "78:67": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    }
+  ],
+  "78:68": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "78:69": [
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "78:70": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "sheepfolds",
+      "tw_match": "sheepfold"
+    }
+  ],
+  "78:71": [
+    {
+      "surface": "ewes",
+      "tw_match": "ewe"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "78:72": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "shepherded",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "79:1": [
+    {
+      "surface": "Psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "79:2": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "79:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "bury",
+      "tw_match": "bury"
+    }
+  ],
+  "79:4": [
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    }
+  ],
+  "79:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "79:6": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "79:7": [
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "79:8": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    }
+  ],
+  "79:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "79:10": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "avenged",
+      "tw_match": "avenge"
+    }
+  ],
+  "79:11": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "79:12": [
+    {
+      "surface": "neighboring",
+      "tw_match": "neighboring"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "insulted",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "79:13": [
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "80:1": [
+    {
+      "surface": "Shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "80:2": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "stir up",
+      "tw_match": "stir up"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "80:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "80:4": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "80:5": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "80:6": [
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "80:7": [
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "80:8": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "transplanted",
+      "tw_match": "transplanted"
+    }
+  ],
+  "80:9": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "80:10": [
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "80:11": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Euphrates River",
+      "tw_match": "Euphrates River"
+    }
+  ],
+  "80:12": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "80:13": [
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "80:14": [
+    {
+      "surface": "God of hosts",
+      "tw_match": "God of hosts"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    }
+  ],
+  "80:15": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    }
+  ],
+  "80:16": [
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "80:17": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    }
+  ],
+  "80:18": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "80:19": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "81:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "81:2": [
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    }
+  ],
+  "81:3": [
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "new moon",
+      "tw_match": "new moon"
+    },
+    {
+      "surface": "feast",
+      "tw_match": "feast"
+    }
+  ],
+  "81:4": [
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "81:5": [
+    {
+      "surface": "regulation",
+      "tw_match": "regulations"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "81:6": [
+    {
+      "surface": "freed",
+      "tw_match": "freed"
+    }
+  ],
+  "81:7": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "81:8": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "81:9": [
+    {
+      "surface": "god",
+      "tw_match": "god"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "81:10": [
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "81:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "81:12": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "81:13": [],
+  "81:14": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "81:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "humiliated",
+      "tw_match": "humiliate"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "81:16": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "82:1": [
+    {
+      "surface": "Psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "Asaph",
+      "tw_match": "Asaph"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "divine",
+      "tw_match": "divine"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "82:2": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "favoritism",
+      "tw_match": "favoritism"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "82:3": [
+    {
+      "surface": "rights",
+      "tw_match": "right"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "82:4": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "82:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "82:6": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "82:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "82:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "83:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "83:2": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "83:3": [],
+  "83:4": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "83:5": [],
+  "83:6": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Ishmaelites",
+      "tw_match": "Ishmaelite"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "83:7": [
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Amalek",
+      "tw_match": "Amalek"
+    },
+    {
+      "surface": "Philistia",
+      "tw_match": "Philistia"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    }
+  ],
+  "83:8": [
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "Lot",
+      "tw_match": "Lot"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "83:9": [
+    {
+      "surface": "Midian",
+      "tw_match": "Midian"
+    }
+  ],
+  "83:10": [
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "manure",
+      "tw_match": "manure"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "83:11": [
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "83:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "83:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "83:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "83:15": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    }
+  ],
+  "83:16": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "83:17": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    }
+  ],
+  "83:18": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "84:1": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "84:2": [
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "84:3": [
+    {
+      "surface": "a house",
+      "tw_match": "a house"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "84:4": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "84:5": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "84:6": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    }
+  ],
+  "84:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "84:8": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "84:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "84:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "84:11": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    }
+  ],
+  "84:12": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    }
+  ],
+  "85:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "85:2": [
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "85:3": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "85:4": [
+    {
+      "surface": "Restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "85:5": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "85:6": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "85:7": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "85:8": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "85:9": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "85:10": [
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "85:11": [
+    {
+      "surface": "Trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "85:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "blessings",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "85:13": [
+    {
+      "surface": "Righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "86:1": [
+    {
+      "surface": "Prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "86:2": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    }
+  ],
+  "86:3": [
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "86:4": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "86:5": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "forgive",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    }
+  ],
+  "86:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    }
+  ],
+  "86:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "86:8": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "86:9": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "86:10": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "86:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reverence",
+      "tw_match": "reverence"
+    }
+  ],
+  "86:12": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "86:13": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "86:14": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "86:15": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    }
+  ],
+  "86:16": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "86:17": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "87:1": [
+    {
+      "surface": "Psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "Korah",
+      "tw_match": "Korah"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "founded",
+      "tw_match": "founded"
+    }
+  ],
+  "87:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "87:3": [
+    {
+      "surface": "Glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "87:4": [
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Philistia",
+      "tw_match": "Philistia"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    }
+  ],
+  "87:5": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "87:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "census",
+      "tw_match": "census"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "87:7": [
+    {
+      "surface": "fountains",
+      "tw_match": "fountain"
+    }
+  ],
+  "88:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "88:2": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "88:3": [
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "88:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "88:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "88:6": [
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "88:7": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "88:8": [],
+  "88:9": [
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "88:10": [
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "88:11": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    }
+  ],
+  "88:12": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "88:13": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "88:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    }
+  ],
+  "88:15": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    }
+  ],
+  "88:16": [
+    {
+      "surface": "terrifying",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "annihilated",
+      "tw_match": "annihilate"
+    }
+  ],
+  "88:17": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "88:18": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    }
+  ],
+  "89:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "89:2": [
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "89:3": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "89:4": [
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "89:5": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "89:6": [
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "89:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "council",
+      "tw_match": "council"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "awesome",
+      "tw_match": "awesome"
+    }
+  ],
+  "89:8": [
+    {
+      "surface": "Yahweh God",
+      "tw_match": "Yahweh God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "89:9": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "raging",
+      "tw_match": "rage"
+    }
+  ],
+  "89:10": [
+    {
+      "surface": "Rahab",
+      "tw_match": "Rahab"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "89:11": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "89:12": [
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "89:13": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "89:14": [
+    {
+      "surface": "Righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    }
+  ],
+  "89:15": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "89:16": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    }
+  ],
+  "89:17": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "89:18": [
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "89:19": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "89:20": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "89:21": [],
+  "89:22": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    }
+  ],
+  "89:23": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "89:24": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "89:25": [
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "89:26": [
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "89:27": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "89:28": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "89:29": [
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "89:30": [
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "regulations",
+      "tw_match": "regulations"
+    }
+  ],
+  "89:31": [
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "89:32": [
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "89:33": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "89:34": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "89:35": [
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "89:36": [
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "89:37": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "89:38": [
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "89:39": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "desecrated",
+      "tw_match": "desecrated"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    }
+  ],
+  "89:40": [
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    },
+    {
+      "surface": "strongholds",
+      "tw_match": "stronghold"
+    }
+  ],
+  "89:41": [
+    {
+      "surface": "robbed",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "neighbors",
+      "tw_match": "neighbor"
+    }
+  ],
+  "89:42": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "89:43": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "89:44": [
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "89:45": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "89:46": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "89:47": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    }
+  ],
+  "89:48": [
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "89:49": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "89:50": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "mocking",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "89:51": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "89:52": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "90:1": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "90:2": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "90:3": [],
+  "90:4": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    }
+  ],
+  "90:5": [
+    {
+      "surface": "flood",
+      "tw_match": "flood"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "90:6": [
+    {
+      "surface": "dries",
+      "tw_match": "dry"
+    }
+  ],
+  "90:7": [
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "90:8": [
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "90:9": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "90:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "90:11": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "90:12": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "90:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "90:14": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "90:15": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "90:16": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "90:17": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "91:1": [
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    },
+    {
+      "surface": "Shaddai",
+      "tw_match": "shaddai"
+    }
+  ],
+  "91:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "91:3": [
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "calamities",
+      "tw_match": "calamity"
+    }
+  ],
+  "91:4": [
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "ram",
+      "tw_match": "ram"
+    }
+  ],
+  "91:5": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "91:6": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "wastes",
+      "tw_match": "waste"
+    }
+  ],
+  "91:7": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "91:8": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "91:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "91:10": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    }
+  ],
+  "91:11": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "91:12": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "91:13": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    }
+  ],
+  "91:14": [
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "91:15": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "91:16": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "92:1": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "92:2": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "92:3": [
+    {
+      "surface": "lyre",
+      "tw_match": "lyre"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    }
+  ],
+  "92:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "92:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "92:6": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "92:7": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    }
+  ],
+  "92:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "92:9": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    }
+  ],
+  "92:10": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "ox",
+      "tw_match": "ox"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "92:11": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "92:12": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "92:13": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "92:14": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "92:15": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    }
+  ],
+  "93:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "girds",
+      "tw_match": "gird"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    }
+  ],
+  "93:2": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    }
+  ],
+  "93:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "93:4": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "93:5": [
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "94:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "94:2": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    }
+  ],
+  "94:3": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "94:4": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "94:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "afflict",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "94:6": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    }
+  ],
+  "94:7": [
+    {
+      "surface": "Yah",
+      "tw_match": "Yah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "94:8": [
+    {
+      "surface": "Understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "fools",
+      "tw_match": "fool"
+    }
+  ],
+  "94:9": [
+    {
+      "surface": "planting",
+      "tw_match": "plant"
+    }
+  ],
+  "94:10": [
+    {
+      "surface": "instructing",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "94:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "94:12": [
+    {
+      "surface": "joys",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "instruct",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "Yah",
+      "tw_match": "Yah"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "94:13": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "94:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "94:15": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "94:16": [],
+  "94:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "94:18": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "94:19": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "94:20": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "creating",
+      "tw_match": "create"
+    },
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    }
+  ],
+  "94:21": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    }
+  ],
+  "94:22": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "94:23": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "95:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "95:2": [
+    {
+      "surface": "psalms",
+      "tw_match": "psalm"
+    }
+  ],
+  "95:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "95:4": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "95:5": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "95:6": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "kneel",
+      "tw_match": "kneel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "95:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "95:8": [
+    {
+      "surface": "harden",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "95:9": [
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    }
+  ],
+  "95:10": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "95:11": [
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    }
+  ],
+  "96:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "96:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "announce",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "96:3": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "96:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "feared",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "96:5": [
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "96:6": [
+    {
+      "surface": "Splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "sanctuary",
+      "tw_match": "sanctuary"
+    }
+  ],
+  "96:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "96:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    }
+  ],
+  "96:9": [
+    {
+      "surface": "Bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "96:10": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "96:11": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "96:12": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "96:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    }
+  ],
+  "97:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "97:2": [
+    {
+      "surface": "Righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "97:3": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    }
+  ],
+  "97:4": [
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "trembles",
+      "tw_match": "tremble"
+    }
+  ],
+  "97:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "97:6": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "97:7": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "carved image",
+      "tw_match": "carved image"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "97:8": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "97:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "97:10": [
+    {
+      "surface": "Lovers",
+      "tw_match": "lover"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "97:11": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "97:12": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    }
+  ],
+  "98:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "98:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "98:3": [
+    {
+      "surface": "covenant loyalty",
+      "tw_match": "covenant loyalty"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "98:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "98:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    }
+  ],
+  "98:6": [
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "98:7": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "98:8": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "98:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "99:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "enthroned",
+      "tw_match": "enthroned"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "99:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "99:3": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "awesome",
+      "tw_match": "awesome"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "99:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "99:5": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "99:6": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Samuel",
+      "tw_match": "Samuel"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "99:7": [
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "99:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "forgiving",
+      "tw_match": "forgive"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    }
+  ],
+  "99:9": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "100:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "100:2": [
+    {
+      "surface": "Serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    }
+  ],
+  "100:3": [
+    {
+      "surface": "Know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "100:4": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "100:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "101:1": [
+    {
+      "surface": "Psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    }
+  ],
+  "101:2": [
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "101:3": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "101:4": [
+    {
+      "surface": "Perverse",
+      "tw_match": "perverse"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "101:5": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "slanders",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    }
+  ],
+  "101:6": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "integrity",
+      "tw_match": "integrity"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "101:7": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "welcome",
+      "tw_match": "welcome"
+    }
+  ],
+  "101:8": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "102:1": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "102:2": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    }
+  ],
+  "102:3": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "102:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "102:5": [],
+  "102:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "102:7": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "102:8": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "mock",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    }
+  ],
+  "102:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "102:10": [
+    {
+      "surface": "raging",
+      "tw_match": "rage"
+    }
+  ],
+  "102:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "102:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "102:13": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "102:14": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "ruins",
+      "tw_match": "ruins"
+    }
+  ],
+  "102:15": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "102:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "102:17": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    }
+  ],
+  "102:18": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "102:19": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "102:20": [
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    }
+  ],
+  "102:21": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "102:22": [
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "102:23": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "102:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "102:25": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "102:26": [
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "102:27": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "102:28": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "103:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "103:2": [
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "rewards",
+      "tw_match": "reward"
+    }
+  ],
+  "103:3": [
+    {
+      "surface": "pardons",
+      "tw_match": "pardon"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "103:4": [
+    {
+      "surface": "redeems",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "crowns",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "103:5": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    }
+  ],
+  "103:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "103:7": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "103:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "103:9": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "103:10": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    }
+  ],
+  "103:11": [
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "103:12": [
+    {
+      "surface": "transgressions",
+      "tw_match": "transgression"
+    }
+  ],
+  "103:13": [
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "103:14": [
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "103:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "103:16": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "acknowledge",
+      "tw_match": "acknowledge"
+    }
+  ],
+  "103:17": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "103:18": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "103:19": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "rules",
+      "tw_match": "rule"
+    }
+  ],
+  "103:20": [
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "103:21": [
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "103:22": [
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    }
+  ],
+  "104:1": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    }
+  ],
+  "104:2": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "curtain",
+      "tw_match": "curtain"
+    }
+  ],
+  "104:3": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "104:4": [
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "messengers",
+      "tw_match": "messenger"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "104:5": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "104:6": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "104:7": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "104:8": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "104:9": [
+    {
+      "surface": "cross",
+      "tw_match": "cross"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "104:10": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "104:11": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "quench",
+      "tw_match": "quench"
+    }
+  ],
+  "104:12": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "104:13": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "104:14": [
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "104:15": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "104:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    }
+  ],
+  "104:17": [
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    }
+  ],
+  "104:18": [
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "104:19": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "104:20": [
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "104:21": [
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "104:22": [],
+  "104:23": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "104:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "104:25": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "104:26": [
+    {
+      "surface": "Leviathan",
+      "tw_match": "Leviathan"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "104:27": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "104:28": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "104:29": [
+    {
+      "surface": "troubled",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "104:30": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    }
+  ],
+  "104:31": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    }
+  ],
+  "104:32": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "shakes",
+      "tw_match": "shake"
+    }
+  ],
+  "104:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "104:34": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "104:35": [
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    }
+  ],
+  "105:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "105:2": [
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    }
+  ],
+  "105:3": [
+    {
+      "surface": "Boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "105:4": [
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "105:5": [
+    {
+      "surface": "miracles",
+      "tw_match": "miracle"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    }
+  ],
+  "105:6": [
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "105:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "105:8": [
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "105:9": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "105:10": [
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "statute",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "105:11": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "105:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "105:13": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "105:14": [
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "105:15": [
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "105:16": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "105:17": [
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "105:18": [
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "105:19": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    }
+  ],
+  "105:20": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "105:21": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "possessions",
+      "tw_match": "possession"
+    }
+  ],
+  "105:22": [
+    {
+      "surface": "instruct",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    }
+  ],
+  "105:23": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    }
+  ],
+  "105:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "105:25": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "mistreat",
+      "tw_match": "mistreat"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "105:26": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "105:27": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    }
+  ],
+  "105:28": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "105:29": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "105:30": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    }
+  ],
+  "105:31": [],
+  "105:32": [
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "105:33": [
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    }
+  ],
+  "105:34": [
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    }
+  ],
+  "105:35": [
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "105:36": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    }
+  ],
+  "105:37": [
+    {
+      "surface": "Israelites",
+      "tw_match": "Israelites"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "stumbled",
+      "tw_match": "stumble"
+    }
+  ],
+  "105:38": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "105:39": [],
+  "105:40": [
+    {
+      "surface": "Israelites",
+      "tw_match": "Israelites"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "105:41": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "105:42": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "105:43": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "105:44": [
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "105:45": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "106:1": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "106:2": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "praiseworthy",
+      "tw_match": "praiseworthy"
+    }
+  ],
+  "106:3": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "106:4": [
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "106:5": [
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "106:6": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "106:7": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    }
+  ],
+  "106:8": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "106:9": [
+    {
+      "surface": "rebuked",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "106:10": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "106:11": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    }
+  ],
+  "106:12": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "106:13": [
+    {
+      "surface": "instructions",
+      "tw_match": "instructions"
+    }
+  ],
+  "106:14": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    }
+  ],
+  "106:15": [
+    {
+      "surface": "horrible",
+      "tw_match": "horrible"
+    }
+  ],
+  "106:16": [
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "106:17": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "106:18": [
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "106:19": [
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "Horeb",
+      "tw_match": "Horeb"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "figure",
+      "tw_match": "figure"
+    }
+  ],
+  "106:20": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "bull",
+      "tw_match": "bull"
+    }
+  ],
+  "106:21": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    }
+  ],
+  "106:22": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Ham",
+      "tw_match": "Ham"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    }
+  ],
+  "106:23": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    }
+  ],
+  "106:24": [
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "106:25": [
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "106:26": [
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    }
+  ],
+  "106:27": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "106:28": [
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "Peor",
+      "tw_match": "Peor"
+    },
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    }
+  ],
+  "106:29": [
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "106:30": [
+    {
+      "surface": "Phinehas",
+      "tw_match": "Phinehas"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "106:31": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "106:32": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    }
+  ],
+  "106:33": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    }
+  ],
+  "106:34": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "106:35": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "106:36": [
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    }
+  ],
+  "106:37": [
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    }
+  ],
+  "106:38": [
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "sacrificed",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "desecrating",
+      "tw_match": "desecrate"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "106:39": [
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prostitutes",
+      "tw_match": "prostitute"
+    }
+  ],
+  "106:40": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "106:41": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "ruled",
+      "tw_match": "rule"
+    }
+  ],
+  "106:42": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "subjection",
+      "tw_match": "subjection"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "106:43": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "rebelling",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "106:44": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "106:45": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "106:46": [],
+  "106:47": [
+    {
+      "surface": "Save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    }
+  ],
+  "106:48": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    }
+  ],
+  "107:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "107:2": [
+    {
+      "surface": "redeemed",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "107:3": [
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "107:4": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    }
+  ],
+  "107:5": [],
+  "107:6": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "107:7": [],
+  "107:8": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "107:9": [
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "107:10": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "107:11": [
+    {
+      "surface": "rebelled",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "Most High",
+      "tw_match": "Most High"
+    }
+  ],
+  "107:12": [
+    {
+      "surface": "humbled",
+      "tw_match": "humbled"
+    },
+    {
+      "surface": "hardship",
+      "tw_match": "hardship"
+    },
+    {
+      "surface": "stumbled",
+      "tw_match": "stumble"
+    }
+  ],
+  "107:13": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "107:14": [
+    {
+      "surface": "bonds",
+      "tw_match": "bonds"
+    }
+  ],
+  "107:15": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "107:16": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "107:17": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "107:18": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "107:19": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "107:20": [
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "107:21": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "107:22": [
+    {
+      "surface": "sacrifices",
+      "tw_match": "sacrifices"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "107:23": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "107:24": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    }
+  ],
+  "107:25": [],
+  "107:26": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "107:27": [
+    {
+      "surface": "staggered",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "drunkards",
+      "tw_match": "drunkard"
+    }
+  ],
+  "107:28": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    }
+  ],
+  "107:29": [],
+  "107:30": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    }
+  ],
+  "107:31": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "107:32": [
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "council",
+      "tw_match": "council"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "107:33": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "107:34": [
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    }
+  ],
+  "107:35": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "107:36": [],
+  "107:37": [
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "107:38": [
+    {
+      "surface": "blesses",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    }
+  ],
+  "107:39": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    }
+  ],
+  "107:40": [
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    }
+  ],
+  "107:41": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "families",
+      "tw_match": "family"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    }
+  ],
+  "107:42": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "107:43": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "108:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    }
+  ],
+  "108:2": [
+    {
+      "surface": "lute",
+      "tw_match": "lute"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    }
+  ],
+  "108:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "108:4": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "108:5": [
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "108:6": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "108:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Shechem",
+      "tw_match": "Shechem"
+    },
+    {
+      "surface": "Succoth",
+      "tw_match": "Succoth"
+    }
+  ],
+  "108:8": [
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    }
+  ],
+  "108:9": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "Philistia",
+      "tw_match": "Philistia"
+    }
+  ],
+  "108:10": [
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    }
+  ],
+  "108:11": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    }
+  ],
+  "108:12": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "108:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "109:1": [
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "Psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "109:2": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    }
+  ],
+  "109:3": [],
+  "109:4": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    }
+  ],
+  "109:5": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "109:6": [
+    {
+      "surface": "Appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "109:7": [
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "guilty",
+      "tw_match": "guilty"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    }
+  ],
+  "109:8": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "109:9": [],
+  "109:10": [
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "109:11": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "109:12": [],
+  "109:13": [
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "109:14": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "109:15": [
+    {
+      "surface": "guilt",
+      "tw_match": "guilt"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "109:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "109:17": [
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "109:18": [
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "109:19": [
+    {
+      "surface": "curses",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "belt",
+      "tw_match": "belt"
+    }
+  ],
+  "109:20": [
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "109:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "109:22": [],
+  "109:23": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "locust",
+      "tw_match": "locust"
+    }
+  ],
+  "109:24": [
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    }
+  ],
+  "109:25": [
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    }
+  ],
+  "109:26": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "109:27": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "109:28": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    }
+  ],
+  "109:29": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    }
+  ],
+  "109:30": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "109:31": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    }
+  ],
+  "110:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    }
+  ],
+  "110:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "110:3": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "110:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Melchizedek",
+      "tw_match": "Melchizedek"
+    }
+  ],
+  "110:5": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "110:6": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "lands",
+      "tw_match": "land"
+    }
+  ],
+  "110:7": [],
+  "111:1": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    }
+  ],
+  "111:2": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "111:3": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "111:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    }
+  ],
+  "111:5": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    }
+  ],
+  "111:6": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "111:7": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "instructions",
+      "tw_match": "instructions"
+    }
+  ],
+  "111:8": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "111:9": [
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "ordained",
+      "tw_match": "ordained"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "awesome",
+      "tw_match": "awesome"
+    }
+  ],
+  "111:10": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "instructions",
+      "tw_match": "instructions"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "112:1": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "fears",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    }
+  ],
+  "112:2": [
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "112:3": [
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "112:4": [
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "112:5": [
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "112:6": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "112:7": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "trusting",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "112:8": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    }
+  ],
+  "112:9": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "112:10": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "rage",
+      "tw_match": "rage"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "113:1": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "113:2": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "113:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    }
+  ],
+  "113:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "113:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "113:6": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "113:7": [],
+  "113:8": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "113:9": [
+    {
+      "surface": "barren",
+      "tw_match": "barren"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "114:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    }
+  ],
+  "114:2": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "114:3": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "114:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "114:5": [
+    {
+      "surface": "Jordan",
+      "tw_match": "Jordan"
+    }
+  ],
+  "114:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rams",
+      "tw_match": "ram"
+    },
+    {
+      "surface": "lambs",
+      "tw_match": "lamb"
+    }
+  ],
+  "114:7": [
+    {
+      "surface": "Tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "114:8": [
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "115:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    }
+  ],
+  "115:2": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "115:3": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "pleases",
+      "tw_match": "please"
+    }
+  ],
+  "115:4": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "115:5": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "115:6": [],
+  "115:7": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "115:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    }
+  ],
+  "115:9": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "115:10": [
+    {
+      "surface": "House",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "115:11": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    }
+  ],
+  "115:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "family",
+      "tw_match": "family"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "115:13": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    }
+  ],
+  "115:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "descendants",
+      "tw_match": "descendant"
+    }
+  ],
+  "115:15": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "115:16": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "115:17": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "115:18": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    }
+  ],
+  "116:1": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "116:2": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "116:3": [
+    {
+      "surface": "snares",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    }
+  ],
+  "116:4": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    }
+  ],
+  "116:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "compassionate",
+      "tw_match": "compassionate"
+    }
+  ],
+  "116:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "116:7": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "116:8": [
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    }
+  ],
+  "116:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "116:10": [
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    }
+  ],
+  "116:11": [],
+  "116:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "116:13": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "116:14": [
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "116:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "116:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "bonds",
+      "tw_match": "bonds"
+    }
+  ],
+  "116:17": [
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "116:18": [
+    {
+      "surface": "fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "vows",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "116:19": [
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "117:1": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    }
+  ],
+  "117:2": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    }
+  ],
+  "118:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "118:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "118:3": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "118:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    }
+  ],
+  "118:5": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    }
+  ],
+  "118:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "118:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:8": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "shelter",
+      "tw_match": "shelter"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:9": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    }
+  ],
+  "118:10": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:15": [
+    {
+      "surface": "joyful",
+      "tw_match": "joyful"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:16": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "118:17": [
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    }
+  ],
+  "118:19": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:20": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "118:21": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "118:22": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "rejected",
+      "tw_match": "rejected"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    },
+    {
+      "surface": "cornerstone",
+      "tw_match": "cornerstone"
+    }
+  ],
+  "118:23": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:24": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "118:25": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "118:26": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "118:27": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "118:28": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "exalt",
+      "tw_match": "exalt"
+    }
+  ],
+  "118:29": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "119:1": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "119:2": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "119:3": [
+    {
+      "surface": "injustice",
+      "tw_match": "injustice"
+    }
+  ],
+  "119:4": [
+    {
+      "surface": "instructions",
+      "tw_match": "instructions"
+    }
+  ],
+  "119:5": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:6": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "119:7": [
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "119:8": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    }
+  ],
+  "119:9": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    }
+  ],
+  "119:10": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "119:11": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "119:12": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:13": [
+    {
+      "surface": "announced",
+      "tw_match": "announce"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "119:14": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:15": [
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "instructions",
+      "tw_match": "instructions"
+    }
+  ],
+  "119:16": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:17": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "119:18": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:19": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "119:20": [
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "119:21": [
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "cursed",
+      "tw_match": "cursed"
+    }
+  ],
+  "119:22": [
+    {
+      "surface": "disgrace",
+      "tw_match": "disgrace"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:23": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "slander",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "meditates",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:24": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "counselors",
+      "tw_match": "counselor"
+    }
+  ],
+  "119:25": [],
+  "119:26": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:27": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "instructions",
+      "tw_match": "instructions"
+    },
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "119:28": [],
+  "119:29": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:30": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "119:31": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shamed",
+      "tw_match": "shame"
+    }
+  ],
+  "119:32": [],
+  "119:33": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "119:34": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:35": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "119:36": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    }
+  ],
+  "119:37": [],
+  "119:38": [
+    {
+      "surface": "Fulfill",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "119:39": [
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "dread",
+      "tw_match": "dread"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "119:40": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "119:41": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "119:42": [
+    {
+      "surface": "mocks",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    }
+  ],
+  "119:43": [
+    {
+      "surface": "word of truth",
+      "tw_match": "word of truth"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "119:44": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "119:45": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "119:46": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "119:47": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "119:48": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:49": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "119:50": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    }
+  ],
+  "119:51": [
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "scoff at",
+      "tw_match": "scoff at"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:52": [
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "119:53": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:54": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "119:55": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:56": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "119:57": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "119:58": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    }
+  ],
+  "119:59": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:60": [],
+  "119:61": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "ensnare",
+      "tw_match": "ensnare"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:62": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "119:63": [
+    {
+      "surface": "companion",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "119:64": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:65": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "119:66": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "discernment",
+      "tw_match": "discernment"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    }
+  ],
+  "119:67": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    }
+  ],
+  "119:68": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:69": [
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    }
+  ],
+  "119:70": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:71": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:72": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "119:73": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "119:74": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "119:75": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    }
+  ],
+  "119:76": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "119:77": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "119:78": [
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    }
+  ],
+  "119:79": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:80": [
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "119:81": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "119:82": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "119:83": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "wineskin",
+      "tw_match": "wineskin"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:84": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "119:85": [
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "pits",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:86": [],
+  "119:87": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "instructions",
+      "tw_match": "instructions"
+    }
+  ],
+  "119:88": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:89": [
+    {
+      "surface": "Forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "119:90": [
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "119:91": [
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "119:92": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    }
+  ],
+  "119:93": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "119:94": [
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "119:95": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:96": [],
+  "119:97": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "meditation",
+      "tw_match": "meditation"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "119:98": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "119:99": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "meditation",
+      "tw_match": "meditation"
+    }
+  ],
+  "119:100": [
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "119:101": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "119:102": [
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    }
+  ],
+  "119:103": [
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "119:104": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "119:105": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    }
+  ],
+  "119:106": [
+    {
+      "surface": "confirmed",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "119:107": [
+    {
+      "surface": "afflicted",
+      "tw_match": "afflict"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "119:108": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "freewill",
+      "tw_match": "freewill"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "119:109": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:110": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    }
+  ],
+  "119:111": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "119:112": [
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "119:113": [
+    {
+      "surface": "minded",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:114": [
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "119:115": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "119:116": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "119:117": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:118": [
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "deception",
+      "tw_match": "deception"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    }
+  ],
+  "119:119": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:120": [
+    {
+      "surface": "trembles",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "119:121": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "119:122": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    }
+  ],
+  "119:123": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "119:124": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:125": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:126": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:127": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "119:128": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "119:129": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:130": [
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "119:131": [],
+  "119:132": [
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "119:133": [
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    }
+  ],
+  "119:134": [
+    {
+      "surface": "Ransom",
+      "tw_match": "ransom"
+    }
+  ],
+  "119:135": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:136": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:137": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "119:138": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:139": [
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    }
+  ],
+  "119:140": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "119:141": [
+    {
+      "surface": "instructions",
+      "tw_match": "instructions"
+    }
+  ],
+  "119:142": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    }
+  ],
+  "119:143": [
+    {
+      "surface": "Distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "119:144": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "119:145": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:146": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:147": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "119:148": [
+    {
+      "surface": "watches",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "119:149": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "119:150": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:151": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "119:152": [
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "119:153": [
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "119:154": [
+    {
+      "surface": "Plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "119:155": [
+    {
+      "surface": "Salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:156": [
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "119:157": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:158": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "119:159": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "119:160": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "119:161": [
+    {
+      "surface": "Commanders",
+      "tw_match": "commander"
+    },
+    {
+      "surface": "trembles",
+      "tw_match": "tremble"
+    }
+  ],
+  "119:162": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "119:163": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    }
+  ],
+  "119:164": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "119:165": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    }
+  ],
+  "119:166": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "119:167": [
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "119:168": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "testimonies",
+      "tw_match": "testimony"
+    }
+  ],
+  "119:169": [
+    {
+      "surface": "plea",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "119:170": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "119:171": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    }
+  ],
+  "119:172": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "119:173": [
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    }
+  ],
+  "119:174": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    }
+  ],
+  "119:175": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "119:176": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "120:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "120:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "120:3": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    }
+  ],
+  "120:4": [
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    }
+  ],
+  "120:5": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "sojourned",
+      "tw_match": "sojourn"
+    },
+    {
+      "surface": "Meshech",
+      "tw_match": "Meshech"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Kedar",
+      "tw_match": "Kedar"
+    }
+  ],
+  "120:6": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "120:7": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "121:1": [],
+  "121:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "121:3": [
+    {
+      "surface": "appoint",
+      "tw_match": "appoint"
+    }
+  ],
+  "121:4": [
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "121:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "121:6": [],
+  "121:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "121:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "122:1": [
+    {
+      "surface": "rejoiced",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "122:2": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "122:3": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "122:4": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Yah",
+      "tw_match": "Yah"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "122:5": [
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "122:6": [
+    {
+      "surface": "Pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "122:7": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "fortresses",
+      "tw_match": "fortress"
+    }
+  ],
+  "122:8": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "122:9": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "123:1": [
+    {
+      "surface": "enthroned",
+      "tw_match": "enthroned"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "123:2": [
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "123:3": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "123:4": [
+    {
+      "surface": "contempt",
+      "tw_match": "contempt"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    }
+  ],
+  "124:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "124:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "124:3": [
+    {
+      "surface": "raged",
+      "tw_match": "rage"
+    }
+  ],
+  "124:4": [],
+  "124:5": [
+    {
+      "surface": "raging",
+      "tw_match": "rage"
+    }
+  ],
+  "124:6": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "124:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    }
+  ],
+  "124:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "125:1": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "enduring",
+      "tw_match": "endure"
+    }
+  ],
+  "125:2": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "125:3": [
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "wrong",
+      "tw_match": "wrong"
+    }
+  ],
+  "125:4": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "125:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "126:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "restored",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "dream",
+      "tw_match": "dream"
+    }
+  ],
+  "126:2": [
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "126:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    }
+  ],
+  "126:4": [
+    {
+      "surface": "Restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "126:5": [
+    {
+      "surface": "sow",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "126:6": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "sowing",
+      "tw_match": "sow"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "127:1": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "127:2": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "hard work",
+      "tw_match": "hard work"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "127:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    }
+  ],
+  "127:4": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    }
+  ],
+  "127:5": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    }
+  ],
+  "128:1": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "honors",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "128:2": [
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "prosper",
+      "tw_match": "prosper"
+    }
+  ],
+  "128:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "fruitful",
+      "tw_match": "fruitful"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    }
+  ],
+  "128:4": [
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "honors",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "128:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "128:6": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "129:1": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "129:2": [],
+  "129:3": [
+    {
+      "surface": "plowers",
+      "tw_match": "plowers"
+    },
+    {
+      "surface": "plowed",
+      "tw_match": "plowed"
+    }
+  ],
+  "129:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "129:5": [
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "129:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "129:7": [
+    {
+      "surface": "binds",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "129:8": [
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "130:1": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "130:2": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "130:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "iniquities",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "130:4": [
+    {
+      "surface": "forgiveness",
+      "tw_match": "forgiveness"
+    },
+    {
+      "surface": "revered",
+      "tw_match": "revered"
+    }
+  ],
+  "130:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "130:6": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "130:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "130:8": [
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "131:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "131:2": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "131:3": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "132:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "afflictions",
+      "tw_match": "affliction"
+    }
+  ],
+  "132:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "vowed",
+      "tw_match": "vow"
+    },
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "132:3": [
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "132:4": [],
+  "132:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "132:6": [
+    {
+      "surface": "Ephrathah",
+      "tw_match": "Ephrathah"
+    }
+  ],
+  "132:7": [
+    {
+      "surface": "tabernacle",
+      "tw_match": "tabernacle"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "footstool",
+      "tw_match": "footstool"
+    }
+  ],
+  "132:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "ark",
+      "tw_match": "ark"
+    }
+  ],
+  "132:9": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "132:10": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "132:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "132:12": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "laws",
+      "tw_match": "law"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "132:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "132:14": [
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "132:15": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "132:16": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "132:17": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "set up",
+      "tw_match": "set up"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "anointed",
+      "tw_match": "anointed"
+    }
+  ],
+  "132:18": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    }
+  ],
+  "133:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    }
+  ],
+  "133:2": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    }
+  ],
+  "133:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "134:1": [
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "134:2": [
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "134:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "135:1": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "135:2": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "courtyards",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "135:3": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    }
+  ],
+  "135:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    }
+  ],
+  "135:5": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    }
+  ],
+  "135:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "135:7": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "storehouse",
+      "tw_match": "storehouse"
+    }
+  ],
+  "135:8": [
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "135:9": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "135:10": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "135:11": [
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    }
+  ],
+  "135:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "135:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "renown",
+      "tw_match": "renown"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    }
+  ],
+  "135:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "135:15": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "135:16": [
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    }
+  ],
+  "135:17": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "135:18": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "trusts",
+      "tw_match": "trust"
+    }
+  ],
+  "135:19": [
+    {
+      "surface": "House",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Aaron",
+      "tw_match": "Aaron"
+    }
+  ],
+  "135:20": [
+    {
+      "surface": "House",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "135:21": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    }
+  ],
+  "136:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:3": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:4": [
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:5": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:6": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:7": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:8": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:9": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:10": [
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:11": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:12": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:13": [
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:14": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:15": [
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "Sea of Reeds",
+      "tw_match": "Sea of Reeds"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:16": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:17": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:18": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:19": [
+    {
+      "surface": "Sihon",
+      "tw_match": "Sihon"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Amorites",
+      "tw_match": "Amorite"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:20": [
+    {
+      "surface": "Og",
+      "tw_match": "Og"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:21": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:22": [
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:23": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:24": [
+    {
+      "surface": "adversaries",
+      "tw_match": "adversary"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:25": [
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "136:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "137:1": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "137:2": [
+    {
+      "surface": "hung",
+      "tw_match": "hung"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    }
+  ],
+  "137:3": [
+    {
+      "surface": "mocked",
+      "tw_match": "mock"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "137:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "137:5": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "137:6": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "chief",
+      "tw_match": "chief"
+    }
+  ],
+  "137:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Edom",
+      "tw_match": "Edom"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    }
+  ],
+  "137:8": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    }
+  ],
+  "137:9": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "seizes",
+      "tw_match": "seize"
+    }
+  ],
+  "138:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    }
+  ],
+  "138:2": [
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "trustworthiness",
+      "tw_match": "trustworthiness"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    }
+  ],
+  "138:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "138:4": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "138:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "138:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "138:7": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "138:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    }
+  ],
+  "139:1": [
+    {
+      "surface": "psalm",
+      "tw_match": "psalm"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "139:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "139:3": [],
+  "139:4": [
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "139:5": [],
+  "139:6": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "139:7": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "139:8": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "139:9": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "139:10": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "139:11": [],
+  "139:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "139:13": [
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "139:14": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "139:15": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "139:16": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "139:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "139:18": [],
+  "139:19": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "bloodshed",
+      "tw_match": "bloodshed"
+    }
+  ],
+  "139:20": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "139:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "139:22": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    }
+  ],
+  "139:23": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    }
+  ],
+  "139:24": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "140:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "140:2": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "140:3": [
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "vipers",
+      "tw_match": "viper"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "140:4": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "140:5": [
+    {
+      "surface": "proud",
+      "tw_match": "proud"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "snares",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "140:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "140:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "140:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "140:9": [],
+  "140:10": [
+    {
+      "surface": "pits",
+      "tw_match": "pit"
+    }
+  ],
+  "140:11": [
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "140:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    }
+  ],
+  "140:13": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "upright",
+      "tw_match": "upright"
+    }
+  ],
+  "141:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "141:2": [
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "141:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    }
+  ],
+  "141:4": [
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    }
+  ],
+  "141:5": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "141:6": [
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    }
+  ],
+  "141:7": [
+    {
+      "surface": "plows",
+      "tw_match": "plow"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    }
+  ],
+  "141:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "141:9": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "snare",
+      "tw_match": "snare"
+    },
+    {
+      "surface": "traps",
+      "tw_match": "trap"
+    }
+  ],
+  "141:10": [
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "142:1": [
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plead",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "142:2": [
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "troubles",
+      "tw_match": "trouble"
+    }
+  ],
+  "142:3": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    }
+  ],
+  "142:4": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "142:5": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "142:6": [
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    }
+  ],
+  "142:7": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "143:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "pleas",
+      "tw_match": "plea"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "143:2": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "143:3": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "143:4": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    }
+  ],
+  "143:5": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "143:6": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Selah",
+      "tw_match": "selah"
+    }
+  ],
+  "143:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "143:8": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "143:9": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "143:10": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "uprightness",
+      "tw_match": "uprightness"
+    }
+  ],
+  "143:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "trouble",
+      "tw_match": "trouble"
+    }
+  ],
+  "143:12": [
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "144:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "144:2": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "fortress",
+      "tw_match": "fortress"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "shield",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "144:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    }
+  ],
+  "144:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "144:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    }
+  ],
+  "144:6": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "disturb",
+      "tw_match": "disturb"
+    }
+  ],
+  "144:7": [
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    }
+  ],
+  "144:8": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "144:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lute",
+      "tw_match": "lute"
+    }
+  ],
+  "144:10": [
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "144:11": [
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "foreigners",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "144:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "plants",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "palace",
+      "tw_match": "palace"
+    }
+  ],
+  "144:13": [
+    {
+      "surface": "storehouses",
+      "tw_match": "storehouse"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    }
+  ],
+  "144:14": [
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "144:15": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "145:1": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "145:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "145:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    }
+  ],
+  "145:4": [
+    {
+      "surface": "Generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "145:5": [
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "meditate",
+      "tw_match": "meditate"
+    }
+  ],
+  "145:6": [
+    {
+      "surface": "awesome",
+      "tw_match": "awesome"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    }
+  ],
+  "145:7": [
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "145:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "merciful",
+      "tw_match": "merciful"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "145:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "145:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "145:11": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "145:12": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "glorious",
+      "tw_match": "glorious"
+    },
+    {
+      "surface": "splendor",
+      "tw_match": "splendor"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    }
+  ],
+  "145:13": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "endures",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "145:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "145:15": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "145:16": [],
+  "145:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "145:18": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "145:19": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "saves",
+      "tw_match": "save"
+    }
+  ],
+  "145:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "145:21": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "146:1": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "146:2": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "146:3": [
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "nobles",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "146:4": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "146:5": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "146:6": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "146:7": [
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "146:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "146:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "refugees",
+      "tw_match": "refugee"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "146:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "generation",
+      "tw_match": "generation"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    }
+  ],
+  "147:1": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "147:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gathers",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "147:3": [
+    {
+      "surface": "binds",
+      "tw_match": "bind"
+    }
+  ],
+  "147:4": [],
+  "147:5": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    }
+  ],
+  "147:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    }
+  ],
+  "147:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praises",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    }
+  ],
+  "147:8": [
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "147:9": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "147:10": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    }
+  ],
+  "147:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "147:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "147:13": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "blesses",
+      "tw_match": "bless"
+    }
+  ],
+  "147:14": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "147:15": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "147:16": [
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "scatters",
+      "tw_match": "scatter"
+    }
+  ],
+  "147:17": [
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "147:18": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "147:19": [
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "statutes",
+      "tw_match": "statute"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "147:20": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "148:1": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "148:2": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "148:3": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "148:4": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "148:5": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    }
+  ],
+  "148:6": [
+    {
+      "surface": "established",
+      "tw_match": "established"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    }
+  ],
+  "148:7": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "148:8": [
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    }
+  ],
+  "148:9": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "148:10": [
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "148:11": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "148:12": [
+    {
+      "surface": "young women",
+      "tw_match": "young women"
+    }
+  ],
+  "148:13": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "exalted",
+      "tw_match": "exalted"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "148:14": [
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "149:1": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "149:2": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "149:3": [
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    }
+  ],
+  "149:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glorifies",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "149:5": [
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "149:6": [
+    {
+      "surface": "exaltation",
+      "tw_match": "exaltation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "swords",
+      "tw_match": "sword"
+    }
+  ],
+  "149:7": [
+    {
+      "surface": "vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    }
+  ],
+  "149:8": [
+    {
+      "surface": "bind",
+      "tw_match": "bind"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "149:9": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "150:1": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    }
+  ],
+  "150:2": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "150:3": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "lute",
+      "tw_match": "lute"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    }
+  ],
+  "150:4": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "150:5": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "150:6": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_REV.json
+++ b/sources/keyword_data/keywords_REV.json
@@ -1,0 +1,7943 @@
+{
+  "1:1": [
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "John",
+      "tw_match": "John"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "in Jesus",
+      "tw_match": "in Jesus"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "lampstands",
+      "tw_match": "lampstand"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "lampstands",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "wrapped around",
+      "tw_match": "wrapped around"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "snow",
+      "tw_match": "snow"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "Hades",
+      "tw_match": "Hades"
+    }
+  ],
+  "1:19": [],
+  "1:20": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "lampstands",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Ephesus",
+      "tw_match": "Ephesus"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "lampstands",
+      "tw_match": "lampstand"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "suffered",
+      "tw_match": "suffer"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "slander",
+      "tw_match": "slander"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Balaam",
+      "tw_match": "Balaam"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "Repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "manna",
+      "tw_match": "manna"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Son of God",
+      "tw_match": "Son of God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "Jezebel",
+      "tw_match": "Jezebel"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "prophetess",
+      "tw_match": "prophetess"
+    },
+    {
+      "surface": "deceives",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "offerings",
+      "tw_match": "offering"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "immorality",
+      "tw_match": "immorality"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "committing",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    }
+  ],
+  "2:25": [],
+  "2:26": [
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "3:4": [],
+  "3:5": [
+    {
+      "surface": "wipe out",
+      "tw_match": "wipe out"
+    },
+    {
+      "surface": "Book of Life",
+      "tw_match": "Book of Life"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "synagogue",
+      "tw_match": "synagogue"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "testing",
+      "tw_match": "testing"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "pillar",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "3:16": [],
+  "3:17": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "advise",
+      "tw_match": "advise"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    }
+  ],
+  "3:20": [],
+  "3:21": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Immediately",
+      "tw_match": "immediately"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "crowns",
+      "tw_match": "crown"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "calf",
+      "tw_match": "calf"
+    },
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "crowns",
+      "tw_match": "crown"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "seals",
+      "tw_match": "seal"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "seals",
+      "tw_match": "seal"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "seals",
+      "tw_match": "seal"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "harp",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "seals",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "seals",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "a bow",
+      "tw_match": "a bow"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "creature",
+      "tw_match": "creature"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Hades",
+      "tw_match": "Hades"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "animals",
+      "tw_match": "animals"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "slaughtered",
+      "tw_match": "slaughtered"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "avenge",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "Reuben",
+      "tw_match": "Reuben"
+    },
+    {
+      "surface": "Gad",
+      "tw_match": "Gad"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Asher",
+      "tw_match": "Asher"
+    },
+    {
+      "surface": "Naphtali",
+      "tw_match": "Naphtali"
+    },
+    {
+      "surface": "Manasseh",
+      "tw_match": "Manasseh"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Simeon",
+      "tw_match": "Simeon"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    },
+    {
+      "surface": "Issachar",
+      "tw_match": "Issachar"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Zebulun",
+      "tw_match": "Zebulun"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "Salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "7:16": [],
+  "7:17": [
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "trumpets",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "trumpeted",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "trumpeted",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "trumpeted",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "trumpeted",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "trumpeted",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "abyss",
+      "tw_match": "abyss"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "abyss",
+      "tw_match": "abyss"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "furnace",
+      "tw_match": "furnace"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    },
+    {
+      "surface": "torment",
+      "tw_match": "torment"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "locusts",
+      "tw_match": "locust"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "crowns",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "breastplates",
+      "tw_match": "breastplate"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "abyss",
+      "tw_match": "abyss"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "woes",
+      "tw_match": "woe"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "trumpeted",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "Release",
+      "tw_match": "release"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "soldiers",
+      "tw_match": "soldier"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "sulfurous",
+      "tw_match": "sulfurous"
+    },
+    {
+      "surface": "breastplates",
+      "tw_match": "breastplate"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "sulfur",
+      "tw_match": "sulfur"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "sulfur",
+      "tw_match": "sulfur"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "9:19": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "snakes",
+      "tw_match": "snake"
+    }
+  ],
+  "9:20": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "murders",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "sorceries",
+      "tw_match": "sorceries"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Seal",
+      "tw_match": "seal"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "reed",
+      "tw_match": "reed"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "cast out",
+      "tw_match": "cast out"
+    },
+    {
+      "surface": "courtyard",
+      "tw_match": "courtyard"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "holy city",
+      "tw_match": "holy city"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sackcloth",
+      "tw_match": "sackcloth"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "lampstands",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "devours",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "sky",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "abyss",
+      "tw_match": "abyss"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "tomb",
+      "tw_match": "tomb"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "celebrate",
+      "tw_match": "celebrate"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "watched",
+      "tw_match": "watch"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "trumpeted",
+      "tw_match": "trumpet"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "destroying",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "ark of the covenant",
+      "tw_match": "ark of the covenant"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "hailstorm",
+      "tw_match": "hailstorm"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "sweeps",
+      "tw_match": "sweep"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Michael",
+      "tw_match": "Michael"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "deceiving",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "heavens",
+      "tw_match": "heavens"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "eagle",
+      "tw_match": "eagle"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "crowns",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "blasphemous",
+      "tw_match": "blasphemous"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "leopard",
+      "tw_match": "leopard"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "lion",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "as if",
+      "tw_match": "as if"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "blasphemies",
+      "tw_match": "blasphemy"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "months",
+      "tw_match": "month"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "blasphemies",
+      "tw_match": "blasphemy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blaspheme",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "Book of Life",
+      "tw_match": "Book of Life"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "13:9": [],
+  "13:10": [
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "deceives",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "telling",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "13:15": [
+    {
+      "surface": "breath",
+      "tw_match": "breath"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "13:16": [
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "13:17": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "13:18": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "understanding",
+      "tw_match": "understanding"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "Mount Zion",
+      "tw_match": "Mount Zion"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "harpists",
+      "tw_match": "harpist"
+    },
+    {
+      "surface": "harping",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "Fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "passion",
+      "tw_match": "passions"
+    },
+    {
+      "surface": "immorality",
+      "tw_match": "immorality"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "worships",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    },
+    {
+      "surface": "sulfur",
+      "tw_match": "sulfur"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "torment",
+      "tw_match": "torment"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "receives",
+      "tw_match": "receive"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "labors",
+      "tw_match": "labors"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "son of man",
+      "tw_match": "son of man"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "reap",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "harvested",
+      "tw_match": "harvest"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "grapevine",
+      "tw_match": "grapevine"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "harvested",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "grapevine",
+      "tw_match": "grapevine"
+    },
+    {
+      "surface": "grapes",
+      "tw_match": "grape"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "trampled",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "harps",
+      "tw_match": "harp"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Ages",
+      "tw_match": "age"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "wrapped around",
+      "tw_match": "wrapped around"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "springs",
+      "tw_match": "spring"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "Holy One",
+      "tw_match": "Holy One"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "16:8": [],
+  "16:9": [
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "repent",
+      "tw_match": "repent"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "false prophet",
+      "tw_match": "false prophet"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "16:14": [
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "16:15": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Hebrew",
+      "tw_match": "Hebrew"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "16:20": [],
+  "16:21": [
+    {
+      "surface": "hail",
+      "tw_match": "hail"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    }
+  ],
+  "17:1": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    }
+  ],
+  "17:2": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "17:3": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "blasphemous",
+      "tw_match": "blasphemous"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "17:4": [
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    }
+  ],
+  "17:5": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "Prostitutes",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "Abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Earth",
+      "tw_match": "earth"
+    }
+  ],
+  "17:6": [
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "wondered",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "wonder",
+      "tw_match": "wonder"
+    }
+  ],
+  "17:7": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "wondering",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "carrying",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "17:8": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "abyss",
+      "tw_match": "abyss"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Book of Life",
+      "tw_match": "Book of Life"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "wonder",
+      "tw_match": "wonder"
+    }
+  ],
+  "17:9": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    }
+  ],
+  "17:10": [],
+  "17:11": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "17:12": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    }
+  ],
+  "17:13": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    }
+  ],
+  "17:14": [
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    }
+  ],
+  "17:15": [
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "languages",
+      "tw_match": "language"
+    }
+  ],
+  "17:16": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "desolated",
+      "tw_match": "desolated"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    }
+  ],
+  "17:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    }
+  ],
+  "17:18": [
+    {
+      "surface": "kingdom",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "18:1": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "18:2": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "demons",
+      "tw_match": "demon"
+    },
+    {
+      "surface": "unclean spirit",
+      "tw_match": "unclean spirit"
+    },
+    {
+      "surface": "detested",
+      "tw_match": "detested"
+    }
+  ],
+  "18:3": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    },
+    {
+      "surface": "passion",
+      "tw_match": "passions"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    }
+  ],
+  "18:4": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    }
+  ],
+  "18:5": [
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "18:6": [],
+  "18:7": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "queen",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "18:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    }
+  ],
+  "18:9": [
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "committed",
+      "tw_match": "committed"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    }
+  ],
+  "18:10": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "torment",
+      "tw_match": "torment"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "18:11": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    }
+  ],
+  "18:12": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    }
+  ],
+  "18:13": [
+    {
+      "surface": "incense",
+      "tw_match": "incense"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "cattle",
+      "tw_match": "cattle"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    }
+  ],
+  "18:14": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "perished",
+      "tw_match": "perish"
+    }
+  ],
+  "18:15": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "torment",
+      "tw_match": "torment"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    }
+  ],
+  "18:16": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "18:17": [
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "18:18": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "18:19": [
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    },
+    {
+      "surface": "mourning",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    }
+  ],
+  "18:20": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "18:21": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "18:22": [
+    {
+      "surface": "harpists",
+      "tw_match": "harpist"
+    },
+    {
+      "surface": "trumpeters",
+      "tw_match": "trumpeters"
+    }
+  ],
+  "18:23": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "bridegroom",
+      "tw_match": "bridegroom"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "sorcery",
+      "tw_match": "sorcery"
+    }
+  ],
+  "18:24": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "slain",
+      "tw_match": "slain"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "19:1": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:2": [
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "prostitute",
+      "tw_match": "prostitute"
+    },
+    {
+      "surface": "corrupting",
+      "tw_match": "corrupt"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "avenged",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "19:3": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "19:4": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "creatures",
+      "tw_match": "creature"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "19:5": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "fearing",
+      "tw_match": "fear"
+    }
+  ],
+  "19:6": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "reigns",
+      "tw_match": "reign"
+    }
+  ],
+  "19:7": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    }
+  ],
+  "19:8": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "19:9": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:10": [
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    }
+  ],
+  "19:11": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "19:12": [
+    {
+      "surface": "crowns",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "19:13": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:14": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    }
+  ],
+  "19:15": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "iron",
+      "tw_match": "iron"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "tramples",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "winepress",
+      "tw_match": "winepress"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "fury",
+      "tw_match": "fury"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "19:16": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Lords",
+      "tw_match": "lord"
+    }
+  ],
+  "19:17": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "19:18": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    }
+  ],
+  "19:19": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    }
+  ],
+  "19:20": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "false prophet",
+      "tw_match": "false prophet"
+    },
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "worshiping",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "lake of fire",
+      "tw_match": "lake of fire"
+    },
+    {
+      "surface": "sulfur",
+      "tw_match": "sulfur"
+    }
+  ],
+  "19:21": [
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    }
+  ],
+  "20:1": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "abyss",
+      "tw_match": "abyss"
+    }
+  ],
+  "20:2": [
+    {
+      "surface": "seized",
+      "tw_match": "seize"
+    },
+    {
+      "surface": "serpent",
+      "tw_match": "serpent"
+    },
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "20:3": [
+    {
+      "surface": "abyss",
+      "tw_match": "abyss"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "20:4": [
+    {
+      "surface": "thrones",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "souls",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "reigned",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "20:5": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "20:6": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "20:7": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    }
+  ],
+  "20:8": [
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "20:9": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "20:10": [
+    {
+      "surface": "devil",
+      "tw_match": "devil"
+    },
+    {
+      "surface": "deceiving",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "lake of fire",
+      "tw_match": "lake of fire"
+    },
+    {
+      "surface": "sulfur",
+      "tw_match": "sulfur"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "false prophet",
+      "tw_match": "false prophet"
+    },
+    {
+      "surface": "tormented",
+      "tw_match": "tormented"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "20:11": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "20:12": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "Book of Life",
+      "tw_match": "Book of Life"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "20:13": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "Hades",
+      "tw_match": "Hades"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "20:14": [
+    {
+      "surface": "Hades",
+      "tw_match": "Hades"
+    },
+    {
+      "surface": "lake of fire",
+      "tw_match": "lake of fire"
+    }
+  ],
+  "20:15": [
+    {
+      "surface": "Book of Life",
+      "tw_match": "Book of Life"
+    },
+    {
+      "surface": "lake of fire",
+      "tw_match": "lake of fire"
+    }
+  ],
+  "21:1": [
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    }
+  ],
+  "21:2": [
+    {
+      "surface": "holy city",
+      "tw_match": "holy city"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    }
+  ],
+  "21:3": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:4": [
+    {
+      "surface": "crying",
+      "tw_match": "cry"
+    }
+  ],
+  "21:5": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    }
+  ],
+  "21:6": [
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "21:7": [
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:8": [
+    {
+      "surface": "sorcerers",
+      "tw_match": "sorcerer"
+    },
+    {
+      "surface": "idolaters",
+      "tw_match": "idolater"
+    },
+    {
+      "surface": "sulfur",
+      "tw_match": "sulfur"
+    }
+  ],
+  "21:9": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "21:10": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "holy city",
+      "tw_match": "holy city"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "21:11": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    }
+  ],
+  "21:12": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "21:13": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "21:14": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "21:15": [
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "21:16": [
+    {
+      "surface": "rod",
+      "tw_match": "rod"
+    }
+  ],
+  "21:17": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "21:18": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "21:19": [
+    {
+      "surface": "foundations",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    }
+  ],
+  "21:20": [
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    }
+  ],
+  "21:21": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "21:22": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Ruler",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "21:23": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "21:24": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "kings",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "21:25": [
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "21:26": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "21:27": [
+    {
+      "surface": "abomination",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "Book of Life",
+      "tw_match": "Book of Life"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "22:1": [
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    }
+  ],
+  "22:2": [
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "leaves",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "22:3": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lamb",
+      "tw_match": "lamb"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "22:4": [],
+  "22:5": [
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reign",
+      "tw_match": "reign"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "22:6": [
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirits",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "22:7": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    }
+  ],
+  "22:8": [
+    {
+      "surface": "John",
+      "tw_match": "John"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "22:9": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "keeping",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "22:10": [
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "22:11": [
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "22:12": [
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "22:13": [],
+  "22:14": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "washing",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "robes",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "22:15": [
+    {
+      "surface": "sorcerers",
+      "tw_match": "sorcerer"
+    },
+    {
+      "surface": "immoral",
+      "tw_match": "immoral"
+    },
+    {
+      "surface": "idolaters",
+      "tw_match": "idolater"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    }
+  ],
+  "22:16": [
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "22:17": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Bride",
+      "tw_match": "bride"
+    }
+  ],
+  "22:18": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "plagues",
+      "tw_match": "plague"
+    }
+  ],
+  "22:19": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy city",
+      "tw_match": "holy city"
+    }
+  ],
+  "22:20": [
+    {
+      "surface": "testifying",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "22:21": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_ROM.json
+++ b/sources/keyword_data/keywords_ROM.json
@@ -1,0 +1,7254 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "the Son",
+      "tw_match": "the Son"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "holiness",
+      "tw_match": "holiness"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "apostleship",
+      "tw_match": "apostleship"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Rome",
+      "tw_match": "Rome"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "encouraged",
+      "tw_match": "encouraged"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Rome",
+      "tw_match": "Rome"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "ungodliness",
+      "tw_match": "ungodliness"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "divine",
+      "tw_match": "divine"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    }
+  ],
+  "1:23": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "1:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lusts",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    }
+  ],
+  "1:25": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "worshiped",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "served",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "Creator",
+      "tw_match": "creator"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "1:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "passions",
+      "tw_match": "passions"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    }
+  ],
+  "1:27": [
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "lust",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "perversion",
+      "tw_match": "perversion"
+    }
+  ],
+  "1:28": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "1:29": [
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "murder",
+      "tw_match": "murder"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "gossips",
+      "tw_match": "gossips"
+    }
+  ],
+  "1:30": [
+    {
+      "surface": "slanderers",
+      "tw_match": "slanderers"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "boastful",
+      "tw_match": "boastful"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "1:31": [
+    {
+      "surface": "faithless",
+      "tw_match": "faithless"
+    }
+  ],
+  "1:32": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "condemn",
+      "tw_match": "condemn"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "repentance",
+      "tw_match": "repentance"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "hardness",
+      "tw_match": "hardness"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:6": [],
+  "2:7": [
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "incorruptibility",
+      "tw_match": "incorruptibility"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "favoritism",
+      "tw_match": "favoritism"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "2:19": [],
+  "2:20": [
+    {
+      "surface": "instructor",
+      "tw_match": "instructors"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "teacher",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "rob",
+      "tw_match": "rob"
+    },
+    {
+      "surface": "temples",
+      "tw_match": "temple"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    }
+  ],
+  "2:24": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    }
+  ],
+  "2:25": [
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    }
+  ],
+  "2:26": [
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    },
+    {
+      "surface": "keeps",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "requirements",
+      "tw_match": "requirements"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    }
+  ],
+  "2:27": [
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    },
+    {
+      "surface": "fulfilling",
+      "tw_match": "fulfill"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    }
+  ],
+  "2:28": [
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    }
+  ],
+  "2:29": [
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "unfaithful",
+      "tw_match": "unfaithful"
+    },
+    {
+      "surface": "unfaithfulness",
+      "tw_match": "unfaithfulness"
+    },
+    {
+      "surface": "faithfulness",
+      "tw_match": "faithfulness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "judged",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "sinner",
+      "tw_match": "sinner"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greeks",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "understands",
+      "tw_match": "understand"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:12": [],
+  "3:13": [
+    {
+      "surface": "grave",
+      "tw_match": "grave"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "deceiving",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "cursing",
+      "tw_match": "cursing"
+    }
+  ],
+  "3:15": [],
+  "3:16": [
+    {
+      "surface": "Destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "3:21": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "witnessed",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "3:22": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in Jesus",
+      "tw_match": "in Jesus"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "3:23": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:24": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "3:25": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "propitiation",
+      "tw_match": "propitiation"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "3:26": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "justifying",
+      "tw_match": "justify"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "in Jesus",
+      "tw_match": "in Jesus"
+    }
+  ],
+  "3:27": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "3:28": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "3:29": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "3:30": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "justify",
+      "tw_match": "justify"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    }
+  ],
+  "3:31": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "justifying",
+      "tw_match": "justify"
+    },
+    {
+      "surface": "ungodly",
+      "tw_match": "ungodly"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "lawless",
+      "tw_match": "lawless"
+    },
+    {
+      "surface": "forgiven",
+      "tw_match": "forgiven"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "uncircumcision",
+      "tw_match": "uncircumcision"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "heir",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "heirs",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    }
+  ],
+  "4:17": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "trusted",
+      "tw_match": "trusted"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "years old",
+      "tw_match": "years old"
+    },
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    }
+  ],
+  "4:20": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "unbelief",
+      "tw_match": "unbelief"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "4:21": [
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "4:23": [],
+  "4:24": [
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "4:25": [
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "justification",
+      "tw_match": "justification"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "produces",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "ungodly",
+      "tw_match": "ungodly"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "reconciled",
+      "tw_match": "reconciled"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "boasting",
+      "tw_match": "boasting"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "reconciliation",
+      "tw_match": "reconciliation"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "ruled",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Adam",
+      "tw_match": "Adam"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "trespass",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "condemnation",
+      "tw_match": "condemnation"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "trespasses",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "justification",
+      "tw_match": "justification"
+    }
+  ],
+  "5:17": [
+    {
+      "surface": "trespass",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "ruled",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "5:18": [
+    {
+      "surface": "trespass",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "condemnation",
+      "tw_match": "condemnation"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "justification",
+      "tw_match": "justification"
+    }
+  ],
+  "5:19": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sinners",
+      "tw_match": "sinner"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    }
+  ],
+  "5:20": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "trespass",
+      "tw_match": "trespass"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "5:21": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "ruled",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "everlasting",
+      "tw_match": "everlasting"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "baptized",
+      "tw_match": "baptized"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "baptism",
+      "tw_match": "baptism"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "planted",
+      "tw_match": "planted"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "resurrection",
+      "tw_match": "resurrection"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "crucified",
+      "tw_match": "crucified"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "enslave",
+      "tw_match": "enslave"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "freed",
+      "tw_match": "freed"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "lusts",
+      "tw_match": "lust"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "6:16": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "6:17": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "6:18": [
+    {
+      "surface": "freed",
+      "tw_match": "freed"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "6:19": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "lawlessness",
+      "tw_match": "lawlessness"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "sanctification",
+      "tw_match": "sanctification"
+    }
+  ],
+  "6:20": [
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "6:21": [
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "6:22": [
+    {
+      "surface": "freed",
+      "tw_match": "freed"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "sanctification",
+      "tw_match": "sanctification"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "6:23": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "bound",
+      "tw_match": "bound"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "released",
+      "tw_match": "release"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "adulteress",
+      "tw_match": "adulteress"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "married",
+      "tw_match": "married"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "passions",
+      "tw_match": "passions"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "released",
+      "tw_match": "release"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "covet",
+      "tw_match": "covet"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "7:10": [],
+  "7:11": [
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "deceived",
+      "tw_match": "deceive"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "7:15": [
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "7:16": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "7:17": [
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "7:18": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "producing",
+      "tw_match": "produce"
+    }
+  ],
+  "7:19": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "7:20": [
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "7:21": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "7:22": [
+    {
+      "surface": "delight",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "law of God",
+      "tw_match": "law of God"
+    }
+  ],
+  "7:23": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "7:24": [],
+  "7:25": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "law of God",
+      "tw_match": "law of God"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "condemnation",
+      "tw_match": "condemnation"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "likeness",
+      "tw_match": "likeness"
+    },
+    {
+      "surface": "sinful",
+      "tw_match": "sinful"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "subject",
+      "tw_match": "subject"
+    },
+    {
+      "surface": "law of God",
+      "tw_match": "law of God"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    }
+  ],
+  "8:12": [],
+  "8:13": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "sons of God",
+      "tw_match": "sons of God"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "received",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "adoption",
+      "tw_match": "adoption"
+    },
+    {
+      "surface": "cry out",
+      "tw_match": "cry out"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "bears",
+      "tw_match": "bears"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "children of God",
+      "tw_match": "children of God"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "heirs",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "sufferings",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "sons of God",
+      "tw_match": "sons of God"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "freed",
+      "tw_match": "freed"
+    },
+    {
+      "surface": "freedom",
+      "tw_match": "freedom"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "children of God",
+      "tw_match": "children of God"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "creation",
+      "tw_match": "creation"
+    },
+    {
+      "surface": "labors",
+      "tw_match": "labors"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "adoption",
+      "tw_match": "adoption"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "8:24": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "hopes",
+      "tw_match": "hope"
+    }
+  ],
+  "8:25": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "endurance",
+      "tw_match": "endurance"
+    }
+  ],
+  "8:26": [
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "pray",
+      "tw_match": "pray"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "intercedes",
+      "tw_match": "intercede"
+    }
+  ],
+  "8:27": [
+    {
+      "surface": "searching",
+      "tw_match": "search"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "intercedes",
+      "tw_match": "intercede"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:28": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "8:29": [
+    {
+      "surface": "foreknew",
+      "tw_match": "foreknew"
+    },
+    {
+      "surface": "predestined",
+      "tw_match": "predestined"
+    },
+    {
+      "surface": "image",
+      "tw_match": "image"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "8:30": [
+    {
+      "surface": "predestined",
+      "tw_match": "predestined"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "8:31": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "8:32": [],
+  "8:33": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    },
+    {
+      "surface": "justifying",
+      "tw_match": "justify"
+    }
+  ],
+  "8:34": [
+    {
+      "surface": "condemning",
+      "tw_match": "condemn"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "interceding",
+      "tw_match": "intercede"
+    }
+  ],
+  "8:35": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "Tribulation",
+      "tw_match": "tribulation"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "8:36": [
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "8:37": [
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    }
+  ],
+  "8:38": [
+    {
+      "surface": "angels",
+      "tw_match": "angel"
+    }
+  ],
+  "8:39": [
+    {
+      "surface": "created",
+      "tw_match": "created"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    },
+    {
+      "surface": "bearing",
+      "tw_match": "bearing"
+    },
+    {
+      "surface": "witness",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "9:2": [],
+  "9:3": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Israelites",
+      "tw_match": "Israelites"
+    },
+    {
+      "surface": "adoption",
+      "tw_match": "adoption"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "covenants",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "children of God",
+      "tw_match": "children of God"
+    },
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "promise",
+      "tw_match": "promise"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Sarah",
+      "tw_match": "Sarah"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "Rebekah",
+      "tw_match": "Rebekah"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    },
+    {
+      "surface": "Isaac",
+      "tw_match": "Isaac"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "endure",
+      "tw_match": "endure"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Esau",
+      "tw_match": "Esau"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:18": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "hardens",
+      "tw_match": "harden"
+    }
+  ],
+  "9:19": [],
+  "9:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "molded",
+      "tw_match": "molded"
+    }
+  ],
+  "9:21": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "dishonor",
+      "tw_match": "dishonor"
+    }
+  ],
+  "9:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "endured",
+      "tw_match": "endure"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    }
+  ],
+  "9:23": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    }
+  ],
+  "9:24": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jews",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "9:25": [
+    {
+      "surface": "Hosea",
+      "tw_match": "Hosea"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "loved",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "9:26": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:27": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "9:28": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:29": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Lord of hosts",
+      "tw_match": "Lord of hosts"
+    },
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    }
+  ],
+  "9:30": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "9:31": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "9:32": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "stumbled",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    }
+  ],
+  "9:33": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "testify",
+      "tw_match": "testify"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "submit",
+      "tw_match": "submit"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "believes",
+      "tw_match": "believe"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "descend",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "abyss",
+      "tw_match": "abyss"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "believes",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "confesses",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "believes",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Jew",
+      "tw_match": "Jew"
+    },
+    {
+      "surface": "Greek",
+      "tw_match": "Greek"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    }
+  ],
+  "10:13": [
+    {
+      "surface": "calls",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    }
+  ],
+  "10:14": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "believe",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    }
+  ],
+  "10:15": [
+    {
+      "surface": "preach",
+      "tw_match": "preach"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "proclaiming",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "good news",
+      "tw_match": "good news"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "10:16": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "report",
+      "tw_match": "report"
+    }
+  ],
+  "10:17": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "10:18": [
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    }
+  ],
+  "10:19": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Moses",
+      "tw_match": "Moses"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "10:20": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "seeking",
+      "tw_match": "seek"
+    }
+  ],
+  "10:21": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Abraham",
+      "tw_match": "Abraham"
+    },
+    {
+      "surface": "tribe",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "foreknew",
+      "tw_match": "foreknew"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "scripture",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "Elijah",
+      "tw_match": "Elijah"
+    },
+    {
+      "surface": "pleads",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "killed",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "altars",
+      "tw_match": "altar"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "divine",
+      "tw_match": "divine"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "seeks",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    },
+    {
+      "surface": "hardened",
+      "tw_match": "harden"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "stumble",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "transgression",
+      "tw_match": "transgression"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "ministry",
+      "tw_match": "ministry"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "provoke",
+      "tw_match": "provoke"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "rejection",
+      "tw_match": "rejection"
+    },
+    {
+      "surface": "reconciliation",
+      "tw_match": "reconciliation"
+    },
+    {
+      "surface": "world",
+      "tw_match": "world"
+    },
+    {
+      "surface": "acceptance",
+      "tw_match": "acceptance"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    }
+  ],
+  "11:18": [
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    }
+  ],
+  "11:19": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "11:20": [
+    {
+      "surface": "unbelief",
+      "tw_match": "unbelief"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "11:21": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:22": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:23": [
+    {
+      "surface": "unbelief",
+      "tw_match": "unbelief"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:24": [
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "11:25": [
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "partial",
+      "tw_match": "partial"
+    },
+    {
+      "surface": "hardening",
+      "tw_match": "harden"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "11:26": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Deliverer",
+      "tw_match": "deliverer"
+    },
+    {
+      "surface": "ungodly",
+      "tw_match": "ungodly"
+    },
+    {
+      "surface": "Jacob",
+      "tw_match": "Jacob"
+    }
+  ],
+  "11:27": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "sins",
+      "tw_match": "sin"
+    }
+  ],
+  "11:28": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "11:29": [
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "calling",
+      "tw_match": "call"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "11:30": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "11:31": [
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    }
+  ],
+  "11:32": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "11:33": [
+    {
+      "surface": "wisdom",
+      "tw_match": "wisdom"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "11:34": [
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "advisor",
+      "tw_match": "advisor"
+    }
+  ],
+  "11:35": [],
+  "11:36": [
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "compassions",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "age",
+      "tw_match": "age"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "distributed",
+      "tw_match": "distributed"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "members",
+      "tw_match": "member"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "gracious",
+      "tw_match": "gracious"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "prophecy",
+      "tw_match": "prophecy"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "encouraging",
+      "tw_match": "encouraging"
+    },
+    {
+      "surface": "encouragement",
+      "tw_match": "encouragement"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "hypocrisy",
+      "tw_match": "hypocrisy"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "suffering",
+      "tw_match": "suffering"
+    },
+    {
+      "surface": "patient",
+      "tw_match": "patient"
+    },
+    {
+      "surface": "prayer",
+      "tw_match": "prayer"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "Bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "persecuting",
+      "tw_match": "persecute"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    }
+  ],
+  "12:15": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "weeping",
+      "tw_match": "weeping"
+    }
+  ],
+  "12:16": [
+    {
+      "surface": "thinking",
+      "tw_match": "thinking"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "12:17": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "12:18": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "12:19": [
+    {
+      "surface": "avenging",
+      "tw_match": "avenge"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Vengeance",
+      "tw_match": "vengeance"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "12:20": [
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "12:21": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "be subject to",
+      "tw_match": "be subject to"
+    },
+    {
+      "surface": "governing",
+      "tw_match": "govern"
+    },
+    {
+      "surface": "authorities",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "terror",
+      "tw_match": "terror"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "carry",
+      "tw_match": "carry"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "vain",
+      "tw_match": "vain"
+    },
+    {
+      "surface": "avenger",
+      "tw_match": "avenger"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "subjected",
+      "tw_match": "subjected"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "conscience",
+      "tw_match": "conscience"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "taxes",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "tax",
+      "tw_match": "tax"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "adultery",
+      "tw_match": "adultery"
+    },
+    {
+      "surface": "kill",
+      "tw_match": "kill"
+    },
+    {
+      "surface": "covet",
+      "tw_match": "covet"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "13:10": [
+    {
+      "surface": "Love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "13:11": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "hour",
+      "tw_match": "hour"
+    },
+    {
+      "surface": "salvation",
+      "tw_match": "salvation"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    }
+  ],
+  "13:12": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "13:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sexual immorality",
+      "tw_match": "sexual immorality"
+    },
+    {
+      "surface": "lust",
+      "tw_match": "lust"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    }
+  ],
+  "13:14": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "believes",
+      "tw_match": "believe"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "slave",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "alike",
+      "tw_match": "alike"
+    },
+    {
+      "surface": "mind",
+      "tw_match": "mind"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:7": [],
+  "14:8": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "bend",
+      "tw_match": "bend"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "trap",
+      "tw_match": "trap"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "blasphemed",
+      "tw_match": "blaspheme"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "kingdom of God",
+      "tw_match": "kingdom of God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "stumbles",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "becomes weak",
+      "tw_match": "becomes weak"
+    }
+  ],
+  "14:22": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "judging",
+      "tw_match": "judge"
+    }
+  ],
+  "14:23": [
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "15:1": [
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    }
+  ],
+  "15:2": [
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "15:3": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "insulting",
+      "tw_match": "insult"
+    }
+  ],
+  "15:4": [
+    {
+      "surface": "instruction",
+      "tw_match": "instruction"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "encouragement",
+      "tw_match": "encouragement"
+    },
+    {
+      "surface": "Scriptures",
+      "tw_match": "scripture"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "15:5": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "patience",
+      "tw_match": "patience"
+    },
+    {
+      "surface": "encouragement",
+      "tw_match": "encouragement"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    }
+  ],
+  "15:6": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Father",
+      "tw_match": "Father"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "15:7": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:8": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "confirm",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "promises",
+      "tw_match": "promise"
+    }
+  ],
+  "15:9": [
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "glorify",
+      "tw_match": "glorify"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "confess",
+      "tw_match": "confess"
+    },
+    {
+      "surface": "psalms",
+      "tw_match": "psalm"
+    }
+  ],
+  "15:10": [
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "15:11": [
+    {
+      "surface": "Praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "15:12": [
+    {
+      "surface": "Isaiah",
+      "tw_match": "Isaiah"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "in him",
+      "tw_match": "in him"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "15:13": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "believing",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "15:14": [
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "instruct",
+      "tw_match": "instruct"
+    }
+  ],
+  "15:15": [
+    {
+      "surface": "reminding",
+      "tw_match": "remind"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:16": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "serving",
+      "tw_match": "serve"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "15:17": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    },
+    {
+      "surface": "boast",
+      "tw_match": "boast"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:18": [
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "produced",
+      "tw_match": "produced"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "15:19": [
+    {
+      "surface": "signs",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "wonders",
+      "tw_match": "wonder"
+    },
+    {
+      "surface": "Spirit of God",
+      "tw_match": "Spirit of God"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "fulfilled",
+      "tw_match": "fulfilled"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "15:20": [
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "proclaim",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    }
+  ],
+  "15:21": [
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "understand",
+      "tw_match": "understand"
+    }
+  ],
+  "15:22": [
+    {
+      "surface": "times",
+      "tw_match": "time"
+    }
+  ],
+  "15:23": [
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "15:24": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "for a while",
+      "tw_match": "for a while"
+    }
+  ],
+  "15:25": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "15:26": [
+    {
+      "surface": "Macedonia",
+      "tw_match": "Macedonia"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "contribution",
+      "tw_match": "contribution"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "15:27": [
+    {
+      "surface": "pleased",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    },
+    {
+      "surface": "to minister",
+      "tw_match": "to minister"
+    }
+  ],
+  "15:28": [
+    {
+      "surface": "completed",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "15:29": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "15:30": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "prayers",
+      "tw_match": "prayer"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "15:31": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "delivered",
+      "tw_match": "delivered"
+    },
+    {
+      "surface": "Judea",
+      "tw_match": "Judea"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "15:32": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "will of God",
+      "tw_match": "will of God"
+    }
+  ],
+  "15:33": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "16:1": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "church",
+      "tw_match": "church"
+    }
+  ],
+  "16:2": [
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "welcome",
+      "tw_match": "welcome"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    }
+  ],
+  "16:3": [
+    {
+      "surface": "Prisca",
+      "tw_match": "Prisca"
+    },
+    {
+      "surface": "Aquila",
+      "tw_match": "Aquila"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "Jesus",
+      "tw_match": "Jesus"
+    }
+  ],
+  "16:4": [
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Gentiles",
+      "tw_match": "Gentile"
+    }
+  ],
+  "16:5": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "firstfruits",
+      "tw_match": "firstfruits"
+    },
+    {
+      "surface": "Asia",
+      "tw_match": "Asia"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "16:6": [
+    {
+      "surface": "Mary",
+      "tw_match": "Mary"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    }
+  ],
+  "16:7": [
+    {
+      "surface": "apostles",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    }
+  ],
+  "16:8": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "16:9": [
+    {
+      "surface": "fellow worker",
+      "tw_match": "fellow worker"
+    },
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "16:10": [
+    {
+      "surface": "in Christ",
+      "tw_match": "in Christ"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    }
+  ],
+  "16:11": [
+    {
+      "surface": "kinsman",
+      "tw_match": "kinsman"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "16:12": [
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    }
+  ],
+  "16:13": [
+    {
+      "surface": "elect",
+      "tw_match": "elect"
+    },
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "16:14": [],
+  "16:15": [
+    {
+      "surface": "saints",
+      "tw_match": "saint"
+    }
+  ],
+  "16:16": [
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "churches",
+      "tw_match": "church"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    }
+  ],
+  "16:17": [
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "traps",
+      "tw_match": "trap"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "16:18": [
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Christ",
+      "tw_match": "Christ"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    }
+  ],
+  "16:19": [
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "innocent",
+      "tw_match": "innocent"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "16:20": [
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "16:21": [
+    {
+      "surface": "Timothy",
+      "tw_match": "Timothy"
+    },
+    {
+      "surface": "fellow worker",
+      "tw_match": "fellow worker"
+    }
+  ],
+  "16:22": [
+    {
+      "surface": "in the Lord",
+      "tw_match": "in the Lord"
+    }
+  ],
+  "16:23": [
+    {
+      "surface": "church",
+      "tw_match": "church"
+    },
+    {
+      "surface": "steward",
+      "tw_match": "steward"
+    }
+  ],
+  "16:24": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ],
+  "16:25": [
+    {
+      "surface": "gospel",
+      "tw_match": "gospel"
+    },
+    {
+      "surface": "preaching",
+      "tw_match": "preaching"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "mystery",
+      "tw_match": "mystery"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    }
+  ],
+  "16:26": [
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "16:27": [
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "eternity",
+      "tw_match": "eternity"
+    },
+    {
+      "surface": "Amen",
+      "tw_match": "amen"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_RUT.json
+++ b/sources/keyword_data/keywords_RUT.json
@@ -1,0 +1,1324 @@
+{
+  "1:1": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "ruling",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "famine",
+      "tw_match": "famine"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "1:3": [],
+  "1:4": [
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:5": [],
+  "1:6": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    }
+  ],
+  "1:10": [],
+  "1:11": [
+    {
+      "surface": "womb",
+      "tw_match": "womb"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "kissed",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "god",
+      "tw_match": "god"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "forsake",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "buried",
+      "tw_match": "buried"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:18": [],
+  "1:19": [
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Almighty",
+      "tw_match": "Almighty"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    }
+  ],
+  "1:22": [
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bless",
+      "tw_match": "bless"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "reaping",
+      "tw_match": "reap"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "bowed",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "reported",
+      "tw_match": "reported"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "reward",
+      "tw_match": "reward"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "refuge",
+      "tw_match": "refuge"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "lord",
+      "tw_match": "lord"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "bread",
+      "tw_match": "bread"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "gleaned",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "2:18": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "gleaned",
+      "tw_match": "glean"
+    }
+  ],
+  "2:19": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "worked",
+      "tw_match": "work"
+    },
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    }
+  ],
+  "2:20": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "forsaken",
+      "tw_match": "forsaken"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "kinsman",
+      "tw_match": "kinsman"
+    },
+    {
+      "surface": "redeemers",
+      "tw_match": "redeemer"
+    }
+  ],
+  "2:21": [
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    }
+  ],
+  "2:22": [
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:23": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    },
+    {
+      "surface": "harvest",
+      "tw_match": "harvest"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "winnowing",
+      "tw_match": "winnow"
+    },
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "wash",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "anoint",
+      "tw_match": "anoint"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    }
+  ],
+  "3:5": [],
+  "3:6": [
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "instructed",
+      "tw_match": "instruct"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    }
+  ],
+  "3:8": [],
+  "3:9": [
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "kinsman",
+      "tw_match": "kinsman"
+    },
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "knows",
+      "tw_match": "know"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "kinsman",
+      "tw_match": "kinsman"
+    },
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Lie",
+      "tw_match": "lie"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "threshing",
+      "tw_match": "thresh"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "barley",
+      "tw_match": "barley"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "kinsman",
+      "tw_match": "kinsman"
+    },
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "kinsman",
+      "tw_match": "kinsman"
+    },
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "kinsman",
+      "tw_match": "kinsman"
+    },
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "redemption",
+      "tw_match": "redemption"
+    },
+    {
+      "surface": "confirm",
+      "tw_match": "confirm"
+    },
+    {
+      "surface": "sandal",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "legal",
+      "tw_match": "legal"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "kinsman",
+      "tw_match": "kinsman"
+    },
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "sandal",
+      "tw_match": "sandal"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "Moabite",
+      "tw_match": "Moabite"
+    },
+    {
+      "surface": "inheritance",
+      "tw_match": "inheritance"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    },
+    {
+      "surface": "witnesses",
+      "tw_match": "witness"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Rachel",
+      "tw_match": "Rachel"
+    },
+    {
+      "surface": "Leah",
+      "tw_match": "Leah"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Prosper",
+      "tw_match": "prosper"
+    },
+    {
+      "surface": "Ephrathah",
+      "tw_match": "Ephrathah"
+    },
+    {
+      "surface": "renowned",
+      "tw_match": "renowned"
+    },
+    {
+      "surface": "Bethlehem",
+      "tw_match": "Bethlehem"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "your house",
+      "tw_match": "your house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Tamar",
+      "tw_match": "Tamar"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "seed",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    },
+    {
+      "surface": "Ruth",
+      "tw_match": "Ruth"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "conception",
+      "tw_match": "conception"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "kinsman",
+      "tw_match": "kinsman"
+    },
+    {
+      "surface": "redeemer",
+      "tw_match": "redeemer"
+    },
+    {
+      "surface": "renowned",
+      "tw_match": "renowned"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "old age",
+      "tw_match": "old age"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "borne",
+      "tw_match": "borne"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    }
+  ],
+  "4:16": [],
+  "4:17": [
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ],
+  "4:18": [
+    {
+      "surface": "generations",
+      "tw_match": "generation"
+    }
+  ],
+  "4:19": [
+    {
+      "surface": "Ram",
+      "tw_match": "ram"
+    }
+  ],
+  "4:20": [],
+  "4:21": [
+    {
+      "surface": "Boaz",
+      "tw_match": "Boaz"
+    }
+  ],
+  "4:22": [
+    {
+      "surface": "Jesse",
+      "tw_match": "Jesse"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_SNG.json
+++ b/sources/keyword_data/keywords_SNG.json
@@ -1,0 +1,1658 @@
+{
+  "1:1": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "kisses",
+      "tw_match": "kiss"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "oils",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Kedar",
+      "tw_match": "Kedar"
+    },
+    {
+      "surface": "curtains",
+      "tw_match": "curtain"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "appointed",
+      "tw_match": "appointed"
+    },
+    {
+      "surface": "keeper",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "mare",
+      "tw_match": "mare"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Pharaoh",
+      "tw_match": "Pharaoh"
+    }
+  ],
+  "1:10": [],
+  "1:11": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "pleasant",
+      "tw_match": "pleasant"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Sharon",
+      "tw_match": "Sharon"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "thorns",
+      "tw_match": "thorn"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "delighted",
+      "tw_match": "delight"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "stag",
+      "tw_match": "stag"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "2:11": [],
+  "2:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "turtledove",
+      "tw_match": "turtledove"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "figs",
+      "tw_match": "fig"
+    },
+    {
+      "surface": "vines",
+      "tw_match": "vines"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "Catch",
+      "tw_match": "catch"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    }
+  ],
+  "2:16": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "2:17": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "stag",
+      "tw_match": "stag"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "loves",
+      "tw_match": "love"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "conceived",
+      "tw_match": "conceived"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "columns",
+      "tw_match": "column"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "terrors",
+      "tw_match": "terror"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "King",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "crowned",
+      "tw_match": "crowned"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wedding",
+      "tw_match": "wedding"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "washing",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "pomegranate",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "shields",
+      "tw_match": "shield"
+    },
+    {
+      "surface": "hanging",
+      "tw_match": "hang"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "fawns",
+      "tw_match": "fawn"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    },
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "blemish",
+      "tw_match": "blemish"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "Descend",
+      "tw_match": "descend"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "leopards",
+      "tw_match": "leopard"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "better",
+      "tw_match": "better"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "oils",
+      "tw_match": "oil"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "sealed",
+      "tw_match": "sealed"
+    },
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "pomegranate",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "frankincense",
+      "tw_match": "frankincense"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    }
+  ],
+  "4:15": [
+    {
+      "surface": "fountain",
+      "tw_match": "fountain"
+    },
+    {
+      "surface": "well",
+      "tw_match": "well"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "4:16": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "bride",
+      "tw_match": "bride"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    },
+    {
+      "surface": "honeycomb",
+      "tw_match": "honeycomb"
+    },
+    {
+      "surface": "honey",
+      "tw_match": "honey"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "washed",
+      "tw_match": "wash"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "searched",
+      "tw_match": "search"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    }
+  ],
+  "5:7": [
+    {
+      "surface": "guards",
+      "tw_match": "guard"
+    }
+  ],
+  "5:8": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Declare",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "5:9": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "distinguished",
+      "tw_match": "distinguish"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "5:12": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "doves",
+      "tw_match": "dove"
+    }
+  ],
+  "5:13": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "myrrh",
+      "tw_match": "myrrh"
+    }
+  ],
+  "5:14": [
+    {
+      "surface": "rods",
+      "tw_match": "rod"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "5:15": [
+    {
+      "surface": "pillars",
+      "tw_match": "pillar"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "5:16": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "glean",
+      "tw_match": "glean"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Tirzah",
+      "tw_match": "Tirzah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "awe",
+      "tw_match": "awe"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "ewes",
+      "tw_match": "ewe"
+    },
+    {
+      "surface": "washing",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "pomegranate",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "veil",
+      "tw_match": "veil"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "queens",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "dove",
+      "tw_match": "dove"
+    },
+    {
+      "surface": "perfect",
+      "tw_match": "perfect"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "queens",
+      "tw_match": "queen"
+    },
+    {
+      "surface": "concubines",
+      "tw_match": "concubine"
+    },
+    {
+      "surface": "praised",
+      "tw_match": "praised"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "awe",
+      "tw_match": "awe"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "soul",
+      "tw_match": "soul"
+    },
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "sandals",
+      "tw_match": "sandal"
+    },
+    {
+      "surface": "noble",
+      "tw_match": "noble"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "wheat",
+      "tw_match": "wheat"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "fawns",
+      "tw_match": "fawn"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "Heshbon",
+      "tw_match": "Heshbon"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Carmel",
+      "tw_match": "Carmel"
+    },
+    {
+      "surface": "purple",
+      "tw_match": "purple"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "captive",
+      "tw_match": "captive"
+    }
+  ],
+  "7:6": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "delights",
+      "tw_match": "delight"
+    }
+  ],
+  "7:7": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "palm",
+      "tw_match": "palm"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "best",
+      "tw_match": "best"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "7:11": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "7:12": [
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "pomegranates",
+      "tw_match": "pomegranate"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "fruits",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "kiss",
+      "tw_match": "kiss"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "pomegranate",
+      "tw_match": "pomegranate"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "desires",
+      "tw_match": "desires"
+    }
+  ],
+  "8:5": [
+    {
+      "surface": "wilderness",
+      "tw_match": "wilderness"
+    },
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "labor",
+      "tw_match": "labor"
+    }
+  ],
+  "8:6": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "seal",
+      "tw_match": "seal"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "Sheol",
+      "tw_match": "Sheol"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    },
+    {
+      "surface": "Yah",
+      "tw_match": "Yah"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "quench",
+      "tw_match": "quench"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "towers",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "vineyard",
+      "tw_match": "vineyard"
+    },
+    {
+      "surface": "Solomon",
+      "tw_match": "Solomon"
+    },
+    {
+      "surface": "keepers",
+      "tw_match": "keeper"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "beloved",
+      "tw_match": "beloved"
+    },
+    {
+      "surface": "stag",
+      "tw_match": "stag"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_TIT.json
+++ b/sources/keyword_data/keywords_TIT.json
@@ -1,0 +1,842 @@
+{
+  "1:1": [
+    {
+      "surface": "Paul",
+      "tw_match": "Paul"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "apostle",
+      "tw_match": "apostle"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "chosen people",
+      "tw_match": "chosen people"
+    },
+    {
+      "surface": "knowledge",
+      "tw_match": "knowledge"
+    },
+    {
+      "surface": "godliness",
+      "tw_match": "godliness"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "promised",
+      "tw_match": "promised"
+    },
+    {
+      "surface": "ages",
+      "tw_match": "age"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "proclamation",
+      "tw_match": "proclamation"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Titus",
+      "tw_match": "Titus"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "God the Father",
+      "tw_match": "God the Father"
+    },
+    {
+      "surface": "Christ Jesus",
+      "tw_match": "Christ Jesus"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "Crete",
+      "tw_match": "Crete"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "ordain",
+      "tw_match": "ordain"
+    },
+    {
+      "surface": "elders",
+      "tw_match": "elder"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "faithful",
+      "tw_match": "faithful"
+    },
+    {
+      "surface": "rebellion",
+      "tw_match": "rebellion"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "overseer",
+      "tw_match": "overseer"
+    },
+    {
+      "surface": "blameless",
+      "tw_match": "blameless"
+    },
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "manager",
+      "tw_match": "manager"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "arrogant",
+      "tw_match": "arrogant"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "friend",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "self-controlled",
+      "tw_match": "self-controlled"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "encourage",
+      "tw_match": "encourage"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "rebellious",
+      "tw_match": "rebellious"
+    },
+    {
+      "surface": "circumcision",
+      "tw_match": "circumcision"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "households",
+      "tw_match": "household"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Cretans",
+      "tw_match": "Cretan"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "testimony",
+      "tw_match": "testimony"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "Jewish",
+      "tw_match": "Jewish"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    },
+    {
+      "surface": "minds",
+      "tw_match": "mind"
+    },
+    {
+      "surface": "consciences",
+      "tw_match": "conscience"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "perseverance",
+      "tw_match": "perseverance"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "likewise",
+      "tw_match": "likewise"
+    },
+    {
+      "surface": "reverent",
+      "tw_match": "reverent"
+    },
+    {
+      "surface": "slanderers",
+      "tw_match": "slanderers"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "teachers",
+      "tw_match": "teacher"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "lovers",
+      "tw_match": "lover"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "subject",
+      "tw_match": "subject"
+    },
+    {
+      "surface": "word of God",
+      "tw_match": "word of God"
+    },
+    {
+      "surface": "insulted",
+      "tw_match": "insult"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "exhort",
+      "tw_match": "exhort"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "be subject to",
+      "tw_match": "be subject to"
+    },
+    {
+      "surface": "masters",
+      "tw_match": "master"
+    },
+    {
+      "surface": "pleasing",
+      "tw_match": "please"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "teaching",
+      "tw_match": "teaching"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "rejecting",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "godlessness",
+      "tw_match": "godlessness"
+    },
+    {
+      "surface": "worldly",
+      "tw_match": "worldly"
+    },
+    {
+      "surface": "passions",
+      "tw_match": "passions"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "godly",
+      "tw_match": "godly"
+    },
+    {
+      "surface": "age",
+      "tw_match": "age"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "receiving",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "blessed",
+      "tw_match": "blessed"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "redeem",
+      "tw_match": "redeem"
+    },
+    {
+      "surface": "lawlessness",
+      "tw_match": "lawlessness"
+    },
+    {
+      "surface": "purify",
+      "tw_match": "purify"
+    },
+    {
+      "surface": "chosen people",
+      "tw_match": "chosen people"
+    },
+    {
+      "surface": "zealous",
+      "tw_match": "zealous"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "exhort",
+      "tw_match": "exhort"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "authority",
+      "tw_match": "authority"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Remind",
+      "tw_match": "remind"
+    },
+    {
+      "surface": "submit",
+      "tw_match": "submit"
+    },
+    {
+      "surface": "rulers",
+      "tw_match": "ruler"
+    },
+    {
+      "surface": "authorities",
+      "tw_match": "authority"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "revile",
+      "tw_match": "revile"
+    },
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "enslaved",
+      "tw_match": "enslave"
+    },
+    {
+      "surface": "passions",
+      "tw_match": "passions"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "envy",
+      "tw_match": "envy"
+    },
+    {
+      "surface": "detestable",
+      "tw_match": "detestable"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "saved",
+      "tw_match": "saved"
+    },
+    {
+      "surface": "washing",
+      "tw_match": "wash"
+    },
+    {
+      "surface": "new birth",
+      "tw_match": "new birth"
+    },
+    {
+      "surface": "Holy Spirit",
+      "tw_match": "Holy Spirit"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "Savior",
+      "tw_match": "Savior"
+    },
+    {
+      "surface": "Jesus Christ",
+      "tw_match": "Jesus Christ"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "grace",
+      "tw_match": "grace"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "heirs",
+      "tw_match": "heir"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "eternal",
+      "tw_match": "eternal"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "trustworthy",
+      "tw_match": "trustworthy"
+    },
+    {
+      "surface": "believed",
+      "tw_match": "believe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "strife",
+      "tw_match": "strife"
+    },
+    {
+      "surface": "conflict",
+      "tw_match": "conflict"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "unprofitable",
+      "tw_match": "unprofitable"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Reject",
+      "tw_match": "reject"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "knowing",
+      "tw_match": "know"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "sinning",
+      "tw_match": "sinning"
+    },
+    {
+      "surface": "self",
+      "tw_match": "self"
+    },
+    {
+      "surface": "condemned",
+      "tw_match": "condemned"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "Tychicus",
+      "tw_match": "Tychicus"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "Apollos",
+      "tw_match": "Apollos"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "unfruitful",
+      "tw_match": "unfruitful"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "loving",
+      "tw_match": "love"
+    },
+    {
+      "surface": "faith",
+      "tw_match": "faith"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_ZEC.json
+++ b/sources/keyword_data/keywords_ZEC.json
@@ -1,0 +1,4242 @@
+{
+  "1:1": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "decrees",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "servants",
+      "tw_match": "servant"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "repented",
+      "tw_match": "repent"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "deserved",
+      "tw_match": "deserve"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "jealous",
+      "tw_match": "jealous"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "passion",
+      "tw_match": "passions"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "mercies",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    }
+  ],
+  "1:19": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "1:20": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:21": [
+    {
+      "surface": "horns",
+      "tw_match": "horns"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "terrify",
+      "tw_match": "terrify"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    }
+  ],
+  "2:1": [],
+  "2:2": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "beasts",
+      "tw_match": "beast"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "honored",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    },
+    {
+      "surface": "hand over",
+      "tw_match": "hand over"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "slaves",
+      "tw_match": "slave"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "glad",
+      "tw_match": "glad"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "declares",
+      "tw_match": "declare"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "choose",
+      "tw_match": "choose"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "holy place",
+      "tw_match": "holy place"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Satan",
+      "tw_match": "Satan"
+    },
+    {
+      "surface": "rebuke",
+      "tw_match": "rebuke"
+    },
+    {
+      "surface": "chosen",
+      "tw_match": "chosen"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "clean",
+      "tw_match": "clean"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "govern",
+      "tw_match": "govern"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "guard",
+      "tw_match": "guard"
+    },
+    {
+      "surface": "courts",
+      "tw_match": "court"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Please",
+      "tw_match": "please"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    },
+    {
+      "surface": "companions",
+      "tw_match": "companion"
+    },
+    {
+      "surface": "sign",
+      "tw_match": "sign"
+    },
+    {
+      "surface": "servant",
+      "tw_match": "servant"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "fig",
+      "tw_match": "fig"
+    }
+  ],
+  "4:1": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    }
+  ],
+  "4:2": [
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "lamp",
+      "tw_match": "lamp"
+    }
+  ],
+  "4:3": [
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "4:4": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "4:5": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "4:6": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "might",
+      "tw_match": "might"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "4:7": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Grace",
+      "tw_match": "grace"
+    }
+  ],
+  "4:8": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "4:9": [
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "4:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "Zerubbabel",
+      "tw_match": "Zerubbabel"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "4:11": [
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "lampstand",
+      "tw_match": "lampstand"
+    }
+  ],
+  "4:12": [
+    {
+      "surface": "olive",
+      "tw_match": "olive"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "pipes",
+      "tw_match": "pipe"
+    },
+    {
+      "surface": "golden",
+      "tw_match": "golden"
+    },
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    }
+  ],
+  "4:13": [
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "4:14": [
+    {
+      "surface": "oil",
+      "tw_match": "oil"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "5:1": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "5:2": [
+    {
+      "surface": "scroll",
+      "tw_match": "scroll"
+    }
+  ],
+  "5:3": [
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "oath",
+      "tw_match": "oath"
+    }
+  ],
+  "5:4": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "thief",
+      "tw_match": "thief"
+    },
+    {
+      "surface": "swears",
+      "tw_match": "swear"
+    },
+    {
+      "surface": "his house",
+      "tw_match": "his house"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    }
+  ],
+  "5:5": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "5:6": [
+    {
+      "surface": "iniquity",
+      "tw_match": "iniquity"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "5:7": [],
+  "5:8": [],
+  "5:9": [
+    {
+      "surface": "wind",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    }
+  ],
+  "5:10": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "5:11": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Shinar",
+      "tw_match": "Shinar"
+    }
+  ],
+  "6:1": [
+    {
+      "surface": "chariots",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "bronze",
+      "tw_match": "bronze"
+    }
+  ],
+  "6:2": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "6:3": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "6:4": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "master",
+      "tw_match": "master"
+    }
+  ],
+  "6:5": [
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    },
+    {
+      "surface": "winds",
+      "tw_match": "wind"
+    },
+    {
+      "surface": "heaven",
+      "tw_match": "heaven"
+    },
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "6:6": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    }
+  ],
+  "6:7": [
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "6:8": [
+    {
+      "surface": "called out",
+      "tw_match": "called out"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "6:9": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "6:10": [
+    {
+      "surface": "exiles",
+      "tw_match": "exile"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "Zephaniah",
+      "tw_match": "Zephaniah"
+    },
+    {
+      "surface": "Babylon",
+      "tw_match": "Babylon"
+    }
+  ],
+  "6:11": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "Joshua",
+      "tw_match": "Joshua"
+    },
+    {
+      "surface": "high priest",
+      "tw_match": "high priest"
+    }
+  ],
+  "6:12": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:13": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "bear",
+      "tw_match": "bear"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "rule",
+      "tw_match": "rule"
+    },
+    {
+      "surface": "throne",
+      "tw_match": "throne"
+    },
+    {
+      "surface": "priest",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "counsel",
+      "tw_match": "counsel"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "6:14": [
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "Zephaniah",
+      "tw_match": "Zephaniah"
+    },
+    {
+      "surface": "memorial",
+      "tw_match": "memorial"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "6:15": [
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "7:1": [
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "Darius",
+      "tw_match": "Darius"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    }
+  ],
+  "7:2": [
+    {
+      "surface": "Bethel",
+      "tw_match": "Bethel"
+    },
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "7:3": [
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "fast",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    }
+  ],
+  "7:4": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "7:5": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "fasted",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "mourned",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "years",
+      "tw_match": "year"
+    },
+    {
+      "surface": "truly",
+      "tw_match": "truly"
+    },
+    {
+      "surface": "fasting",
+      "tw_match": "fasting"
+    }
+  ],
+  "7:6": [],
+  "7:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "proclaimed",
+      "tw_match": "proclaim"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "prosperity",
+      "tw_match": "prosperity"
+    },
+    {
+      "surface": "Negev",
+      "tw_match": "Negev"
+    }
+  ],
+  "7:8": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Zechariah",
+      "tw_match": "Zechariah"
+    }
+  ],
+  "7:9": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "covenant faithfulness",
+      "tw_match": "covenant faithfulness"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    }
+  ],
+  "7:10": [
+    {
+      "surface": "foreigner",
+      "tw_match": "foreigner"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    }
+  ],
+  "7:11": [],
+  "7:12": [
+    {
+      "surface": "hard",
+      "tw_match": "hard"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Spirit",
+      "tw_match": "Spirit"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    }
+  ],
+  "7:13": [
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "call out",
+      "tw_match": "call out"
+    }
+  ],
+  "7:14": [
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "desolate",
+      "tw_match": "desolate"
+    },
+    {
+      "surface": "wasteland",
+      "tw_match": "wasteland"
+    }
+  ],
+  "8:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "8:2": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "zeal",
+      "tw_match": "zeal"
+    }
+  ],
+  "8:3": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Holy",
+      "tw_match": "holy"
+    }
+  ],
+  "8:4": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "old",
+      "tw_match": "old"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    }
+  ],
+  "8:5": [],
+  "8:6": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:7": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "8:8": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    }
+  ],
+  "8:9": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "temple",
+      "tw_match": "temple"
+    }
+  ],
+  "8:10": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "gathered",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "profit",
+      "tw_match": "profit"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "8:11": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "8:12": [
+    {
+      "surface": "seeds",
+      "tw_match": "seed"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "vine",
+      "tw_match": "vine"
+    },
+    {
+      "surface": "fruit",
+      "tw_match": "fruit"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "produce",
+      "tw_match": "produce"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "inherit",
+      "tw_match": "inherit"
+    }
+  ],
+  "8:13": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "curse",
+      "tw_match": "curse"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "house of Israel",
+      "tw_match": "house of Israel"
+    },
+    {
+      "surface": "blessing",
+      "tw_match": "blessing"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    }
+  ],
+  "8:14": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "provoked",
+      "tw_match": "provoked"
+    }
+  ],
+  "8:15": [
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "8:16": [
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "Judge",
+      "tw_match": "judge"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "gates",
+      "tw_match": "gate"
+    }
+  ],
+  "8:17": [
+    {
+      "surface": "evil",
+      "tw_match": "evil"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "oaths",
+      "tw_match": "oath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:18": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    }
+  ],
+  "8:19": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "fasts",
+      "tw_match": "fast"
+    },
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "tenth",
+      "tw_match": "tenth"
+    },
+    {
+      "surface": "times",
+      "tw_match": "time"
+    },
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "festivals",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    }
+  ],
+  "8:20": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "8:21": [
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    }
+  ],
+  "8:22": [
+    {
+      "surface": "mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "beg",
+      "tw_match": "beg"
+    },
+    {
+      "surface": "favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "8:23": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "language",
+      "tw_match": "language"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "robe",
+      "tw_match": "robe"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "9:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "9:2": [
+    {
+      "surface": "Hamath",
+      "tw_match": "Hamath"
+    },
+    {
+      "surface": "Damascus",
+      "tw_match": "Damascus"
+    },
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "Sidon",
+      "tw_match": "Sidon"
+    },
+    {
+      "surface": "wise",
+      "tw_match": "wise"
+    }
+  ],
+  "9:3": [
+    {
+      "surface": "Tyre",
+      "tw_match": "Tyre"
+    },
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    }
+  ],
+  "9:4": [
+    {
+      "surface": "Lord",
+      "tw_match": "Lord"
+    },
+    {
+      "surface": "dispossess",
+      "tw_match": "dispossess"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "devoured",
+      "tw_match": "devour"
+    }
+  ],
+  "9:5": [
+    {
+      "surface": "Ashkelon",
+      "tw_match": "Ashkelon"
+    },
+    {
+      "surface": "afraid",
+      "tw_match": "afraid"
+    },
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "tremble",
+      "tw_match": "tremble"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    },
+    {
+      "surface": "hopes",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "9:6": [
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    }
+  ],
+  "9:7": [
+    {
+      "surface": "abominations",
+      "tw_match": "abomination"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    },
+    {
+      "surface": "Jebusites",
+      "tw_match": "Jebusite"
+    }
+  ],
+  "9:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    }
+  ],
+  "9:9": [
+    {
+      "surface": "joy",
+      "tw_match": "joy"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "donkey",
+      "tw_match": "donkey"
+    }
+  ],
+  "9:10": [
+    {
+      "surface": "chariot",
+      "tw_match": "chariot"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "peace",
+      "tw_match": "peace"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "dominion",
+      "tw_match": "dominion"
+    },
+    {
+      "surface": "the River",
+      "tw_match": "the River"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "9:11": [
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "free",
+      "tw_match": "free"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    }
+  ],
+  "9:12": [
+    {
+      "surface": "stronghold",
+      "tw_match": "stronghold"
+    },
+    {
+      "surface": "hope",
+      "tw_match": "hope"
+    },
+    {
+      "surface": "declaring",
+      "tw_match": "declare"
+    }
+  ],
+  "9:13": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Greece",
+      "tw_match": "Greece"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "9:14": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "trumpet",
+      "tw_match": "trumpet"
+    }
+  ],
+  "9:15": [
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "stones",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "drunk",
+      "tw_match": "drunk"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "9:16": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "crown",
+      "tw_match": "crown"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    }
+  ],
+  "9:17": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "virgins",
+      "tw_match": "virgin"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "10:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    }
+  ],
+  "10:2": [
+    {
+      "surface": "household",
+      "tw_match": "household"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "diviners",
+      "tw_match": "diviner"
+    },
+    {
+      "surface": "envision",
+      "tw_match": "envision"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "dreams",
+      "tw_match": "dream"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "10:3": [
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "goats",
+      "tw_match": "goat"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "punish",
+      "tw_match": "punish"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "warhorse",
+      "tw_match": "warhorse"
+    }
+  ],
+  "10:4": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "cornerstone",
+      "tw_match": "cornerstone"
+    },
+    {
+      "surface": "tent",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "bow",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "ruler",
+      "tw_match": "ruler"
+    }
+  ],
+  "10:5": [
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "warriors",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "trample",
+      "tw_match": "trample"
+    },
+    {
+      "surface": "enemies",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "warhorses",
+      "tw_match": "warhorse"
+    }
+  ],
+  "10:6": [
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "Joseph",
+      "tw_match": "Joseph"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "mercy",
+      "tw_match": "mercy"
+    },
+    {
+      "surface": "I am Yahweh",
+      "tw_match": "I am Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "10:7": [
+    {
+      "surface": "Ephraim",
+      "tw_match": "Ephraim"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "10:8": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "10:9": [
+    {
+      "surface": "sowed",
+      "tw_match": "sow"
+    }
+  ],
+  "10:10": [
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Gilead",
+      "tw_match": "Gilead"
+    },
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    }
+  ],
+  "10:11": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "affliction",
+      "tw_match": "affliction"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "the Nile",
+      "tw_match": "the Nile"
+    },
+    {
+      "surface": "majesty",
+      "tw_match": "majesty"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "scepter",
+      "tw_match": "scepter"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "Egyptians",
+      "tw_match": "Egyptian"
+    }
+  ],
+  "10:12": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:1": [
+    {
+      "surface": "Lebanon",
+      "tw_match": "Lebanon"
+    },
+    {
+      "surface": "devour",
+      "tw_match": "devour"
+    },
+    {
+      "surface": "cedars",
+      "tw_match": "cedar"
+    }
+  ],
+  "11:2": [
+    {
+      "surface": "Lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "cypress",
+      "tw_match": "cypress"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    },
+    {
+      "surface": "oaks",
+      "tw_match": "oak"
+    },
+    {
+      "surface": "Bashan",
+      "tw_match": "Bashan"
+    }
+  ],
+  "11:3": [
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "glory",
+      "tw_match": "glory"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "Jordan River",
+      "tw_match": "Jordan River"
+    },
+    {
+      "surface": "devastated",
+      "tw_match": "devastate"
+    }
+  ],
+  "11:4": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "watch",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    }
+  ],
+  "11:5": [
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "punished",
+      "tw_match": "punished"
+    },
+    {
+      "surface": "Blessed",
+      "tw_match": "bless"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "working",
+      "tw_match": "work"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "11:6": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "turn over",
+      "tw_match": "turn over"
+    },
+    {
+      "surface": "person",
+      "tw_match": "person"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    }
+  ],
+  "11:7": [
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "slaughter",
+      "tw_match": "slaughter"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "staffs",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "called",
+      "tw_match": "called"
+    },
+    {
+      "surface": "Favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "shepherded",
+      "tw_match": "shepherd"
+    }
+  ],
+  "11:8": [
+    {
+      "surface": "month",
+      "tw_match": "month"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "impatient",
+      "tw_match": "impatient"
+    }
+  ],
+  "11:9": [
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "neighbor",
+      "tw_match": "neighbor"
+    }
+  ],
+  "11:10": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Favor",
+      "tw_match": "favor"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "tribes",
+      "tw_match": "tribe"
+    }
+  ],
+  "11:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "covenant",
+      "tw_match": "covenant"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "watching",
+      "tw_match": "watch"
+    },
+    {
+      "surface": "knew",
+      "tw_match": "knew"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "11:12": [
+    {
+      "surface": "good",
+      "tw_match": "good"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "11:13": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ],
+  "11:14": [
+    {
+      "surface": "staff",
+      "tw_match": "staff"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    }
+  ],
+  "11:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "foolish",
+      "tw_match": "foolish"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    }
+  ],
+  "11:16": [
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "perishing",
+      "tw_match": "perish"
+    },
+    {
+      "surface": "sheep",
+      "tw_match": "sheep"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "11:17": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "forsakes",
+      "tw_match": "forsake"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    }
+  ],
+  "12:1": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "foundation",
+      "tw_match": "foundation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "12:2": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "stagger",
+      "tw_match": "stagger"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "siege",
+      "tw_match": "siege"
+    }
+  ],
+  "12:3": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "stone",
+      "tw_match": "stone"
+    },
+    {
+      "surface": "hurt",
+      "tw_match": "hurt"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    }
+  ],
+  "12:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "horse",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "12:5": [
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "12:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "leaders",
+      "tw_match": "leader"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "grain",
+      "tw_match": "grain"
+    },
+    {
+      "surface": "consume",
+      "tw_match": "consume"
+    },
+    {
+      "surface": "right",
+      "tw_match": "right"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:7": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "tents",
+      "tw_match": "tent"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "honor",
+      "tw_match": "honor"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "angel",
+      "tw_match": "angel"
+    }
+  ],
+  "12:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "12:10": [
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    },
+    {
+      "surface": "compassion",
+      "tw_match": "compassion"
+    },
+    {
+      "surface": "pleading",
+      "tw_match": "plead"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "mourns",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "lament",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "firstborn",
+      "tw_match": "firstborn"
+    }
+  ],
+  "12:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "laments",
+      "tw_match": "lament"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    }
+  ],
+  "12:12": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "mourn",
+      "tw_match": "mourn"
+    },
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Nathan",
+      "tw_match": "Nathan"
+    }
+  ],
+  "12:13": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Levi",
+      "tw_match": "Levi"
+    }
+  ],
+  "12:14": [
+    {
+      "surface": "clan",
+      "tw_match": "clan"
+    },
+    {
+      "surface": "clans",
+      "tw_match": "clan"
+    }
+  ],
+  "13:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "spring",
+      "tw_match": "spring"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "David",
+      "tw_match": "David"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "sin",
+      "tw_match": "sin"
+    }
+  ],
+  "13:2": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "idols",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "spirit",
+      "tw_match": "spirit"
+    }
+  ],
+  "13:3": [
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "bore",
+      "tw_match": "bore"
+    },
+    {
+      "surface": "tell",
+      "tw_match": "tell"
+    },
+    {
+      "surface": "lies",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prophesies",
+      "tw_match": "prophesy"
+    }
+  ],
+  "13:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "ashamed",
+      "tw_match": "ashamed"
+    },
+    {
+      "surface": "vision",
+      "tw_match": "vision"
+    },
+    {
+      "surface": "prophesy",
+      "tw_match": "prophesy"
+    },
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "deceive",
+      "tw_match": "deceive"
+    }
+  ],
+  "13:5": [
+    {
+      "surface": "prophet",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "works",
+      "tw_match": "work"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    },
+    {
+      "surface": "young man",
+      "tw_match": "young man"
+    }
+  ],
+  "13:6": [
+    {
+      "surface": "friends",
+      "tw_match": "friend"
+    },
+    {
+      "surface": "house",
+      "tw_match": "house"
+    }
+  ],
+  "13:7": [
+    {
+      "surface": "Sword",
+      "tw_match": "sword"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "flock",
+      "tw_match": "flock"
+    },
+    {
+      "surface": "scatter",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    }
+  ],
+  "13:8": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "perish",
+      "tw_match": "perish"
+    }
+  ],
+  "13:9": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "test",
+      "tw_match": "test"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "tested",
+      "tw_match": "tested"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:1": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    }
+  ],
+  "14:2": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "captured",
+      "tw_match": "capture"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "plundered",
+      "tw_match": "plundered"
+    },
+    {
+      "surface": "captivity",
+      "tw_match": "captivity"
+    }
+  ],
+  "14:3": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "14:4": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Mount of Olives",
+      "tw_match": "Mount of Olives"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "14:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "just",
+      "tw_match": "just"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Uzziah",
+      "tw_match": "Uzziah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "14:6": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "14:7": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "time",
+      "tw_match": "time"
+    }
+  ],
+  "14:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "the western sea",
+      "tw_match": "the western sea"
+    }
+  ],
+  "14:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:10": [
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Arabah",
+      "tw_match": "Arabah"
+    },
+    {
+      "surface": "Rimmon",
+      "tw_match": "Rimmon"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Benjamin",
+      "tw_match": "Benjamin"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "Tower",
+      "tw_match": "tower"
+    },
+    {
+      "surface": "king’s",
+      "tw_match": "king’s"
+    },
+    {
+      "surface": "winepresses",
+      "tw_match": "winepress"
+    }
+  ],
+  "14:11": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "complete",
+      "tw_match": "complete"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "14:12": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "tongues",
+      "tw_match": "tongue"
+    }
+  ],
+  "14:13": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "seize",
+      "tw_match": "seize"
+    }
+  ],
+  "14:14": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "14:15": [
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "mules",
+      "tw_match": "mule"
+    },
+    {
+      "surface": "camels",
+      "tw_match": "camel"
+    },
+    {
+      "surface": "donkeys",
+      "tw_match": "donkey"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "suffer",
+      "tw_match": "suffer"
+    }
+  ],
+  "14:16": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "year",
+      "tw_match": "year"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Shelters",
+      "tw_match": "shelter"
+    }
+  ],
+  "14:17": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "worship",
+      "tw_match": "worship"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "14:18": [
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "receive",
+      "tw_match": "receive"
+    },
+    {
+      "surface": "plague",
+      "tw_match": "plague"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Shelters",
+      "tw_match": "shelter"
+    }
+  ],
+  "14:19": [
+    {
+      "surface": "punishment",
+      "tw_match": "punishment"
+    },
+    {
+      "surface": "Egypt",
+      "tw_match": "Egypt"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "keep",
+      "tw_match": "keep"
+    },
+    {
+      "surface": "Festival",
+      "tw_match": "festival"
+    },
+    {
+      "surface": "Shelters",
+      "tw_match": "shelter"
+    }
+  ],
+  "14:20": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "horses",
+      "tw_match": "horse"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "Yahweh’s house",
+      "tw_match": "Yahweh’s house"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "altar",
+      "tw_match": "altar"
+    }
+  ],
+  "14:21": [
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Yahweh of hosts",
+      "tw_match": "Yahweh of hosts"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    }
+  ]
+}

--- a/sources/keyword_data/keywords_ZEP.json
+++ b/sources/keyword_data/keywords_ZEP.json
@@ -1,0 +1,1240 @@
+{
+  "1:1": [
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Zephaniah",
+      "tw_match": "Zephaniah"
+    },
+    {
+      "surface": "Hezekiah",
+      "tw_match": "Hezekiah"
+    },
+    {
+      "surface": "days",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Josiah",
+      "tw_match": "Josiah"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    }
+  ],
+  "1:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:3": [
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "stumbling",
+      "tw_match": "stumble"
+    },
+    {
+      "surface": "wicked",
+      "tw_match": "wicked"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "1:4": [
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Baal",
+      "tw_match": "Baal"
+    },
+    {
+      "surface": "idol",
+      "tw_match": "idol"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    }
+  ],
+  "1:5": [
+    {
+      "surface": "bowing",
+      "tw_match": "bow"
+    },
+    {
+      "surface": "skies",
+      "tw_match": "sky"
+    },
+    {
+      "surface": "swearing",
+      "tw_match": "swearing"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:6": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "seek",
+      "tw_match": "seek"
+    }
+  ],
+  "1:7": [
+    {
+      "surface": "Lord Yahweh",
+      "tw_match": "Lord Yahweh"
+    },
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "prepared",
+      "tw_match": "prepared"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    }
+  ],
+  "1:8": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "sacrifice",
+      "tw_match": "sacrifice"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    }
+  ],
+  "1:9": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "lords",
+      "tw_match": "lord"
+    }
+  ],
+  "1:10": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    },
+    {
+      "surface": "Gate",
+      "tw_match": "gate"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    }
+  ],
+  "1:11": [
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    }
+  ],
+  "1:12": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "search",
+      "tw_match": "search"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "lamps",
+      "tw_match": "lamp"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "good",
+      "tw_match": "good"
+    }
+  ],
+  "1:13": [
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "plant",
+      "tw_match": "plant"
+    },
+    {
+      "surface": "vineyards",
+      "tw_match": "vineyards"
+    },
+    {
+      "surface": "wine",
+      "tw_match": "wine"
+    }
+  ],
+  "1:14": [
+    {
+      "surface": "day of Yahweh",
+      "tw_match": "day of Yahweh"
+    },
+    {
+      "surface": "warrior",
+      "tw_match": "warrior"
+    },
+    {
+      "surface": "cries",
+      "tw_match": "cry"
+    }
+  ],
+  "1:15": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "anguish",
+      "tw_match": "anguish"
+    },
+    {
+      "surface": "destruction",
+      "tw_match": "destruction"
+    },
+    {
+      "surface": "desolation",
+      "tw_match": "desolation"
+    }
+  ],
+  "1:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "horn",
+      "tw_match": "horn"
+    },
+    {
+      "surface": "cry",
+      "tw_match": "cry"
+    }
+  ],
+  "1:17": [
+    {
+      "surface": "distress",
+      "tw_match": "distress"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "sinned",
+      "tw_match": "sin"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "dung",
+      "tw_match": "dung"
+    }
+  ],
+  "1:18": [
+    {
+      "surface": "silver",
+      "tw_match": "silver"
+    },
+    {
+      "surface": "gold",
+      "tw_match": "gold"
+    },
+    {
+      "surface": "deliver",
+      "tw_match": "deliver"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "wrath",
+      "tw_match": "wrath"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "2:1": [
+    {
+      "surface": "Gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "2:2": [
+    {
+      "surface": "decree",
+      "tw_match": "decree"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "chaff",
+      "tw_match": "chaff"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:3": [
+    {
+      "surface": "Seek",
+      "tw_match": "seek"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "righteousness",
+      "tw_match": "righteousness"
+    },
+    {
+      "surface": "humility",
+      "tw_match": "humility"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    }
+  ],
+  "2:4": [
+    {
+      "surface": "Gaza",
+      "tw_match": "Gaza"
+    },
+    {
+      "surface": "Ashkelon",
+      "tw_match": "Ashkelon"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "Ashdod",
+      "tw_match": "Ashdod"
+    },
+    {
+      "surface": "Ekron",
+      "tw_match": "Ekron"
+    }
+  ],
+  "2:5": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "word of Yahweh",
+      "tw_match": "word of Yahweh"
+    },
+    {
+      "surface": "Canaan",
+      "tw_match": "Canaan"
+    },
+    {
+      "surface": "land",
+      "tw_match": "land"
+    },
+    {
+      "surface": "Philistines",
+      "tw_match": "Philistines"
+    },
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    }
+  ],
+  "2:6": [
+    {
+      "surface": "the sea",
+      "tw_match": "the sea"
+    },
+    {
+      "surface": "shepherds",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "flocks",
+      "tw_match": "flock"
+    }
+  ],
+  "2:7": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "the house",
+      "tw_match": "the house"
+    },
+    {
+      "surface": "Judah",
+      "tw_match": "Judah"
+    },
+    {
+      "surface": "shepherd",
+      "tw_match": "shepherd"
+    },
+    {
+      "surface": "houses",
+      "tw_match": "house"
+    },
+    {
+      "surface": "Ashkelon",
+      "tw_match": "Ashkelon"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "restore",
+      "tw_match": "restore"
+    }
+  ],
+  "2:8": [
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "insults",
+      "tw_match": "insult"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "reproached",
+      "tw_match": "reproach"
+    }
+  ],
+  "2:9": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Moab",
+      "tw_match": "Moab"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "Sodom",
+      "tw_match": "Sodom"
+    },
+    {
+      "surface": "Ammon",
+      "tw_match": "Ammon"
+    },
+    {
+      "surface": "Gomorrah",
+      "tw_match": "Gomorrah"
+    },
+    {
+      "surface": "possession",
+      "tw_match": "possession"
+    },
+    {
+      "surface": "pit",
+      "tw_match": "pit"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "forever",
+      "tw_match": "forever"
+    },
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "plunder",
+      "tw_match": "plunder"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    }
+  ],
+  "2:10": [
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "reproached",
+      "tw_match": "reproach"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "2:11": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "gods",
+      "tw_match": "god"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "bow down",
+      "tw_match": "bow down"
+    }
+  ],
+  "2:12": [
+    {
+      "surface": "sword",
+      "tw_match": "sword"
+    }
+  ],
+  "2:13": [
+    {
+      "surface": "destroy",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "Assyria",
+      "tw_match": "Assyria"
+    },
+    {
+      "surface": "Nineveh",
+      "tw_match": "Nineveh"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "dry",
+      "tw_match": "dry"
+    },
+    {
+      "surface": "like",
+      "tw_match": "like"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    }
+  ],
+  "2:14": [
+    {
+      "surface": "herds",
+      "tw_match": "herd"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "animal",
+      "tw_match": "animals"
+    },
+    {
+      "surface": "nation",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "desert",
+      "tw_match": "desert"
+    },
+    {
+      "surface": "columns",
+      "tw_match": "column"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "devastation",
+      "tw_match": "devastation"
+    },
+    {
+      "surface": "threshold",
+      "tw_match": "threshold"
+    },
+    {
+      "surface": "cedar",
+      "tw_match": "cedar"
+    },
+    {
+      "surface": "work",
+      "tw_match": "work"
+    }
+  ],
+  "2:15": [
+    {
+      "surface": "exultant",
+      "tw_match": "exultant"
+    },
+    {
+      "surface": "ruin",
+      "tw_match": "ruin"
+    },
+    {
+      "surface": "beast",
+      "tw_match": "beast"
+    },
+    {
+      "surface": "shake",
+      "tw_match": "shake"
+    }
+  ],
+  "3:1": [
+    {
+      "surface": "Woe",
+      "tw_match": "woe"
+    },
+    {
+      "surface": "rebelling",
+      "tw_match": "rebel"
+    },
+    {
+      "surface": "defiled",
+      "tw_match": "defiled"
+    }
+  ],
+  "3:2": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    }
+  ],
+  "3:3": [
+    {
+      "surface": "princes",
+      "tw_match": "prince"
+    },
+    {
+      "surface": "lions",
+      "tw_match": "lion"
+    },
+    {
+      "surface": "judges",
+      "tw_match": "judge"
+    }
+  ],
+  "3:4": [
+    {
+      "surface": "prophets",
+      "tw_match": "prophet"
+    },
+    {
+      "surface": "priests",
+      "tw_match": "priest"
+    },
+    {
+      "surface": "profane",
+      "tw_match": "profane"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    },
+    {
+      "surface": "law",
+      "tw_match": "law"
+    }
+  ],
+  "3:5": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "righteous",
+      "tw_match": "righteous"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "justice",
+      "tw_match": "justice"
+    },
+    {
+      "surface": "unrighteous",
+      "tw_match": "unrighteous"
+    },
+    {
+      "surface": "know",
+      "tw_match": "know"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    }
+  ],
+  "3:6": [
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "destroyed",
+      "tw_match": "destroy"
+    },
+    {
+      "surface": "ruined",
+      "tw_match": "ruined"
+    }
+  ],
+  "3:7": [
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "corrupted",
+      "tw_match": "corrupted"
+    }
+  ],
+  "3:8": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "prey",
+      "tw_match": "prey"
+    },
+    {
+      "surface": "judgment",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "nations",
+      "tw_match": "nation"
+    },
+    {
+      "surface": "assemble",
+      "tw_match": "assemble"
+    },
+    {
+      "surface": "kingdoms",
+      "tw_match": "kingdom"
+    },
+    {
+      "surface": "jealousy",
+      "tw_match": "jealousy"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "consumed",
+      "tw_match": "consume"
+    }
+  ],
+  "3:9": [
+    {
+      "surface": "pure",
+      "tw_match": "pure"
+    },
+    {
+      "surface": "call",
+      "tw_match": "call"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "serve",
+      "tw_match": "serve"
+    }
+  ],
+  "3:10": [
+    {
+      "surface": "Cush",
+      "tw_match": "Cush"
+    },
+    {
+      "surface": "scattered",
+      "tw_match": "scatter"
+    },
+    {
+      "surface": "offering",
+      "tw_match": "offering"
+    }
+  ],
+  "3:11": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "transgressed",
+      "tw_match": "transgress"
+    },
+    {
+      "surface": "exultant",
+      "tw_match": "exultant"
+    },
+    {
+      "surface": "pride",
+      "tw_match": "pride"
+    },
+    {
+      "surface": "haughty",
+      "tw_match": "haughty"
+    },
+    {
+      "surface": "holy",
+      "tw_match": "holy"
+    }
+  ],
+  "3:12": [
+    {
+      "surface": "leave",
+      "tw_match": "leave"
+    },
+    {
+      "surface": "humble",
+      "tw_match": "humble"
+    },
+    {
+      "surface": "lowly",
+      "tw_match": "lowly"
+    },
+    {
+      "surface": "trust",
+      "tw_match": "trust"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ],
+  "3:13": [
+    {
+      "surface": "remnant",
+      "tw_match": "remnant"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "commit",
+      "tw_match": "commit"
+    },
+    {
+      "surface": "unrighteousness",
+      "tw_match": "unrighteousness"
+    },
+    {
+      "surface": "lie",
+      "tw_match": "lie"
+    },
+    {
+      "surface": "tongue",
+      "tw_match": "tongue"
+    },
+    {
+      "surface": "frightening",
+      "tw_match": "frighten"
+    }
+  ],
+  "3:14": [
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "Rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    }
+  ],
+  "3:15": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "judgments",
+      "tw_match": "judgment"
+    },
+    {
+      "surface": "enemy",
+      "tw_match": "enemy"
+    },
+    {
+      "surface": "king",
+      "tw_match": "king"
+    },
+    {
+      "surface": "Israel",
+      "tw_match": "Israel"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    }
+  ],
+  "3:16": [
+    {
+      "surface": "day",
+      "tw_match": "day"
+    },
+    {
+      "surface": "Jerusalem",
+      "tw_match": "Jerusalem"
+    },
+    {
+      "surface": "fear",
+      "tw_match": "fear"
+    },
+    {
+      "surface": "Zion",
+      "tw_match": "Zion"
+    }
+  ],
+  "3:17": [
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    },
+    {
+      "surface": "God",
+      "tw_match": "God"
+    },
+    {
+      "surface": "Mighty",
+      "tw_match": "mighty"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "rejoice",
+      "tw_match": "rejoice"
+    },
+    {
+      "surface": "love",
+      "tw_match": "love"
+    },
+    {
+      "surface": "exult",
+      "tw_match": "exult"
+    },
+    {
+      "surface": "rejoicing",
+      "tw_match": "rejoice"
+    }
+  ],
+  "3:18": [
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "assembly",
+      "tw_match": "assembly"
+    },
+    {
+      "surface": "reproach",
+      "tw_match": "reproach"
+    }
+  ],
+  "3:19": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "save",
+      "tw_match": "save"
+    },
+    {
+      "surface": "gather",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "shame",
+      "tw_match": "shame"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    }
+  ],
+  "3:20": [
+    {
+      "surface": "time",
+      "tw_match": "time"
+    },
+    {
+      "surface": "gathering",
+      "tw_match": "gather"
+    },
+    {
+      "surface": "praise",
+      "tw_match": "praise"
+    },
+    {
+      "surface": "earth",
+      "tw_match": "earth"
+    },
+    {
+      "surface": "restoring",
+      "tw_match": "restore"
+    },
+    {
+      "surface": "Yahweh",
+      "tw_match": "Yahweh"
+    }
+  ]
+}

--- a/utils/keywords.py
+++ b/utils/keywords.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Iterable, List, Set, Tuple
+
+# Map canonical book names to the 3-letter (or 4 with leading digit) codes
+# used by the keyword dataset filenames, e.g., sources/keyword_data/keywords_JHN.json
+BOOK_TO_CODE: Dict[str, str] = {
+    # Pentateuch
+    "Genesis": "GEN",
+    "Exodus": "EXO",
+    "Leviticus": "LEV",
+    "Numbers": "NUM",
+    "Deuteronomy": "DEU",
+    # History
+    "Joshua": "JOS",
+    "Judges": "JDG",
+    "Ruth": "RUT",
+    "1 Samuel": "1SA",
+    "2 Samuel": "2SA",
+    "1 Kings": "1KI",
+    "2 Kings": "2KI",
+    "1 Chronicles": "1CH",
+    "2 Chronicles": "2CH",
+    "Ezra": "EZR",
+    "Nehemiah": "NEH",
+    "Esther": "EST",
+    # Poetry/Wisdom
+    "Job": "JOB",
+    "Psalm": "PSA",
+    "Proverbs": "PRO",
+    "Ecclesiastes": "ECC",
+    "Song of Solomon": "SNG",
+    # Major Prophets
+    "Isaiah": "ISA",
+    "Jeremiah": "JER",
+    "Lamentations": "LAM",
+    "Ezekiel": "EZK",
+    "Daniel": "DAN",
+    # Minor Prophets
+    "Hosea": "HOS",
+    "Joel": "JOL",
+    "Amos": "AMO",
+    "Obadiah": "OBA",
+    "Jonah": "JON",
+    "Micah": "MIC",
+    "Nahum": "NAM",
+    "Habakkuk": "HAB",
+    "Zephaniah": "ZEP",
+    "Haggai": "HAG",
+    "Zechariah": "ZEC",
+    "Malachi": "MAL",
+    # Gospels/Acts
+    "Matthew": "MAT",
+    "Mark": "MRK",
+    "Luke": "LUK",
+    "John": "JHN",
+    "Acts": "ACT",
+    # Paul’s Epistles
+    "Romans": "ROM",
+    "1 Corinthians": "1CO",
+    "2 Corinthians": "2CO",
+    "Galatians": "GAL",
+    "Ephesians": "EPH",
+    "Philippians": "PHP",
+    "Colossians": "COL",
+    "1 Thessalonians": "1TH",
+    "2 Thessalonians": "2TH",
+    "1 Timothy": "1TI",
+    "2 Timothy": "2TI",
+    "Titus": "TIT",
+    "Philemon": "PHM",
+    # General Epistles + Revelation
+    "Hebrews": "HEB",
+    "James": "JAS",
+    "1 Peter": "1PE",
+    "2 Peter": "2PE",
+    "1 John": "1JN",
+    "2 John": "2JN",
+    "3 John": "3JN",
+    "Jude": "JUD",
+    "Revelation": "REV",
+}
+
+
+@lru_cache(maxsize=128)
+def load_keywords_json(data_root: Path, code: str) -> Dict[str, List[Dict[str, str]]]:
+    """Load a keyword JSON for a given book code (cached)."""
+    path = data_root / f"keywords_{code}.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _in_range(ch: int, vs: int, start_ch: int, start_vs: int | None, end_ch: int | None, end_vs: int | None) -> bool:
+    s_vs = start_vs if start_vs is not None else 1
+    e_ch = end_ch if end_ch is not None else start_ch
+    e_vs = end_vs if end_vs is not None else 10_000
+    if ch < start_ch or ch > e_ch:
+        return False
+    if ch == start_ch and vs < s_vs:
+        return False
+    if ch == e_ch and vs > e_vs:
+        return False
+    return True
+
+
+def select_keywords(
+    data_root: Path,
+    canonical_book: str,
+    ranges: Iterable[Tuple[int, int | None, int | None, int | None]],
+) -> List[str]:
+    """Select distinct tw_match keywords for a book across the given ranges.
+
+    ranges: iterable of (start_ch, start_vs, end_ch, end_vs). Use None to denote
+            whole chapter/book semantics (mirrors utils.bsb.select_verses input).
+    """
+    code = BOOK_TO_CODE.get(canonical_book)
+    if not code:
+        return []
+    data = load_keywords_json(data_root, code)
+
+    # Pre-parse available verse keys into (ch, vs)
+    # Keys are "<chapter>:<verse>" strings.
+    parsed: List[Tuple[int, int, str]] = []
+    for k in data.keys():
+        try:
+            ch_s, vs_s = k.split(":", 1)
+            parsed.append((int(ch_s), int(vs_s), k))
+        except Exception:
+            continue
+
+    found: Set[str] = set()
+    for sc, sv, ec, ev in ranges:
+        for ch, vs, key in parsed:
+            if _in_range(ch, vs, sc, sv, ec, ev):
+                entries = data.get(key, [])
+                for e in entries:
+                    tw = e.get("tw_match")
+                    if tw:
+                        found.add(tw)
+
+    return sorted(found)
+


### PR DESCRIPTION
Summary

- Adds new intent `get-passage-keywords` that mirrors the passage-summary flow to parse/normalize a single-book selection and return a list of distinct `tw_match` keywords.
- Copies 66 keyword datasets into `sources/keyword_data/` (from https://github.com/IanLindsley/node-twl-generator/tree/main/datasets/keywords).
- Wires the handler into the LangGraph and the intent classifier prompt with examples.

Details

- New utils: `utils/keywords.py` maps canonical book names to dataset codes and selects keywords over (chapter, verse) ranges.
- New node: `handle_get_passage_keywords` parses selection (same prompt + heuristics as summary), normalizes to one canonical book, builds ranges, loads from `sources/keyword_data`, and responds with:
  `Keywords in <range>

<comma-separated keywords>`.
- Graph: registers node, routes from `process_intents`, and fans in through `translate_responses_node`.
- Intent enum + classifier prompt extended.

Rationale

- Reuses robust passage selection + normalization to keep UX identical to summaries; efficient per-book loading.

Test Plan

- `ruff check .` → clean
- `pylint brain.py` → OK (file-level disable for too-many-statements consistent with module); didn't modify unrelated repo warnings.
- `mypy .` → pre-existing repo issues; no new errors from added files.
- `pytest -q` → 6 passed.
- Manual: spot-check keyword selection for `John 1–3` and `Hebrews 1:1–11` paths.

Notes

- No API surface changes.
- Data-only commit included separately for dataset files.