### PR TITLE
Phase 1: add architecture guardrails

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -16,6 +16,7 @@ jobs:
       RUN_OPENAI_API_TESTS: "1"
       BASE_URL: "https://example.invalid"
       FACEBOOK_USER_AGENT: "facebookexternalua"
+      LOG_PSEUDONYM_SECRET: ${{ secrets.LOG_PSEUDONYM_SECRET }}
       META_APP_SECRET: "testsecret"
       META_VERIFY_TOKEN: "verifytoken"
       META_WHATSAPP_TOKEN: "whatsapptoken"

--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -25,6 +25,9 @@ jobs:
       META_SANDBOX_PHONE_NUMBER: "15555555555"
       BT_SERVANT_LOG_LEVEL: "info"
       DATA_DIR: "./data"
+      ENABLE_ADMIN_AUTH: "False"
+      ADMIN_API_TOKEN: "admin-token"
+      HEALTHCHECK_API_TOKEN: "health-token"
     steps:
       - name: Checkout merge commit
         uses: actions/checkout@v4

--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -40,12 +40,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest ruff pylint mypy pyright
+          pip install pytest pytest-cov ruff pylint mypy pyright import-linter bandit pip-audit deptry
 
       - name: Ensure data dir
         run: mkdir -p data
 
-      - name: Ruff
+      - name: Ruff (format check)
+        run: ruff format --check bt_servant_engine
+
+      - name: Ruff (lint)
         run: ruff check .
 
       - name: Pylint
@@ -57,5 +60,17 @@ jobs:
       - name: Pyright
         run: pyright
 
-      - name: Pytest (full, includes OpenAI tests)
-        run: pytest -vv -r a -s --log-cli-level=INFO --durations=20
+      - name: Import Linter
+        run: lint-imports
+
+      - name: Bandit
+        run: bandit -q -r bt_servant_engine
+
+      - name: Pip Audit
+        run: pip-audit -r requirements.txt
+
+      - name: Deptry
+        run: deptry .
+
+      - name: Pytest (full, includes OpenAI tests + coverage)
+        run: pytest --maxfail=1 --disable-warnings -q --cov=bt_servant_engine --cov-report=term-missing --cov-fail-under=70

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -40,12 +40,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest ruff pylint mypy pyright
+          pip install pytest pytest-cov ruff pylint mypy pyright import-linter bandit pip-audit deptry
 
       - name: Ensure data dir
         run: mkdir -p data
 
-      - name: Ruff
+      - name: Ruff (format check)
+        run: ruff format --check bt_servant_engine
+
+      - name: Ruff (lint)
         run: ruff check .
 
       - name: Pylint
@@ -57,5 +60,17 @@ jobs:
       - name: Pyright
         run: pyright
 
-      - name: Pytest (full, includes OpenAI tests)
-        run: pytest -vv -r a -s --log-cli-level=INFO --durations=20
+      - name: Import Linter
+        run: lint-imports
+
+      - name: Bandit
+        run: bandit -q -r bt_servant_engine
+
+      - name: Pip Audit
+        run: pip-audit -r requirements.txt
+
+      - name: Deptry
+        run: deptry .
+
+      - name: Pytest (full, includes OpenAI tests + coverage)
+        run: pytest --maxfail=1 --disable-warnings -q --cov=bt_servant_engine --cov-report=term-missing --cov-fail-under=70

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -18,6 +18,7 @@ jobs:
       # Required config envs (safe defaults for tests)
       BASE_URL: "https://example.invalid"
       FACEBOOK_USER_AGENT: "facebookexternalua"
+      LOG_PSEUDONYM_SECRET: ${{ secrets.LOG_PSEUDONYM_SECRET }}
       META_APP_SECRET: "testsecret"
       META_VERIFY_TOKEN: "verifytoken"
       META_WHATSAPP_TOKEN: "whatsapptoken"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -27,6 +27,9 @@ jobs:
       META_SANDBOX_PHONE_NUMBER: "15555555555"
       BT_SERVANT_LOG_LEVEL: "info"
       DATA_DIR: "./data"
+      ENABLE_ADMIN_AUTH: "False"
+      ADMIN_API_TOKEN: "admin-token"
+      HEALTHCHECK_API_TOKEN: "health-token"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,29 @@
+[importlinter]
+root_package = bt_servant_engine
+
+[contract:layers]
+name = Onion layering (strict)
+type = layers
+layers =
+    bt_servant_engine.apps.api
+    bt_servant_engine.adapters
+    bt_servant_engine.services.intents
+    bt_servant_engine.services
+    bt_servant_engine.core
+
+[contract:no_api_to_adapters]
+name = Routes must not import adapters directly
+type = forbidden
+source_modules =
+    bt_servant_engine.apps.api
+forbidden_modules =
+    bt_servant_engine.adapters
+
+[contract:no_services_to_adapters]
+name = Services must not import adapters
+type = forbidden
+source_modules =
+    bt_servant_engine.services
+    bt_servant_engine.services.intents
+forbidden_modules =
+    bt_servant_engine.adapters

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,82 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-lint
+        name: ruff (lint)
+        entry: ruff check .
+        language: system
+        pass_filenames: false
+        stages: [commit]
+
+      - id: ruff-format
+        name: ruff (format)
+        entry: ruff format --check bt_servant_engine
+        language: system
+        pass_filenames: false
+        stages: [commit]
+
+      - id: mypy
+        name: mypy (types)
+        entry: mypy .
+        language: system
+        pass_filenames: false
+        stages: [commit]
+
+      - id: pyright
+        name: pyright (types)
+        entry: pyright
+        language: system
+        pass_filenames: false
+        stages: [commit]
+
+      - id: import-linter
+        name: import-linter (onion architecture)
+        entry: lint-imports
+        language: system
+        pass_filenames: false
+        stages: [commit]
+
+      - id: bandit
+        name: bandit (security)
+        entry: bandit -q -r bt_servant_engine
+        language: system
+        pass_filenames: false
+        stages: [push]
+
+      - id: pip-audit
+        name: pip-audit (supply chain)
+        entry: pip-audit
+        language: system
+        pass_filenames: false
+        stages: [push]
+
+      - id: deptry
+        name: deptry (dependency hygiene)
+        entry: deptry .
+        language: system
+        pass_filenames: false
+        stages: [push]
+
+      - id: pytest
+        name: pytest (with coverage threshold)
+        entry: >-
+          bash -lc '
+            export OPENAI_API_KEY="${OPENAI_API_KEY:-sk-test}" \
+              META_VERIFY_TOKEN="${META_VERIFY_TOKEN:-verifytoken}" \
+              META_WHATSAPP_TOKEN="${META_WHATSAPP_TOKEN:-whatsapptoken}" \
+              META_PHONE_NUMBER_ID="${META_PHONE_NUMBER_ID:-1234567890}" \
+              META_APP_SECRET="${META_APP_SECRET:-metasecret}" \
+              LOG_PSEUDONYM_SECRET="${LOG_PSEUDONYM_SECRET:-test-secret}" \
+              FACEBOOK_USER_AGENT="${FACEBOOK_USER_AGENT:-facebookexternalua}" \
+              BASE_URL="${BASE_URL:-https://example.invalid}" \
+              META_SANDBOX_PHONE_NUMBER="${META_SANDBOX_PHONE_NUMBER:-15555555555}" \
+              DATA_DIR="${DATA_DIR:-./data}" \
+              ENABLE_ADMIN_AUTH="${ENABLE_ADMIN_AUTH:-False}" \
+              ADMIN_API_TOKEN="${ADMIN_API_TOKEN:-admin-token}" \
+              HEALTHCHECK_API_TOKEN="${HEALTHCHECK_API_TOKEN:-health-token}"
+            mkdir -p "$DATA_DIR"
+            pytest --maxfail=1 --disable-warnings -q -m "not openai" --cov=bt_servant_engine --cov-report=term-missing --cov-fail-under=70
+          '
+        language: system
+        pass_filenames: false
+        stages: [push]

--- a/brain.py
+++ b/brain.py
@@ -1549,7 +1549,7 @@ def set_agentic_strength(state: Any) -> dict:
     try:
         set_user_agentic_strength(user_id, desired)
     except ValueError:
-        masked_user_id = get_log_safe_user_id(user_id)
+        masked_user_id = get_log_safe_user_id(user_id, secret=config.LOG_PSEUDONYM_SECRET)
         logger.warning("[agentic-strength] Attempted to set invalid value '%s' for user %s", desired, masked_user_id)
         msg = (
             "That setting isn't supported. I can only use normal, low, or very low for agentic strength."

--- a/bt_servant.py
+++ b/bt_servant.py
@@ -973,7 +973,7 @@ async def handle_meta_webhook(  # pylint: disable=too-many-nested-blocks,too-man
                             end=_sig_t1,
                             trace_id=user_message.message_id,
                         )
-                        log_user_id = get_log_safe_user_id(user_message.user_id)
+                        log_user_id = get_log_safe_user_id(user_message.user_id, secret=config.LOG_PSEUDONYM_SECRET)
                         logger.info("%s message from %s with id %s and timestamp %s received.",
                                     user_message.message_type, log_user_id, user_message.message_id,
                                     user_message.timestamp)
@@ -1025,7 +1025,7 @@ async def handle_meta_webhook(  # pylint: disable=too-many-nested-blocks,too-man
 async def process_message(user_message: UserMessage):  # pylint: disable=too-many-branches,too-many-locals,too-many-statements
     """Serialize user processing per user id and send responses back."""
     async with user_locks[user_message.user_id]:
-        log_user_id = get_log_safe_user_id(user_message.user_id)
+        log_user_id = get_log_safe_user_id(user_message.user_id, secret=config.LOG_PSEUDONYM_SECRET)
         start_time = time.time()
         # ensure all spans produced in this coroutine are associated to this message
         set_current_trace(user_message.message_id)

--- a/bt_servant_engine/__init__.py
+++ b/bt_servant_engine/__init__.py
@@ -1,0 +1,1 @@
+"""Core package placeholder for upcoming onion architecture refactor."""

--- a/bt_servant_engine/adapters/__init__.py
+++ b/bt_servant_engine/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure adapter layer placeholder."""

--- a/bt_servant_engine/apps/__init__.py
+++ b/bt_servant_engine/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Application delivery layer package (created during refactor bootstrap)."""

--- a/bt_servant_engine/apps/api/__init__.py
+++ b/bt_servant_engine/apps/api/__init__.py
@@ -1,0 +1,1 @@
+"""API delivery subpackage placeholder."""

--- a/bt_servant_engine/apps/api/routes/__init__.py
+++ b/bt_servant_engine/apps/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API route module namespace for upcoming FastAPI routers."""

--- a/bt_servant_engine/core/__init__.py
+++ b/bt_servant_engine/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core domain and port definitions placeholder."""

--- a/bt_servant_engine/services/__init__.py
+++ b/bt_servant_engine/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application service layer placeholder."""

--- a/bt_servant_engine/services/intents/__init__.py
+++ b/bt_servant_engine/services/intents/__init__.py
@@ -1,0 +1,1 @@
+"""Intent-specific service implementations placeholder."""

--- a/messaging.py
+++ b/messaging.py
@@ -55,7 +55,7 @@ async def send_text_message(user_id: str, text: str) -> None:
         "type": "text",
         "text": {"body": text}
     }
-    log_user_id = get_log_safe_user_id(user_id)
+    log_user_id = get_log_safe_user_id(user_id, secret=config.LOG_PSEUDONYM_SECRET)
     async with httpx.AsyncClient() as client:
         response = await client.post(url, headers=headers, json=payload)
         if response.status_code >= 400:
@@ -67,7 +67,7 @@ async def send_text_message(user_id: str, text: str) -> None:
 @record_timing("messaging:send_voice_message")
 async def send_voice_message(user_id: str, text: str) -> None:
     """Synthesize `text` to speech and send as a WhatsApp audio message."""
-    log_user_id = get_log_safe_user_id(user_id)
+    log_user_id = get_log_safe_user_id(user_id, secret=config.LOG_PSEUDONYM_SECRET)
     loop = asyncio.get_running_loop()
     path_to_voice_message = await loop.run_in_executor(None, _create_voice_message, user_id, text)
     try:
@@ -201,7 +201,7 @@ def _create_voice_message(user_id: str, text: str) -> str:
 
     # Create a safe temp file with .mp3 suffix (timezone-aware UTC)
     timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y%m%dT%H%M%S")
-    masked_user_id = get_log_safe_user_id(user_id)
+    masked_user_id = get_log_safe_user_id(user_id, secret=config.LOG_PSEUDONYM_SECRET)
     filename = f"response_{masked_user_id}_{timestamp}.mp3"
     temp_audio_path = os.path.join(tempfile.gettempdir(), filename)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,83 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bt-servant-engine"
+version = "0.1.0"
+description = "BT Servant Engine — strict onion/hexagonal refactor baseline"
+readme = "README.md"
+requires-python = ">=3.12"
+authors = [{ name = "unfoldingWord", email = "info@unfoldingword.org" }]
+license = { text = "MIT" }
+dependencies = [
+  "fastapi>=0.116",
+  "uvicorn>=0.30",
+  "pydantic>=2.7",
+  "pydantic-settings>=2.3",
+  "openai>=1.76",
+  "httpx>=0.28",
+  "langgraph>=0.5",
+  "chromadb>=1.0",
+  "tinydb>=4.8",
+  "typing-extensions>=4.12",
+]
+
+[project.optional-dependencies]
+dev = [
+  "python-dotenv>=1.0",
+  "ruff>=0.4",
+  "mypy>=1.10",
+  "pyright>=1.1",
+  "pytest>=8.2",
+  "pytest-cov>=5.0",
+  "bandit>=1.7",
+  "pip-audit>=2.7",
+  "deptry>=0.16",
+  "import-linter>=2.0",
+  "pre-commit>=3.8",
+  "typing-extensions>=4.12",
+]
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
-# Keep default core rules and add DTZ; ignore E501 (long lines) because
-# prompt constants intentionally exceed the limit and are hard-wrapped elsewhere.
 select = ["E", "F", "W", "B", "DTZ"]
+# Allow long prompt strings and whitespace artifacts that are intentionally preserved.
 ignore = ["E501", "W291", "W293"]
+
+[tool.ruff.lint.pylint]
+max-statements = 50   # PLR0915
+max-branches  = 12    # PLR0912
+max-returns   = 6     # PLR0911
+max-args      = 5     # PLR0913
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10   # C901
+
+[tool.mypy]
+python_version = "3.12"
+warn_unused_configs = true
+pretty = true
+
+[tool.pyright]
+pythonVersion = "3.12"
+typeCheckingMode = "strict"
+reportMissingTypeStubs = false
+
+[tool.pytest.ini_options]
+addopts = "-q --maxfail=1 --disable-warnings -m 'not openai'"
+testpaths = ["tests"]
+
+[tool.deptry]
+ignore_notebooks = true
+exclude = ["venv", ".venv", "build", "dist", "tests"]
+known_first_party = ["bt_servant_engine"]
+pep621_dev_dependency_groups = ["dev"]
+# Uvicorn is invoked via CLI entrypoint rather than imported.
+[tool.deptry.per_rule_ignores]
+DEP002 = ["uvicorn"]
+# Add more per-rule ignores here as needed, e.g.:
+# # DEP001 = ["typing-extensions"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ pytest
 aenum==3.1.16
 aiofiles==24.1.0
 aiohappyeyeballs==2.6.1
-aiohttp==3.11.18
+aiohttp==3.12.14
 aiohttp-retry==2.9.1
-aiosignal==1.3.2
+aiosignal==1.4.0
 annotated-types==0.7.0
 anyio==4.9.0
 asgiref==3.8.1

--- a/scripts/check_repo.sh
+++ b/scripts/check_repo.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run full repo checks: ruff, pylint, mypy, and test suite.
+# Run full repo checks: format, lint, type, security, deps, and tests.
 # Usage: scripts/check_repo.sh
 
 RED=\033[31m
@@ -16,6 +16,9 @@ if [[ -f .venv/bin/activate ]]; then
   # shellcheck disable=SC1091
   source .venv/bin/activate
 fi
+
+echo -e "${YLW}Running ruff format (check only)...${RST}"
+ruff format --check bt_servant_engine
 
 echo -e "${YLW}Running ruff on repo...${RST}"
 ruff check .
@@ -34,8 +37,51 @@ else
   exit 1
 fi
 
-echo -e "${YLW}Running tests (pytest -q -m 'not openai')...${RST}"
+echo -e "${YLW}Running import linter (lint-imports)...${RST}"
+if command -v lint-imports >/dev/null 2>&1; then
+  lint-imports
+else
+  echo -e "${RED}lint-imports not found in PATH. Install with: pip install import-linter${RST}"
+  exit 1
+fi
+
+echo -e "${YLW}Running bandit (security scan)...${RST}"
+bandit -q -r bt_servant_engine
+
+echo -e "${YLW}Running pip-audit (supply chain)...${RST}"
+if command -v pip-audit >/dev/null 2>&1; then
+  pip-audit -r requirements.txt
+else
+  echo -e "${RED}pip-audit not found in PATH. Install with: pip install pip-audit${RST}"
+  exit 1
+fi
+
+echo -e "${YLW}Running deptry (dependency hygiene)...${RST}"
+if command -v deptry >/dev/null 2>&1; then
+  deptry .
+else
+  echo -e "${RED}deptry not found in PATH. Install with: pip install deptry${RST}"
+  exit 1
+fi
+
+echo -e "${YLW}Running tests (pytest with coverage)...${RST}"
+# Provide required environment defaults for settings validation.
+export OPENAI_API_KEY="${OPENAI_API_KEY:-sk-test}" \
+  META_VERIFY_TOKEN="${META_VERIFY_TOKEN:-verifytoken}" \
+  META_WHATSAPP_TOKEN="${META_WHATSAPP_TOKEN:-whatsapptoken}" \
+  META_PHONE_NUMBER_ID="${META_PHONE_NUMBER_ID:-1234567890}" \
+  META_APP_SECRET="${META_APP_SECRET:-metasecret}" \
+  LOG_PSEUDONYM_SECRET="${LOG_PSEUDONYM_SECRET:-test-secret}" \
+  FACEBOOK_USER_AGENT="${FACEBOOK_USER_AGENT:-facebookexternalua}" \
+  BASE_URL="${BASE_URL:-https://example.invalid}" \
+  META_SANDBOX_PHONE_NUMBER="${META_SANDBOX_PHONE_NUMBER:-15555555555}" \
+  DATA_DIR="${DATA_DIR:-./data}" \
+  ENABLE_ADMIN_AUTH="${ENABLE_ADMIN_AUTH:-False}" \
+  ADMIN_API_TOKEN="${ADMIN_API_TOKEN:-admin-token}" \
+  HEALTHCHECK_API_TOKEN="${HEALTHCHECK_API_TOKEN:-health-token}"
+mkdir -p "${DATA_DIR}"
 # Exclude OpenAI-costly tests by default; run them on-demand only.
-pytest -q -m "not openai"
+pytest --maxfail=1 --disable-warnings -q -m "not openai" \
+  --cov=bt_servant_engine --cov-report=term-missing --cov-fail-under=70
 
 echo -e "${GRN}Repo checks and tests passed.${RST}"

--- a/scripts/init_env.sh
+++ b/scripts/init_env.sh
@@ -31,8 +31,7 @@ fi
 echo "[init_env] Installing runtime requirements from $REQ_TO_USE" >&2
 pip install -r "$REQ_TO_USE"
 
-echo "[init_env] Installing dev tools (pytest, ruff, pylint, mypy, pyright)" >&2
-pip install pytest ruff pylint mypy pyright
+echo "[init_env] Installing dev tools (pytest, coverage, linting, security)" >&2
+pip install pytest pytest-cov ruff pylint mypy pyright bandit pip-audit deptry import-linter pre-commit
 
 echo "[init_env] Done. Activate with: source .venv/bin/activate" >&2
-

--- a/tests/test_chroma_merge.py
+++ b/tests/test_chroma_merge.py
@@ -136,13 +136,13 @@ def test_merge_create_new_id_with_tags_and_copy(fake_chroma):
     task_id = task["task_id"]
 
     # Poll for completion
-    for _ in range(250):
+    for _ in range(400):
         st = client.get(f"/chroma/merge-tasks/{task_id}")
         assert st.status_code == 200
         data = st.json()
         if data["status"] in ("completed", "failed"):
             break
-        time.sleep(0.02)
+        time.sleep(0.05)
     assert data["status"] == "completed"
     # Verify dest content and ids
     dst = fake_chroma.get_collection("dst")

--- a/tests/test_chroma_merge.py
+++ b/tests/test_chroma_merge.py
@@ -181,13 +181,13 @@ def test_cancel_merge(fake_chroma):
     assert cancel.status_code in (202, 409)
 
     # Wait for cancel to be acknowledged
-    for _ in range(50):
+    for _ in range(200):
         st = client.get(f"/chroma/merge-tasks/{task_id}")
         assert st.status_code == 200
         data = st.json()
         if data["status"] in ("cancelled", "completed", "failed"):
             break
-        time.sleep(0.02)
+        time.sleep(0.05)
     assert data["status"] in ("cancelled", "completed")
     # If cancelled, ensure partial progress
     if data["status"] == "cancelled":

--- a/tests/test_messaging_voice.py
+++ b/tests/test_messaging_voice.py
@@ -62,8 +62,9 @@ def test_create_voice_message_makes_file_and_returns_path(monkeypatch) -> None:
     # Arrange: stub the OpenAI client used by messaging and seed pseudonym secret
     monkeypatch.setattr(messaging, "open_ai_client", _FakeOpenAI(), raising=True)
     monkeypatch.setenv("LOG_PSEUDONYM_SECRET", "voice-test-secret")
+    monkeypatch.setattr(messaging.config, "LOG_PSEUDONYM_SECRET", "voice-test-secret", raising=True)
     clear_log_safe_user_cache()
-    masked_user = get_log_safe_user_id("user123")
+    masked_user = get_log_safe_user_id("user123", secret="voice-test-secret")
 
     # Act
     path = messaging._create_voice_message("user123", "hello there")


### PR DESCRIPTION
## Summary
- add `.importlinter` with strict onion contracts and placeholder packages for upcoming refactor
- wire `.pre-commit-config.yaml` and expand scripts/CI to run lint/type/security/deps/tests
- document expectations in `AGENTS.md` and bump `aiohttp`/`aiosignal` for pip-audit parity

## Testing
- scripts/check_repo.sh
