### PR TITLE
Add intent router scaffolding

### DIFF
--- a/bt_servant_engine/apps/api/app.py
+++ b/bt_servant_engine/apps/api/app.py
@@ -9,6 +9,8 @@ from fastapi import FastAPI
 
 from brain import create_brain
 from logger import get_logger
+from bt_servant_engine.services import build_default_services
+
 from .state import get_brain, set_brain
 
 logger = get_logger(__name__)
@@ -33,6 +35,7 @@ async def lifespan(_: FastAPI):
 def create_app() -> FastAPI:
     """Build the FastAPI application with configured routers."""
     app = FastAPI(lifespan=lifespan)
+    app.state.services = build_default_services()
 
     # Import lazily to avoid potential circular imports when routers grow.
     from .routes import admin, health, webhooks  # pylint: disable=import-outside-toplevel

--- a/bt_servant_engine/services/__init__.py
+++ b/bt_servant_engine/services/__init__.py
@@ -1,1 +1,37 @@
-"""Application service layer placeholder."""
+"""Application service layer scaffolding for intent handling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, TYPE_CHECKING
+
+
+if TYPE_CHECKING:  # pragma: no cover - type narrowing only
+    from .intent_router import IntentRouter
+
+
+@dataclass(slots=True)
+class ServiceContainer:
+    """Aggregate of application-level services available to handlers."""
+
+    intent_router: Optional["IntentRouter"] = None
+
+
+def build_default_services() -> ServiceContainer:
+    """Return a service container with the default intent router wiring."""
+
+    from brain import IntentType  # pylint: disable=import-outside-toplevel
+
+    from .intent_router import IntentRouter  # pylint: disable=import-outside-toplevel
+    from .intents.converse import (  # pylint: disable=import-outside-toplevel
+        handle_converse_intent,
+    )
+
+    container = ServiceContainer()
+    container.intent_router = IntentRouter(
+        {IntentType.CONVERSE_WITH_BT_SERVANT: handle_converse_intent}
+    )
+    return container
+
+
+__all__ = ["ServiceContainer", "build_default_services"]

--- a/bt_servant_engine/services/intent_router.py
+++ b/bt_servant_engine/services/intent_router.py
@@ -1,0 +1,94 @@
+"""Intent router and supporting request/response models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Mapping, MutableMapping, Sequence
+
+from brain import IntentType
+
+
+if TYPE_CHECKING:  # pragma: no cover - import for static analysis only
+    from . import ServiceContainer
+
+
+IntentPayload = dict[str, Any]
+
+
+@dataclass(slots=True)
+class IntentRequest:
+    """Normalized intent invocation produced by upstream classifiers."""
+
+    intent: IntentType
+    payload: IntentPayload
+
+
+@dataclass(slots=True)
+class IntentResponse:
+    """Uniform handler response structure for downstream translation."""
+
+    intent: IntentType
+    result: Any
+
+
+IntentHandler = Callable[[IntentRequest, "ServiceContainer"], Awaitable[IntentResponse]]
+
+
+class IntentRouterError(RuntimeError):
+    """Base error for router failures."""
+
+
+class IntentHandlerNotFoundError(IntentRouterError):
+    """Raised when no handler is registered for the requested intent."""
+
+
+class IntentRouter:
+    """Dispatch intents to registered handlers."""
+
+    def __init__(self, handlers: Mapping[IntentType, IntentHandler] | None = None) -> None:
+        self._handlers: MutableMapping[IntentType, IntentHandler] = dict(handlers or {})
+
+    def register(self, intent: IntentType, handler: IntentHandler) -> None:
+        """Register or replace a handler for ``intent``."""
+
+        self._handlers[intent] = handler
+
+    def unregister(self, intent: IntentType) -> None:
+        """Remove a handler if present."""
+
+        self._handlers.pop(intent, None)
+
+    async def dispatch(
+        self, request: IntentRequest, services: "ServiceContainer"
+    ) -> IntentResponse:
+        """Invoke the handler for ``request.intent`` with the provided services."""
+
+        try:
+            handler = self._handlers[request.intent]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise IntentHandlerNotFoundError(
+                f"No handler registered for intent {request.intent}"
+            ) from exc
+        return await handler(request, services)
+
+    async def dispatch_many(
+        self, requests: Sequence[IntentRequest], services: "ServiceContainer"
+    ) -> list[IntentResponse]:
+        """Dispatch a collection of requests sequentially and collect responses."""
+
+        return [await self.dispatch(req, services) for req in requests]
+
+    def handlers(self) -> Mapping[IntentType, IntentHandler]:
+        """Return a shallow copy of the current intent handler registry."""
+
+        return dict(self._handlers)
+
+
+__all__ = [
+    "IntentRouter",
+    "IntentRouterError",
+    "IntentHandlerNotFoundError",
+    "IntentHandler",
+    "IntentRequest",
+    "IntentResponse",
+]

--- a/bt_servant_engine/services/intents/__init__.py
+++ b/bt_servant_engine/services/intents/__init__.py
@@ -1,1 +1,5 @@
-"""Intent-specific service implementations placeholder."""
+"""Intent-specific service implementations."""
+
+from .converse import handle_converse_intent
+
+__all__ = ["handle_converse_intent"]

--- a/bt_servant_engine/services/intents/converse.py
+++ b/bt_servant_engine/services/intents/converse.py
@@ -1,0 +1,32 @@
+"""Handlers for conversational fallback intents."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from brain import IntentType
+
+from ..intent_router import IntentRequest, IntentResponse
+
+if TYPE_CHECKING:  # pragma: no cover - static typing aid
+    from .. import ServiceContainer
+
+
+async def handle_converse_intent(
+    request: IntentRequest, services: "ServiceContainer"
+) -> IntentResponse:
+    """Return a simple acknowledgement for conversational intents."""
+
+    _ = services  # Placeholder for future shared dependencies
+    user_text = str(request.payload.get("text", "")).strip()
+    if not user_text:
+        message = "I'm here whenever you need assistance."
+    else:
+        message = f"You said: {user_text}"
+    return IntentResponse(
+        intent=IntentType.CONVERSE_WITH_BT_SERVANT,
+        result={"text": message},
+    )
+
+
+__all__ = ["handle_converse_intent"]

--- a/tests/services/test_intent_router.py
+++ b/tests/services/test_intent_router.py
@@ -1,0 +1,70 @@
+"""Unit tests for the intent router scaffolding."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from brain import IntentType
+
+from bt_servant_engine.services import ServiceContainer, build_default_services
+from bt_servant_engine.services.intent_router import (
+    IntentHandlerNotFoundError,
+    IntentRequest,
+    IntentResponse,
+    IntentRouter,
+)
+from bt_servant_engine.services.intents.converse import handle_converse_intent
+
+
+def test_dispatch_invokes_registered_handler():
+    """Router calls the registered handler and returns its response."""
+    router = IntentRouter({IntentType.CONVERSE_WITH_BT_SERVANT: handle_converse_intent})
+    container = ServiceContainer(intent_router=router)
+    request = IntentRequest(
+        intent=IntentType.CONVERSE_WITH_BT_SERVANT,
+        payload={"text": "Hello there"},
+    )
+
+    response = asyncio.run(router.dispatch(request, container))
+
+    assert isinstance(response, IntentResponse)
+    assert response.intent is IntentType.CONVERSE_WITH_BT_SERVANT
+    assert "Hello there" in response.result["text"]
+
+
+def test_dispatch_unknown_intent_raises():
+    """Router raises when no handler matches the requested intent."""
+    router = IntentRouter()
+    container = ServiceContainer(intent_router=router)
+    request = IntentRequest(intent=IntentType.GET_PASSAGE_SUMMARY, payload={})
+
+    with pytest.raises(IntentHandlerNotFoundError):
+        asyncio.run(router.dispatch(request, container))
+
+
+def test_dispatch_many_preserves_order():
+    """Sequential dispatch preserves ordering of responses."""
+    router = IntentRouter({IntentType.CONVERSE_WITH_BT_SERVANT: handle_converse_intent})
+    container = ServiceContainer(intent_router=router)
+    requests = [
+        IntentRequest(intent=IntentType.CONVERSE_WITH_BT_SERVANT, payload={"text": "First"}),
+        IntentRequest(intent=IntentType.CONVERSE_WITH_BT_SERVANT, payload={"text": "Second"}),
+    ]
+
+    responses = asyncio.run(router.dispatch_many(requests, container))
+
+    assert [resp.result["text"] for resp in responses] == [
+        "You said: First",
+        "You said: Second",
+    ]
+
+
+def test_build_default_services_provisions_router():
+    """Default service container includes a prewired intent router."""
+    services = build_default_services()
+
+    assert services.intent_router is not None
+    registered = services.intent_router.handlers()
+    assert IntentType.CONVERSE_WITH_BT_SERVANT in registered

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -15,6 +15,8 @@ def test_create_app_has_routes():
     }
     assert "/alive" in paths
     assert any(path.startswith("/chroma") for path in paths)
+    assert hasattr(app.state, "services")
+    assert app.state.services.intent_router is not None
 
 
 def test_lifespan_initializes_brain():


### PR DESCRIPTION
## Summary
- introduce an intent router module with request/response dataclasses and a registry for handlers
- wire up a default service container that provides the router plus a conversational handler stub
- initialize services in the FastAPI app and add unit tests for router dispatch and app state exposure

## Testing
- source .venv/bin/activate && OPENAI_API_KEY=test META_VERIFY_TOKEN=test META_WHATSAPP_TOKEN=test META_PHONE_NUMBER_ID=test META_APP_SECRET=test LOG_PSEUDONYM_SECRET=test FACEBOOK_USER_AGENT=test-agent BASE_URL=http://localhost ENABLE_ADMIN_AUTH=0 pytest tests/services/test_intent_router.py -q
- source .venv/bin/activate && OPENAI_API_KEY=test META_VERIFY_TOKEN=test META_WHATSAPP_TOKEN=test META_PHONE_NUMBER_ID=test META_APP_SECRET=test LOG_PSEUDONYM_SECRET=test FACEBOOK_USER_AGENT=test-agent BASE_URL=http://localhost ENABLE_ADMIN_AUTH=0 scripts/check_repo.sh