### PR TITLE
feature/agentic strength

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@
 - Agentic strength now supports `normal`, `low`, and `very_low`. Use
   `_resolve_agentic_strength` + `_model_for_agentic_strength` to pick models instead of
   hardcoding string comparisons.
+- When the user asks for an assessment or approach before coding, pause and confirm the
+  plan in the conversation before modifying files. Only move to implementation after the
+  user signs off.
 - Docstrings for public functions; keep comments minimal and useful.
 - Tools: `ruff` for style, `pylint` for code hygiene, `mypy` for typing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,9 @@
 - Keep functions small and single-purpose; prefer explicit returns.
 - Node handlers in `brain.py` should stay lean (target ≤60 lines). When they start
   to sprawl, extract helper functions so the orchestrators remain readable.
+- Agentic strength now supports `normal`, `low`, and `very_low`. Use
+  `_resolve_agentic_strength` + `_model_for_agentic_strength` to pick models instead of
+  hardcoding string comparisons.
 - Docstrings for public functions; keep comments minimal and useful.
 - Tools: `ruff` for style, `pylint` for code hygiene, `mypy` for typing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@
 - Python 3.12+, 4-space indentation, UTF-8 files.
 - Naming: `snake_case` for functions/vars, `PascalCase` for classes, `UPPER_SNAKE` for constants.
 - Keep functions small and single-purpose; prefer explicit returns.
+- Node handlers in `brain.py` should stay lean (target ≤60 lines). When they start
+  to sprawl, extract helper functions so the orchestrators remain readable.
 - Docstrings for public functions; keep comments minimal and useful.
 - Tools: `ruff` for style, `pylint` for code hygiene, `mypy` for typing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,14 @@ Recommended workflow
 - Do NOT duplicate selection parsing/normalization inside individual handlers. Call this helper and handle the `error` case by returning an intent‑specific message.
 - For labeling output headers, always use `utils/bsb.label_ranges(...)` to build a canonical reference string. It already special‑cases whole‑book selections to avoid odd labels like "Book 1‑10000".
 
+## GitHub CLI Usage
+
+- The development workstation has `gh` (GitHub CLI) installed. Prefer `gh pr create` to open pull requests directly from the terminal.
+- When a PR is ready:
+  1. Ensure the branch is pushed (`git push origin <branch>`).
+  2. Run `gh pr create` with the appropriate base, title, and body, or use `gh pr create --fill` after preparing the template.
+  3. Confirm the PR URL and share it with reviewers.
+
 ### Passage Summary Intent
 - Extraction and scope:
   - Supports a single canonical book per request. Disallow cross‑book selections.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,7 +263,7 @@ Recommended workflow
 ### Passage Selection (DRY)
 
 - Use the shared helper in `brain.py` to parse and normalize user queries that refer to Bible passages:
-  - `_resolve_selection_for_single_book(query: str, query_lang: str, focus_hint: str | None = None, focus_keywords: Sequence[str] | None = None) -> tuple[canonical_book | None, ranges | None, error | None]`
+  - `_resolve_selection_for_single_book(query: str, query_lang: str, focus_hint: str | None = None) -> tuple[canonical_book | None, ranges | None, error | None]`
   - It handles: translation to English for parsing, extraction via the selection prompt, the "chapters X–Y" heuristic, canonicalization (single book), and range building (including whole‑book sentinel handling).
 - Do NOT duplicate selection parsing/normalization inside individual handlers. Call this helper and handle the `error` case by returning an intent‑specific message.
 - For labeling output headers, always use `utils/bsb.label_ranges(...)` to build a canonical reference string. It already special‑cases whole‑book selections to avoid odd labels like "Book 1‑10000".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,7 +263,7 @@ Recommended workflow
 ### Passage Selection (DRY)
 
 - Use the shared helper in `brain.py` to parse and normalize user queries that refer to Bible passages:
-  - `_resolve_selection_for_single_book(query: str, query_lang: str) -> tuple[canonical_book | None, ranges | None, error | None]`
+  - `_resolve_selection_for_single_book(query: str, query_lang: str, focus_hint: str | None = None) -> tuple[canonical_book | None, ranges | None, error | None]`
   - It handles: translation to English for parsing, extraction via the selection prompt, the "chapters X–Y" heuristic, canonicalization (single book), and range building (including whole‑book sentinel handling).
 - Do NOT duplicate selection parsing/normalization inside individual handlers. Call this helper and handle the `error` case by returning an intent‑specific message.
 - For labeling output headers, always use `utils/bsb.label_ranges(...)` to build a canonical reference string. It already special‑cases whole‑book selections to avoid odd labels like "Book 1‑10000".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,7 +263,7 @@ Recommended workflow
 ### Passage Selection (DRY)
 
 - Use the shared helper in `brain.py` to parse and normalize user queries that refer to Bible passages:
-  - `_resolve_selection_for_single_book(query: str, query_lang: str, focus_hint: str | None = None) -> tuple[canonical_book | None, ranges | None, error | None]`
+  - `_resolve_selection_for_single_book(query: str, query_lang: str, focus_hint: str | None = None, focus_keywords: Sequence[str] | None = None) -> tuple[canonical_book | None, ranges | None, error | None]`
   - It handles: translation to English for parsing, extraction via the selection prompt, the "chapters X–Y" heuristic, canonicalization (single book), and range building (including whole‑book sentinel handling).
 - Do NOT duplicate selection parsing/normalization inside individual handlers. Call this helper and handle the `error` case by returning an intent‑specific message.
 - For labeling output headers, always use `utils/bsb.label_ranges(...)` to build a canonical reference string. It already special‑cases whole‑book selections to avoid odd labels like "Book 1‑10000".

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ uvicorn bt_servant:app --reload
 | `OPENAI_PRICING_JSON`  | (Optional) Per-million token pricing to compute costs in perf reports |
 | `ENABLE_ADMIN_AUTH`    | (Optional) When `true`, protect admin endpoints with a token   |
 | `ADMIN_API_TOKEN`      | (Optional) Token value accepted for admin endpoints            |
+| `AGENTIC_STRENGTH`     | (Optional) Default LLM agentic strength (`normal` or `low`)    |
 
 Other acceptable values for log level: critical, error, warning, and debug
 

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ Other acceptable values for log level: critical, error, warning, and debug
 
 ## Pricing Defaults
 
-- The engine computes token and cost totals in its performance reports. By default, it includes pricing for `gpt-4o` and voice flows (`gpt-4o-transcribe`, `gpt-4o-mini-tts`) if no environment override is provided.
+- The engine computes token and cost totals in its performance reports. By default, it includes pricing for `gpt-4o`, `gpt-4o-mini`, and voice flows (`gpt-4o-transcribe`, `gpt-4o-mini-tts`) if no environment override is provided.
 
 ```
-OPENAI_PRICING_JSON='{"gpt-4o": {"input_per_million": 2.5, "output_per_million": 10.0, "cached_input": 1.25}, "gpt-4o-transcribe": {"input_per_million": 2.5, "output_per_million": 10.0, "audio_input_per_million": 6.0}, "gpt-4o-mini-tts": {"input_per_million": 0.6, "audio_output_per_million": 12.0}}'
+OPENAI_PRICING_JSON='{"gpt-4o": {"input_per_million": 2.5, "output_per_million": 10.0, "cached_input": 1.25}, "gpt-4o-mini": {"input_per_million": 0.15, "output_per_million": 0.6}, "gpt-4o-transcribe": {"input_per_million": 2.5, "output_per_million": 10.0, "audio_input_per_million": 6.0}, "gpt-4o-mini-tts": {"input_per_million": 0.6, "audio_output_per_million": 12.0}}'
 ```
 
 - To override (e.g., if pricing changes), set `OPENAI_PRICING_JSON` in your environment or `.env` to a JSON object mapping model names to per‑million rates. Recognized keys per model:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ uvicorn bt_servant:app --reload
 | `OPENAI_PRICING_JSON`  | (Optional) Per-million token pricing to compute costs in perf reports |
 | `ENABLE_ADMIN_AUTH`    | (Optional) When `true`, protect admin endpoints with a token   |
 | `ADMIN_API_TOKEN`      | (Optional) Token value accepted for admin endpoints            |
-| `AGENTIC_STRENGTH`     | (Optional) Default LLM agentic strength (`normal`, `low`, `very_low`). Default is `very_low`.    |
+| `AGENTIC_STRENGTH`     | (Optional) Default LLM agentic strength (`normal`, `low`, `very_low`). Default is `low`.    |
 
 Other acceptable values for log level: critical, error, warning, and debug
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ uvicorn bt_servant:app --reload
 | `OPENAI_PRICING_JSON`  | (Optional) Per-million token pricing to compute costs in perf reports |
 | `ENABLE_ADMIN_AUTH`    | (Optional) When `true`, protect admin endpoints with a token   |
 | `ADMIN_API_TOKEN`      | (Optional) Token value accepted for admin endpoints            |
-| `AGENTIC_STRENGTH`     | (Optional) Default LLM agentic strength (`normal`, `low`, `very_low`)    |
+| `AGENTIC_STRENGTH`     | (Optional) Default LLM agentic strength (`normal`, `low`, `very_low`). Default is `very_low`.    |
 
 Other acceptable values for log level: critical, error, warning, and debug
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ uvicorn bt_servant:app --reload
 | `OPENAI_PRICING_JSON`  | (Optional) Per-million token pricing to compute costs in perf reports |
 | `ENABLE_ADMIN_AUTH`    | (Optional) When `true`, protect admin endpoints with a token   |
 | `ADMIN_API_TOKEN`      | (Optional) Token value accepted for admin endpoints            |
-| `AGENTIC_STRENGTH`     | (Optional) Default LLM agentic strength (`normal` or `low`)    |
+| `AGENTIC_STRENGTH`     | (Optional) Default LLM agentic strength (`normal`, `low`, `very_low`)    |
 
 Other acceptable values for log level: critical, error, warning, and debug
 

--- a/brain.py
+++ b/brain.py
@@ -1374,7 +1374,7 @@ def translate_responses(state: Any) -> dict:  # pylint: disable=too-many-locals
     translated_responses: list[str] = []
     for resp in responses_for_translation:
         if isinstance(resp, str):
-            sample = resp.lstrip()[:LANG_DETECTION_SAMPLE_CHARS]
+            sample = _sample_for_language_detection(resp)
             detected_lang = detect_language(sample) if sample else target_language
             if detected_lang != target_language:
                 logger.info('preparing to translate to %s', target_language)
@@ -3084,3 +3084,15 @@ def create_brain():
 
     return builder.compile()
 LANG_DETECTION_SAMPLE_CHARS = 100
+
+
+def _sample_for_language_detection(text: str) -> str:
+    """Return a short prefix ending at a whitespace boundary for detection."""
+    trimmed = text.lstrip()
+    if len(trimmed) <= LANG_DETECTION_SAMPLE_CHARS:
+        return trimmed
+    snippet = trimmed[:LANG_DETECTION_SAMPLE_CHARS]
+    parts = snippet.rsplit(maxsplit=1)
+    if len(parts) > 1 and parts[0]:
+        return parts[0]
+    return snippet

--- a/brain.py
+++ b/brain.py
@@ -1094,6 +1094,7 @@ def _build_translation_helps_messages(ref_label: str, context_obj: dict[str, obj
     """Construct the LLM messages for the translation helps prompt."""
     payload = json.dumps(context_obj, ensure_ascii=False)
     return [
+        {"role": "developer", "content": "Focus only on the portion of the user's message that asked for translation helps."},
         {"role": "developer", "content": f"Selection: {ref_label}"},
         {"role": "developer", "content": "Use the JSON context below strictly:"},
         {"role": "developer", "content": payload},
@@ -2596,6 +2597,7 @@ def handle_get_passage_summary(state: Any) -> dict:
 
     # Summarize using LLM with strict system prompt
     sum_messages: list[EasyInputMessageParam] = [
+        {"role": "developer", "content": "Focus only on summarizing the portion of the user's message that asked for a passage summary."},
         {"role": "developer", "content": f"Passage reference: {ref_label}"},
         {"role": "developer", "content": f"Passage verses (use only this content):\n{joined}"},
         {"role": "user", "content": "Provide a concise, faithful summary of the passage above."},

--- a/brain.py
+++ b/brain.py
@@ -1150,6 +1150,7 @@ class BrainState(TypedDict, total=False):
     passage_selection: list[dict]
     # Delivery hint for bt_servant to send a voice message instead of text
     send_voice_message: bool
+    voice_message_text: str
 
 
 # Centralized capability registry and builders for feature help/boilerplate
@@ -2973,6 +2974,13 @@ def handle_listen_to_scripture(state: Any) -> dict:
     """
     out = handle_retrieve_scripture(state)
     out["send_voice_message"] = True
+    responses = cast(list[dict], out.get("responses", []))
+    if responses:
+        # Reconstruct scripture text for voice playback using the structured response.
+        out["voice_message_text"] = _reconstruct_structured_text(
+            resp_item=responses[0],
+            localize_to=None,
+        )
     return out
 
 def handle_translate_scripture(state: Any) -> dict:  # pylint: disable=too-many-branches,too-many-return-statements

--- a/brain.py
+++ b/brain.py
@@ -1330,7 +1330,7 @@ def combine_responses(chat_history, latest_user_message, responses) -> str:
     return combined
 
 
-def translate_responses(state: Any) -> dict:
+def translate_responses(state: Any) -> dict:  # pylint: disable=too-many-locals
     """Translate the response(s) into the user's desired language if needed.
 
     Scripture-protected responses are not combined via LLM and are not machine-
@@ -1374,7 +1374,9 @@ def translate_responses(state: Any) -> dict:
     translated_responses: list[str] = []
     for resp in responses_for_translation:
         if isinstance(resp, str):
-            if detect_language(resp) != target_language:
+            sample = resp.lstrip()[:LANG_DETECTION_SAMPLE_CHARS]
+            detected_lang = detect_language(sample) if sample else target_language
+            if detected_lang != target_language:
                 logger.info('preparing to translate to %s', target_language)
                 translated_responses.append(translate_text(response_text=resp, target_language=target_language))
             else:
@@ -3081,3 +3083,4 @@ def create_brain():
     builder.set_finish_point("chunk_message_node")
 
     return builder.compile()
+LANG_DETECTION_SAMPLE_CHARS = 100

--- a/brain.py
+++ b/brain.py
@@ -1714,7 +1714,7 @@ def detect_language(text: str, *, agentic_strength: Optional[str] = None) -> str
         strength = "normal"
     model_name = _model_for_agentic_strength(strength, allow_low=True, allow_very_low=True)
     response = open_ai_client.responses.parse(
-        model=model_name,
+        model="gpt-4o",
         instructions=DETECT_LANGUAGE_AGENT_SYSTEM_PROMPT,
         input=cast(Any, messages),
         text_format=MessageLanguage,

--- a/brain.py
+++ b/brain.py
@@ -913,16 +913,6 @@ def _build_translation_queue(
     return queue
 
 
-def _focus_translation_helps_query(query: str) -> str:
-    """Heuristically focus the clause that requests translation helps."""
-    lowered = query.lower()
-    keywords = ["translation", "translate", "translating", "help"]
-    focus_start = max((lowered.rfind(word) for word in keywords), default=-1)
-    if focus_start == -1:
-        return query
-    return query[focus_start:]
-
-
 def _resolve_target_language(
     state: BrainState,
     responses_for_translation: list[dict | str],
@@ -2726,9 +2716,7 @@ def handle_get_translation_helps(state: Any) -> dict:
     bsb_root = Path("sources") / "bible_data" / "en" / "bsb"
     logger.info("[translation-helps] loading helps from %s", th_root)
 
-    focused_query = _focus_translation_helps_query(query)
-    state_with_focus = cast(BrainState, dict(s, transformed_query=focused_query))
-    canonical_book, ranges, raw_helps, err = _prepare_translation_helps(state_with_focus, th_root, bsb_root)
+    canonical_book, ranges, raw_helps, err = _prepare_translation_helps(s, th_root, bsb_root)
     if err:
         return {"responses": [{"intent": IntentType.GET_TRANSLATION_HELPS, "response": err}]}
     assert canonical_book is not None and ranges is not None and raw_helps is not None

--- a/brain.py
+++ b/brain.py
@@ -1895,6 +1895,10 @@ def query_open_ai(state: Any) -> dict:
             },
             {
                 "role": "developer",
+                "content": "Focus only on the portion of the user's message requesting general Bible translation assistance.",
+            },
+            {
+                "role": "developer",
                 "content": chat_history_context_message
             },
             {
@@ -2038,6 +2042,10 @@ def consult_fia_resources(state: Any) -> dict:  # pylint: disable=too-many-local
         {
             "role": "developer",
             "content": f"FIA context resources: {context_payload}",
+        },
+        {
+            "role": "developer",
+            "content": "Focus only on the portion of the user's message that requests FIA guidance.",
         },
         {
             "role": "developer",

--- a/bt_servant.py
+++ b/bt_servant.py
@@ -96,7 +96,7 @@ def _compute_agentic_strengths(user_id: str) -> tuple[str, Optional[str]]:
     """Return effective agentic strength and stored user preference (if any)."""
     user_strength = get_user_agentic_strength(user_id=user_id)
     system_strength = str(config.AGENTIC_STRENGTH).lower()
-    if system_strength not in {"normal", "low"}:
+    if system_strength not in {"normal", "low", "very_low"}:
         system_strength = "normal"
     effective = user_strength or system_strength
     return effective, user_strength

--- a/bt_servant.py
+++ b/bt_servant.py
@@ -1079,6 +1079,10 @@ async def process_message(user_message: UserMessage):  # pylint: disable=too-man
                     # Preserve legacy behavior for audio conversations without explicit voice payloads
                     should_send_text = False
 
+                if voice_text:
+                    normalized_voice = voice_text.strip()
+                    responses = [r for r in responses if r.strip() != normalized_voice]
+
                 if should_send_text and responses:
                     response_count = len(responses)
                     formatted_responses = list(responses)

--- a/bt_servant.py
+++ b/bt_servant.py
@@ -1079,10 +1079,6 @@ async def process_message(user_message: UserMessage):  # pylint: disable=too-man
                     # Preserve legacy behavior for audio conversations without explicit voice payloads
                     should_send_text = False
 
-                if voice_text:
-                    normalized_voice = voice_text.strip()
-                    responses = [r for r in responses if r.strip() != normalized_voice]
-
                 if should_send_text and responses:
                     response_count = len(responses)
                     formatted_responses = list(responses)

--- a/config.py
+++ b/config.py
@@ -40,7 +40,7 @@ class Config(BaseSettings):
     # Enable admin auth for protected endpoints (default False for local/dev tests)
     ENABLE_ADMIN_AUTH: bool = Field(default=True)
     # Tuning knob for LLM creativity/agency (normal | low)
-    AGENTIC_STRENGTH: Literal["normal", "low"] = Field(default="normal")
+    AGENTIC_STRENGTH: Literal["normal", "low", "very_low"] = Field(default="normal")
 
     # Optional with default value
     DATA_DIR: Path = Field(default=Path("/data"))

--- a/config.py
+++ b/config.py
@@ -40,7 +40,7 @@ class Config(BaseSettings):
     # Enable admin auth for protected endpoints (default False for local/dev tests)
     ENABLE_ADMIN_AUTH: bool = Field(default=True)
     # Tuning knob for LLM creativity/agency (normal | low)
-    AGENTIC_STRENGTH: Literal["normal", "low", "very_low"] = Field(default="very_low")
+    AGENTIC_STRENGTH: Literal["normal", "low", "very_low"] = Field(default="low")
 
     # Optional with default value
     DATA_DIR: Path = Field(default=Path("/data"))

--- a/config.py
+++ b/config.py
@@ -4,6 +4,7 @@ Loads values from environment (and optional .env) with typed fields.
 """
 import os
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -38,6 +39,8 @@ class Config(BaseSettings):
     HEALTHCHECK_API_TOKEN: str | None = Field(default=None)
     # Enable admin auth for protected endpoints (default False for local/dev tests)
     ENABLE_ADMIN_AUTH: bool = Field(default=True)
+    # Tuning knob for LLM creativity/agency (normal | low)
+    AGENTIC_STRENGTH: Literal["normal", "low"] = Field(default="normal")
 
     # Optional with default value
     DATA_DIR: Path = Field(default=Path("/data"))

--- a/config.py
+++ b/config.py
@@ -50,6 +50,8 @@ class Config(BaseSettings):
             '{'
             '"gpt-4o": {"input_per_million": 2.5, '
             '"output_per_million": 10.0, "cached_input": 1.25}, '
+            '"gpt-4o-mini": {"input_per_million": 0.15, '
+            '"output_per_million": 0.6}, '
             '"gpt-4o-transcribe": {"input_per_million": 2.5, '
             '"output_per_million": 10.0, '
             '"audio_input_per_million": 6.0}, '

--- a/config.py
+++ b/config.py
@@ -28,7 +28,7 @@ class Config(BaseSettings):
     BT_SERVANT_LOG_LEVEL: str = Field(default="info")
     MAX_META_TEXT_LENGTH: int = Field(default=4096)
     # Max verses to include in get-translation-helps context to control token usage
-    TRANSLATION_HELPS_VERSE_LIMIT: int = Field(default=10)
+    TRANSLATION_HELPS_VERSE_LIMIT: int = Field(default=5)
     # Max verses allowed for retrieve-scripture (prevents huge selections like an entire book)
     RETRIEVE_SCRIPTURE_VERSE_LIMIT: int = Field(default=120)
     # Max verses allowed for translate-scripture (avoid very large translations)

--- a/config.py
+++ b/config.py
@@ -40,7 +40,7 @@ class Config(BaseSettings):
     # Enable admin auth for protected endpoints (default False for local/dev tests)
     ENABLE_ADMIN_AUTH: bool = Field(default=True)
     # Tuning knob for LLM creativity/agency (normal | low)
-    AGENTIC_STRENGTH: Literal["normal", "low", "very_low"] = Field(default="normal")
+    AGENTIC_STRENGTH: Literal["normal", "low", "very_low"] = Field(default="very_low")
 
     # Optional with default value
     DATA_DIR: Path = Field(default=Path("/data"))

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -23,6 +23,8 @@ from .user import (
     update_user_chat_history,
     get_user_response_language,
     set_user_response_language,
+    get_user_agentic_strength,
+    set_user_agentic_strength,
     set_first_interaction,
     is_first_interaction
 )
@@ -31,6 +33,8 @@ __all__ = [
     "update_user_chat_history",
     "get_user_response_language",
     "set_user_response_language",
+    "get_user_agentic_strength",
+    "set_user_agentic_strength",
     "set_first_interaction",
     "is_first_interaction",
     "get_or_create_chroma_collection",

--- a/db/user.py
+++ b/db/user.py
@@ -12,7 +12,7 @@ else:
 
 # NOTE: consider moving to configuration if needed.
 CHAT_HISTORY_MAX = 5
-VALID_AGENTIC_STRENGTH = {"normal", "low"}
+VALID_AGENTIC_STRENGTH = {"normal", "low", "very_low"}
 
 
 def get_user_chat_history(user_id: str) -> List[Dict[str, str]]:

--- a/db/user.py
+++ b/db/user.py
@@ -12,6 +12,7 @@ else:
 
 # NOTE: consider moving to configuration if needed.
 CHAT_HISTORY_MAX = 5
+VALID_AGENTIC_STRENGTH = {"normal", "low"}
 
 
 def get_user_chat_history(user_id: str) -> List[Dict[str, str]]:
@@ -64,6 +65,36 @@ def set_user_response_language(user_id: str, language: str) -> None:
     )
 
     updated["response_language"] = language
+    db.upsert(updated, cond)
+
+
+def get_user_agentic_strength(user_id: str) -> Optional[str]:
+    """Get the user's preferred agentic strength, or None if not set."""
+    q = Query()
+    cond = cast(QueryLike, q.user_id == user_id)
+    raw = get_user_db().table("users").get(cond)
+    result = cast(Optional[Dict[str, Any]], raw)
+    strength = result.get("agentic_strength") if result else None
+    if isinstance(strength, str) and strength in VALID_AGENTIC_STRENGTH:
+        return strength
+    return None
+
+
+def set_user_agentic_strength(user_id: str, strength: str) -> None:
+    """Persist the user's preferred agentic strength level."""
+    normalized = strength.strip().lower()
+    if normalized not in VALID_AGENTIC_STRENGTH:
+        raise ValueError(f"invalid agentic strength: {strength}")
+
+    q = Query()
+    db = get_user_db().table("users")
+    cond = cast(QueryLike, q.user_id == user_id)
+    existing_raw = db.get(cond)
+    existing = cast(Optional[Dict[str, Any]], existing_raw)
+    updated: Dict[str, Any] = (
+        existing.copy() if isinstance(existing, dict) else {"user_id": user_id}
+    )
+    updated["agentic_strength"] = normalized
     db.upsert(updated, cond)
 
 

--- a/env.example
+++ b/env.example
@@ -32,3 +32,6 @@ META_SANDBOX_PHONE_NUMBER=14438677777
 ENABLE_ADMIN_AUTH=False
 ADMIN_API_TOKEN=change-me-for-admin
 HEALTHCHECK_API_TOKEN=change-me-for-health
+
+# Agentic creativity tuning for LLM calls (normal | low)
+AGENTIC_STRENGTH=normal

--- a/tests/test_agentic_strength.py
+++ b/tests/test_agentic_strength.py
@@ -78,5 +78,5 @@ def test_set_agentic_strength_handles_unknown(monkeypatch: pytest.MonkeyPatch) -
     out = brain.set_agentic_strength(cast(Any, state))
 
     assert not called, "should not persist an unknown preference"
-    assert "normal or low" in out["responses"][0]["response"]
+    assert "normal, low, or very low" in out["responses"][0]["response"]
     assert "agentic_strength" not in out

--- a/tests/test_agentic_strength.py
+++ b/tests/test_agentic_strength.py
@@ -1,0 +1,82 @@
+"""Tests for agentic strength preference handling."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+import brain
+
+
+class _StubResponse:  # pylint: disable=too-few-public-methods
+    """Simple container matching the subset of Response fields we use."""
+
+    def __init__(self, parsed: brain.AgenticStrengthSetting) -> None:
+        self.output_parsed = parsed
+        self.usage = None
+
+
+def test_set_agentic_strength_persists_choice(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the user asks for a valid level, it is stored and echoed."""
+
+    parsed = brain.AgenticStrengthSetting(strength=brain.AgenticStrengthChoice.LOW)
+    monkeypatch.setattr(
+        brain.open_ai_client.responses,
+        "parse",
+        lambda **_kwargs: _StubResponse(parsed),
+    )
+
+    captured: dict[str, Any] = {}
+
+    def _fake_set(user_id: str, strength: str) -> None:  # noqa: D401
+        captured["user_id"] = user_id
+        captured["strength"] = strength
+
+    monkeypatch.setattr(brain, "set_user_agentic_strength", _fake_set)
+
+    state: dict[str, Any] = {
+        "user_id": "user-123",
+        "user_query": "set my agentic strength to low",
+        "user_chat_history": [],
+    }
+
+    out = brain.set_agentic_strength(cast(Any, state))
+
+    assert captured == {"user_id": "user-123", "strength": "low"}
+    assert out.get("agentic_strength") == "low"
+    assert out.get("user_agentic_strength") == "low"
+    response_text = out["responses"][0]["response"]
+    assert "agentic strength set to" in response_text.lower()
+    assert "low" in response_text.lower()
+
+
+def test_set_agentic_strength_handles_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the LLM can't find a valid level, prompt the user again."""
+
+    parsed = brain.AgenticStrengthSetting(strength=brain.AgenticStrengthChoice.UNKNOWN)
+    monkeypatch.setattr(
+        brain.open_ai_client.responses,
+        "parse",
+        lambda **_kwargs: _StubResponse(parsed),
+    )
+
+    called = False
+
+    def _fail_set(*_args: Any, **_kwargs: Any) -> None:  # noqa: ANN401
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(brain, "set_user_agentic_strength", _fail_set)
+
+    state: dict[str, Any] = {
+        "user_id": "user-456",
+        "user_query": "make it stronger",
+        "user_chat_history": [],
+    }
+
+    out = brain.set_agentic_strength(cast(Any, state))
+
+    assert not called, "should not persist an unknown preference"
+    assert "normal or low" in out["responses"][0]["response"]
+    assert "agentic_strength" not in out

--- a/tests/test_consult_fia_resources.py
+++ b/tests/test_consult_fia_resources.py
@@ -47,6 +47,7 @@ def test_consult_fia_resources_falls_back_to_english(monkeypatch: pytest.MonkeyP
 
     def _fake_create(**kwargs: Any) -> Any:  # noqa: ANN401
         captured_messages["input"] = kwargs["input"]
+        captured_messages["model"] = kwargs.get("model")
         return _FakeResponse()
 
     monkeypatch.setattr(brain, "get_chroma_collection", _fake_get_collection)
@@ -58,6 +59,7 @@ def test_consult_fia_resources_falls_back_to_english(monkeypatch: pytest.MonkeyP
         "user_chat_history": [],
         "user_response_language": "es",
         "query_language": "es",
+        "agentic_strength": "low",
     }
 
     out = brain.consult_fia_resources(cast(Any, state))
@@ -65,10 +67,48 @@ def test_consult_fia_resources_falls_back_to_english(monkeypatch: pytest.MonkeyP
     assert out["responses"][0]["intent"] == brain.IntentType.CONSULT_FIA_RESOURCES
     assert out.get("collection_used") == "en_fia_resources"
 
+    assert captured_messages.get("model") == "gpt-4o-mini"
+
     # Ensure the FIA manual and vector doc both reached the prompt payload
     payload = captured_messages["input"][0]["content"]
     assert "FIA manual reference text" in payload
     assert "English FIA doc" in payload
+
+
+def test_consult_fia_resources_uses_normal_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defaults to gpt-4o when agentic strength remains normal."""
+
+    class _FakeResponse:  # pylint: disable=too-few-public-methods
+        usage = None
+        output_text = "fia guidance"
+
+    captured: dict[str, Any] = {}
+
+    def _fake_create(**kwargs: Any) -> Any:  # noqa: ANN401
+        captured["model"] = kwargs.get("model")
+        return _FakeResponse()
+
+    def _fake_get_collection(_name: str) -> _FakeCollection:
+        return _FakeCollection([
+            ("Localized", 0.2, {"name": "Localized", "source": "fia/local.md"}),
+        ])
+
+    monkeypatch.setattr(brain, "get_chroma_collection", _fake_get_collection)
+    monkeypatch.setattr(brain.open_ai_client.responses, "create", _fake_create)
+    monkeypatch.setattr(brain, "FIA_REFERENCE_CONTENT", "reference body")
+
+    state: dict[str, Any] = {
+        "transformed_query": "Explain FIA step 3",
+        "user_chat_history": [],
+        "user_response_language": "en",
+        "query_language": "en",
+        "agentic_strength": "normal",
+    }
+
+    out = brain.consult_fia_resources(cast(Any, state))
+
+    assert out["responses"], "expected consult FIA response"
+    assert captured.get("model") == "gpt-4o"
 
 
 def test_consult_fia_resources_handles_missing_context(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_perf_coverage_llm_calls.py
+++ b/tests/test_perf_coverage_llm_calls.py
@@ -154,7 +154,7 @@ def test_translate_responses_span_has_tokens(monkeypatch: pytest.MonkeyPatch) ->
         return _FakeChat()
 
     # Force translation by reporting response language != target language
-    monkeypatch.setattr(brain, "detect_language", lambda _t: "en")
+    monkeypatch.setattr(brain, "detect_language", lambda _t, **_k: "en")
     monkeypatch.setattr(brain.open_ai_client.responses, "create", _fake_resp_create)
     monkeypatch.setattr(brain.open_ai_client.chat.completions, "create", _fake_chat_create)
 


### PR DESCRIPTION
- **(CODEX) Add agentic strength tuning and intent**
- **(CODEX) Add gpt-4o-mini default pricing**
- **(CODEX) Cap language detection payload**
- **(CODEX) Avoid truncating detection sample mid-word**
- **(CODEX) Respect agentic strength for language detection**
- **(CODEX) Refine translation response flow**
- **(CODEX) Slim translation helps payload**
- **(CODEX) Refactor translation helps handler**
- **(CODEX) Expand agentic strength handling**
- **(CODEX) Default agentic strength to very low**
- **(CODEX) Default agentic strength to low**
- **(CODEX) Prevent combining of summary/keyword helps**
- **(CODEX) Keep voice replies aligned with translation flow**
- **(CODEX) Refine listen flow voice handling**
- **Revert "(CODEX) Refine listen flow voice handling"**
- **(CODEX) Document approach confirmation step**
- **(CODEX) Clarify intent scope via prompts**
- **(CODEX) Focus prompts on intent-specific clauses**
- **(CODEX) Scope passage selection per intent**
- **(CODEX) Silence text output for listen flow**
- **(CODEX) Focus passage parsing and keep translation helps separate**
- **(CODEX) Reinforce LLM focus without keyword fallbacks**
- **Use gpt-4o for lang detection**
