### PR TITLE
Add consult FIA resources intent

### DIFF
--- a/db/chroma_db.py
+++ b/db/chroma_db.py
@@ -18,9 +18,9 @@ DATA_DIR: Path = Path(str(config.DATA_DIR))
 DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 openai_ef: Any = embedding_functions.OpenAIEmbeddingFunction(
-                model_name="text-embedding-ada-002",
-                api_key=config.OPENAI_API_KEY
-            )
+    model_name="text-embedding-ada-002",
+    api_key_env_var="OPENAI_API_KEY",
+)
 
 settings = Settings(
     chroma_segment_cache_policy="LRU",

--- a/tests/test_chroma_endpoints.py
+++ b/tests/test_chroma_endpoints.py
@@ -21,6 +21,11 @@ class DummyEmbeddingFunction:
         """Signal that this is a legacy-style embedder to keep Chroma happy."""
         return True
 
+    @staticmethod
+    def name() -> str:
+        """Match OpenAI embedding function static interface."""
+        return "dummy-embedding"
+
 
 def make_tmp_client(tmp_path):
     """Create a chromadb PersistentClient rooted at a tmp path."""

--- a/tests/test_consult_fia_resources.py
+++ b/tests/test_consult_fia_resources.py
@@ -1,0 +1,91 @@
+"""Unit tests for consult_fia_resources intent handling."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+import brain
+
+
+class _FakeCollection:  # pylint: disable=too-few-public-methods
+    """Simple stand-in for a Chroma collection."""
+
+    def __init__(self, documents: list[tuple[str, float, dict[str, str]]]) -> None:
+        self._documents = documents
+
+    def query(self, *, query_texts: list[str], n_results: int) -> dict[str, Any]:  # noqa: ARG002
+        """Return a deterministic subset of stored docs for the test."""
+        _ = query_texts
+        docs = [doc for doc, _dist, _meta in self._documents][:n_results]
+        distances = [dist for _doc, dist, _meta in self._documents][:n_results]
+        metadatas = [meta for _doc, _dist, meta in self._documents][:n_results]
+        return {
+            "documents": [docs],
+            "distances": [distances],
+            "metadatas": [metadatas],
+        }
+
+
+def test_consult_fia_resources_falls_back_to_english(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Falls back to the English FIA collection when localized resources are missing."""
+
+    captured_messages: dict[str, Any] = {}
+
+    def _fake_get_collection(name: str) -> _FakeCollection | None:
+        if name == "en_fia_resources":
+            docs = [
+                ("English FIA doc", 0.1, {"name": "EN FIA", "source": "fia/en.doc"}),
+            ]
+            return _FakeCollection(docs)
+        return None
+
+    class _FakeResponse:  # pylint: disable=too-few-public-methods
+        usage = None
+        output_text = "synthesized fia answer"
+
+    def _fake_create(**kwargs: Any) -> Any:  # noqa: ANN401
+        captured_messages["input"] = kwargs["input"]
+        return _FakeResponse()
+
+    monkeypatch.setattr(brain, "get_chroma_collection", _fake_get_collection)
+    monkeypatch.setattr(brain.open_ai_client.responses, "create", _fake_create)
+    monkeypatch.setattr(brain, "FIA_REFERENCE_CONTENT", "FIA manual reference text")
+
+    state: dict[str, Any] = {
+        "transformed_query": "What does FIA step 2 look like in Mark 1?",
+        "user_chat_history": [],
+        "user_response_language": "es",
+        "query_language": "es",
+    }
+
+    out = brain.consult_fia_resources(cast(Any, state))
+
+    assert out["responses"][0]["intent"] == brain.IntentType.CONSULT_FIA_RESOURCES
+    assert out.get("collection_used") == "en_fia_resources"
+
+    # Ensure the FIA manual and vector doc both reached the prompt payload
+    payload = captured_messages["input"][0]["content"]
+    assert "FIA manual reference text" in payload
+    assert "English FIA doc" in payload
+
+
+def test_consult_fia_resources_handles_missing_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Returns a helpful fallback when no FIA resources are available."""
+
+    monkeypatch.setattr(brain, "get_chroma_collection", lambda _name: None)
+    monkeypatch.setattr(brain, "FIA_REFERENCE_CONTENT", "")
+
+    state: dict[str, Any] = {
+        "transformed_query": "How do I translate the Bible?",
+        "user_chat_history": [],
+        "user_response_language": None,
+        "query_language": "en",
+    }
+
+    out = brain.consult_fia_resources(cast(Any, state))
+
+    response_text = out["responses"][0]["response"]
+    assert "couldn't find any FIA resources" in response_text
+    assert brain.IntentType.CONSULT_FIA_RESOURCES == out["responses"][0]["intent"]

--- a/tests/test_determine_intents_openai.py
+++ b/tests/test_determine_intents_openai.py
@@ -60,3 +60,18 @@ def test_intents_detect_keywords(query: str) -> None:
     out = determine_intents(cast(Any, state))
     intents = set(out["user_intents"])  # list[IntentType]
     assert IntentType.GET_PASSAGE_KEYWORDS in intents
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "How do I translate the Bible?",
+        "What are the steps of the FIA process?",
+        "What does FIA step 2 look like in the first chapter of Mark?",
+    ],
+)
+def test_intents_detect_consult_fia_resources(query: str) -> None:
+    state: dict[str, Any] = {"transformed_query": query}
+    out = determine_intents(cast(Any, state))
+    intents = set(out["user_intents"])  # list[IntentType]
+    assert IntentType.CONSULT_FIA_RESOURCES in intents


### PR DESCRIPTION
## Summary
- add consult-fia-resources intent with FIA manual context and collection fallback
- update intent classification, capabilities, and graph wiring
- add unit/perf coverage and OpenAI intent cases for FIA queries

## Testing
- scripts/check_repo.sh
- RUN_OPENAI_API_TESTS=1 pytest -q -m openai