### PR TITLE
(CODEX) Add structured passage followups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,3 +346,12 @@ Recommended workflow
     can sometimes lose the concrete type and infer a callable union. Use
     `cast(str, ...)` or `str(...)` at the call site to make the argument type
     explicit, e.g., `set_user_response_language(cast(str, user_id), cast(str, code))`.
+
+### LangGraph State Updates
+- Never mutate the incoming LangGraph `state` in-place. Always return a dict of
+  changes from the node so the orchestrator can merge them. Direct assignments
+  like `state["foo"] = bar` are ignored once execution resumes and lead to
+  duplicated follow-ups or stale context.
+- When branching with `add_conditional_edges`, return `langgraph.types.Send`
+  instances that carry a merged copy of the state instead of mutating the
+  original reference. This keeps state propagation deterministic.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,13 @@ The refactor is partially complete. Major accomplishments and remaining work:
 4. **Preserve behavior** - Each change must maintain functionality
 5. **Update imports atomically** - Change all references in the same commit
 
+### LangGraph State Handling
+- Do **not** mutate the LangGraph state dict in-place inside nodes. Always
+  return a dict of updates so the orchestrator can merge changes deterministically.
+- For conditional edges added via `add_conditional_edges`, emit
+  `langgraph.types.Send` packets that carry a merged state instead of writing to
+  the original dict. This prevents double follow-up prompts and stale context.
+
 ### What NOT to Do
 
 - **DON'T create new features** during the refactor - only restructure existing code

--- a/bt_servant_engine/services/intents/passage_intents.py
+++ b/bt_servant_engine/services/intents/passage_intents.py
@@ -167,7 +167,12 @@ def get_passage_summary(
                 "intent": IntentType.GET_PASSAGE_SUMMARY,
                 "response": response_text,
             }
-        ]
+        ],
+        "passage_followup_context": {
+            "intent": IntentType.GET_PASSAGE_SUMMARY,
+            "book": canonical_book,
+            "ranges": [tuple(r) for r in ranges],
+        },
     }
 
 
@@ -223,7 +228,12 @@ def get_passage_keywords(
                 "intent": IntentType.GET_PASSAGE_KEYWORDS,
                 "response": response_text,
             }
-        ]
+        ],
+        "passage_followup_context": {
+            "intent": IntentType.GET_PASSAGE_KEYWORDS,
+            "book": canonical_book,
+            "ranges": [tuple(r) for r in ranges],
+        },
     }
 
 
@@ -440,7 +450,14 @@ def retrieve_scripture(  # pylint: disable=too-many-arguments,too-many-locals,to
                 {"type": "scripture", "text": translated_body},
             ],
         }
-        return {"responses": [{"intent": IntentType.RETRIEVE_SCRIPTURE, "response": response_obj}]}
+        return {
+            "responses": [{"intent": IntentType.RETRIEVE_SCRIPTURE, "response": response_obj}],
+            "passage_followup_context": {
+                "intent": IntentType.RETRIEVE_SCRIPTURE,
+                "book": canonical_book,
+                "ranges": [tuple(r) for r in ranges],
+            },
+        }
 
     # No auto-translation required; return verbatim with canonical header (to be localized downstream if desired)
     # Load localized titles for the resolved source language (if present)
@@ -458,7 +475,14 @@ def retrieve_scripture(  # pylint: disable=too-many-arguments,too-many-locals,to
             {"type": "scripture", "text": scripture_text},
         ],
     }
-    return {"responses": [{"intent": IntentType.RETRIEVE_SCRIPTURE, "response": response_obj}]}
+    return {
+        "responses": [{"intent": IntentType.RETRIEVE_SCRIPTURE, "response": response_obj}],
+        "passage_followup_context": {
+            "intent": IntentType.RETRIEVE_SCRIPTURE,
+            "book": canonical_book,
+            "ranges": [tuple(r) for r in ranges],
+        },
+    }
 
 
 def listen_to_scripture(
@@ -501,6 +525,9 @@ def listen_to_scripture(
         )
         for resp in responses:
             resp["suppress_text_delivery"] = True
+    ctx = out.get("passage_followup_context")
+    if isinstance(ctx, dict):
+        ctx["intent"] = IntentType.LISTEN_TO_SCRIPTURE
     return out
 
 

--- a/bt_servant_engine/services/passage_followups.py
+++ b/bt_servant_engine/services/passage_followups.py
@@ -1,0 +1,239 @@
+"""Deterministic helpers for building passage follow-up suggestions."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Callable, Iterable, Mapping, MutableMapping, Optional, Sequence, Tuple, cast
+
+from bt_servant_engine.core.config import config
+from bt_servant_engine.core.intents import IntentType
+from bt_servant_engine.core.logging import get_logger
+from utils.bsb import (
+    BOOK_MAP,
+    label_ranges,
+    load_book_json,
+    parse_ch_verse_from_reference,
+)
+
+logger = get_logger(__name__)
+
+BSB_DATA_ROOT = Path("sources") / "bible_data" / "en" / "bsb"
+BOOK_SEQUENCE = list(BOOK_MAP.keys())
+
+PassageRange = Tuple[int, int, int]
+RawRange = Tuple[int, int | None, int | None, int | None]
+
+
+@lru_cache(maxsize=128)
+def _chapter_lengths(book: str) -> MutableMapping[int, int]:
+    """Return a mapping of chapter -> verse count for the given book."""
+    mapping = BOOK_MAP.get(book)
+    if not mapping:
+        raise KeyError(f"Unknown canonical book '{book}'")
+
+    entries = load_book_json(BSB_DATA_ROOT, mapping["file_stem"])
+    lengths: dict[int, int] = {}
+    for entry in entries:
+        ref = entry.get("reference")
+        if not isinstance(ref, str):
+            continue
+        parsed = parse_ch_verse_from_reference(ref)
+        if parsed is None:
+            continue
+        chapter, verse = parsed
+        current = lengths.get(chapter, 0)
+        if verse > current:
+            lengths[chapter] = verse
+    return lengths
+
+
+def _resolve_range_endpoint(
+    range_tuple: RawRange,
+    lengths: Mapping[int, int],
+) -> tuple[int, int]:
+    """Return the final (chapter, verse) that was delivered for a range tuple."""
+    _start_chapter, _start_verse, end_chapter, end_verse = range_tuple
+    if end_chapter is None or end_chapter >= 10_000:
+        end_chapter = max(lengths.keys())
+    if end_verse is None or end_verse >= 10_000:
+        end_verse = lengths[end_chapter]
+    return end_chapter, end_verse
+
+
+def _next_book_name(book: str) -> str:
+    """Return the canonical book that follows the provided book (wrap to Genesis)."""
+    try:
+        idx = BOOK_SEQUENCE.index(book)
+    except ValueError as exc:
+        raise KeyError(f"Unknown canonical book '{book}'") from exc
+    return BOOK_SEQUENCE[(idx + 1) % len(BOOK_SEQUENCE)]
+
+
+def _normalize_ranges(ranges: Sequence[Iterable[int | None]]) -> list[RawRange]:
+    """Return ranges as concrete tuples; coerce inputs like lists to tuples."""
+    out: list[RawRange] = []
+    for r in ranges:
+        items = list(r)
+        if len(items) != 4:
+            raise ValueError(f"Expected 4-tuple range, got {items!r}")
+        start_chapter = items[0]
+        if start_chapter is None:
+            raise ValueError("start_chapter cannot be None for normalized ranges")
+        out.append(
+            (
+                cast(int, start_chapter),
+                None if items[1] is None else cast(int, items[1]),
+                None if items[2] is None else cast(int, items[2]),
+                None if items[3] is None else cast(int, items[3]),
+            )
+        )
+    return out
+
+
+class _PassageFollowupAbort(Exception):
+    """Internal control-flow exception for deterministic follow-up selection."""
+
+
+def propose_next_passage_range(
+    book: str,
+    ranges: Sequence[Iterable[int | None]],
+    verse_limit: int,
+) -> Optional[tuple[str, PassageRange]]:
+    """Return the next single-chapter range to propose after the provided selection.
+
+    The algorithm walks forward from the delivered verses by up to ``verse_limit``
+    verses. Ranges never cross chapters or books. When the end of a book is reached,
+    the suggestion wraps to the first chapter of the next canonical book. After
+    Revelation, the suggestion wraps back to Genesis.
+    """
+    try:
+        if verse_limit <= 0:
+            logger.warning("[passage-followup] verse_limit <= 0; skipping suggestion")
+            raise _PassageFollowupAbort
+
+        try:
+            normalized_ranges = _normalize_ranges(ranges)
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            logger.exception("[passage-followup] Invalid ranges supplied; skipping suggestion")
+            raise _PassageFollowupAbort from exc
+
+        if not normalized_ranges:
+            logger.warning("[passage-followup] Empty ranges supplied; skipping suggestion")
+            raise _PassageFollowupAbort
+
+        try:
+            chapter_lengths = _chapter_lengths(book)
+        except KeyError as exc:
+            logger.exception("[passage-followup] Unknown book '%s'; skipping suggestion", book)
+            raise _PassageFollowupAbort from exc
+
+        last_range = normalized_ranges[-1]
+        end_chapter, end_verse = _resolve_range_endpoint(last_range, chapter_lengths)
+        next_book = book
+        next_chapter = end_chapter
+        next_verse = end_verse + 1
+
+        chapter_length = chapter_lengths.get(next_chapter, 0)
+        if 0 < chapter_length < next_verse:
+            # Advance to next chapter within the same book
+            next_chapter += 1
+            if next_chapter not in chapter_lengths:
+                # Roll over to the next canonical book
+                next_book = _next_book_name(book)
+                try:
+                    chapter_lengths = _chapter_lengths(next_book)
+                except KeyError as exc:  # pragma: no cover - defensive guard
+                    logger.exception(
+                        "[passage-followup] Unknown next book '%s'; skipping suggestion", next_book
+                    )
+                    raise _PassageFollowupAbort from exc
+                next_chapter = 1
+            next_verse = 1
+            chapter_length = chapter_lengths.get(next_chapter, 0)
+
+        if chapter_length == 0:
+            logger.warning(
+                "[passage-followup] No verse data recorded for %s %s; skipping suggestion",
+                book,
+                next_chapter,
+            )
+            raise _PassageFollowupAbort
+
+        # Clamp to available verses without crossing chapter boundaries
+        chapter_max = chapter_lengths.get(next_chapter)
+        if not chapter_max:
+            logger.warning(
+                "[passage-followup] Missing chapter length for %s %s; skipping suggestion",
+                next_book,
+                next_chapter,
+            )
+            raise _PassageFollowupAbort
+        end_suggested = min(next_verse + verse_limit - 1, chapter_max)
+
+        return next_book, (next_chapter, next_verse, end_suggested)
+    except _PassageFollowupAbort:
+        return None
+
+
+ENGLISH_FOLLOWUP_TEMPLATES: dict[IntentType, str] = {
+    IntentType.GET_PASSAGE_SUMMARY: "Would you like me to summarize {label} next?",
+    IntentType.GET_PASSAGE_KEYWORDS: "Would you like me to show key terms from {label}?",
+    IntentType.GET_TRANSLATION_HELPS: "Would you like translation helps for {label}?",
+    IntentType.RETRIEVE_SCRIPTURE: "Would you like me to retrieve {label}?",
+    IntentType.LISTEN_TO_SCRIPTURE: "Would you like me to read {label} aloud?",
+    IntentType.TRANSLATE_SCRIPTURE: "Would you like me to translate {label}?",
+}
+
+
+def build_followup_question(
+    intent: IntentType,
+    context: Mapping[str, object],
+    target_language: Optional[str],
+    translate_text_fn: Optional[Callable[[str, str], str]] = None,
+) -> Optional[str]:
+    """Return a localized deterministic follow-up question for passage intents."""
+    template = ENGLISH_FOLLOWUP_TEMPLATES.get(intent)
+    if not template:
+        return None
+
+    book = context.get("book")
+    ranges = context.get("ranges")
+    if not isinstance(book, str) or not isinstance(ranges, Sequence):
+        logger.debug("[passage-followup] Missing or invalid context for intent=%s", intent.value)
+        return None
+
+    normalized_ranges = cast(Sequence[Iterable[int | None]], ranges)
+    suggestion = propose_next_passage_range(
+        book,
+        normalized_ranges,
+        config.TRANSLATION_HELPS_VERSE_LIMIT,
+    )
+    if not suggestion:
+        return None
+
+    next_book, (chapter, start_verse, end_verse) = suggestion
+    label = label_ranges(
+        next_book,
+        [(chapter, start_verse, chapter, end_verse)],
+    )
+    english_question = template.format(label=label)
+
+    lang = (target_language or "").strip().lower() or "en"
+    if lang == "en" or translate_text_fn is None:
+        return english_question
+
+    try:
+        return translate_text_fn(english_question, lang)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception(
+            "[passage-followup] Failed to translate follow-up to language '%s'; using English",
+            lang,
+        )
+        return english_question
+
+
+__all__ = [
+    "build_followup_question",
+    "propose_next_passage_range",
+]

--- a/bt_servant_engine/services/preprocessing.py
+++ b/bt_servant_engine/services/preprocessing.py
@@ -538,6 +538,10 @@ request is outside the scope of Bible translation, the Bible translation process
 If the user is clearly asking for information about the BT Servant system itself—especially short cues like "help",
 "help!", "help me", or "help please"—classify the message as `retrieve-system-information`.
 
+If the user declines or rejects a follow-up offer (even when the preprocessor expands the response, for example
+"No, I don't want to summarize John 3:5."), always classify it as `converse-with-bt-servant`. Never treat these "no"
+responses as unsupported requests.
+
 You must choose one or more intents from the following list:
 
 <intents>
@@ -703,6 +707,14 @@ Here are example classifications:
   </example>
   <example>
     <message>How are you doing today?</message>
+    <intent>converse-with-bt-servant</intent>
+  </example>
+  <example>
+    <message>No, I don't want keywords from another passage.</message>
+    <intent>converse-with-bt-servant</intent>
+  </example>
+  <example>
+    <message>No, I don't need translation helps for John 3:16.</message>
     <intent>converse-with-bt-servant</intent>
   </example>
 </examples>

--- a/tests/services/test_passage_followups.py
+++ b/tests/services/test_passage_followups.py
@@ -1,0 +1,66 @@
+"""Tests for deterministic passage follow-up helpers."""
+
+from bt_servant_engine.core.intents import IntentType
+from bt_servant_engine.services.passage_followups import (
+    build_followup_question,
+    propose_next_passage_range,
+)
+
+
+class TestProposeNextPassageRange:
+    """Tests for propose_next_passage_range."""
+
+    def test_within_same_chapter(self) -> None:
+        """Returns next verses within the same chapter when available."""
+        result = propose_next_passage_range(
+            "John",
+            [(3, 16, 3, 20)],
+            verse_limit=5,
+        )
+        assert result is not None
+        next_book, next_range = result
+        assert next_book == "John"
+        assert next_range == (3, 21, 25)
+
+    def test_rolls_to_next_chapter(self) -> None:
+        """Moves to the next chapter when the current chapter is exhausted."""
+        result = propose_next_passage_range(
+            "John",
+            [(3, 33, 3, 36)],
+            verse_limit=5,
+        )
+        assert result is not None
+        next_book, next_range = result
+        assert next_book == "John"
+        assert next_range == (4, 1, 5)
+
+    def test_wraps_to_genesis_after_revelation(self) -> None:
+        """Wraps around to Genesis when Revelation is exhausted."""
+        result = propose_next_passage_range(
+            "Revelation",
+            [(22, 17, 22, 21)],
+            verse_limit=5,
+        )
+        assert result is not None
+        next_book, next_range = result
+        assert next_book == "Genesis"
+        assert next_range == (1, 1, 5)
+
+
+class TestBuildFollowupQuestion:  # pylint: disable=too-few-public-methods
+    """Tests for building localized follow-up questions."""
+
+    def test_builds_english_question(self) -> None:
+        """Returns an English follow-up question with the proposed label."""
+        context = {
+            "intent": IntentType.GET_PASSAGE_SUMMARY,
+            "book": "John",
+            "ranges": [(3, 16, 3, 20)],
+        }
+        question = build_followup_question(
+            IntentType.GET_PASSAGE_SUMMARY,
+            context,
+            target_language="en",
+        )
+        assert question is not None
+        assert "John 3:21-25" in question


### PR DESCRIPTION
## Summary
- add passage follow-up builder with translation-aware prompts and wire into translation pipeline
- persist follow-up flag on result payload and avoid state mutation to keep langgraph deterministic
- document state-handling rules and extend tests for new follow-up behaviors and translation helpers

## Testing
- scripts/check_repo.sh
